### PR TITLE
feat: drag'n'drop to breadcrumbs and tabs and directory status bar

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "EdenExplorer"
-version = "0.2.3"
+version = "0.3.0"
 dependencies = [
  "bincode",
  "crossbeam-channel",

--- a/README.md
+++ b/README.md
@@ -287,12 +287,13 @@
 - [x] **Window management improvements** with proper maximization bounds and minimum size constraints
 - [x] **File/Directory filtering** - typing characters automatically start filtering items in the item viewer
 - [x] **Windows environment variables PATH support** - Automatically expands Windows PATHs in breadcrumb input
+- [x] Drag and drop files into breadcrumb folders and directory tabs
 
 ### 🚀 Upcoming Features
 - [ ] Image previews using Spacebar - GPU texture via wgpu / egui_wgpu_backend
-- [ ] Drag and drop files into breadcrumb folders and directory tabs
 - [ ] Support network devices
 - [ ] Drag and drop files from EdenExplorer into Windows objects (Desktop, File Explorer, applications, etc.)
+- [ ] Enable/Disable Windows context menu integration. By enabling, the context menu will populate with default Windows registry context menu items
 
 ## 🐛 Known Bugs
 - Hitting "Shift" after already shift-selecting files drops the entire file selection

--- a/src/gui/utils.rs
+++ b/src/gui/utils.rs
@@ -548,7 +548,7 @@ pub fn draw_object_drag_ghost(
         painter.rect_filled(
             ghost_rect,
             CornerRadius::same(palette.medium_radius),
-            palette.primary_hover,
+            palette.primary_subtle,
         );
 
         // --- Text ---
@@ -559,7 +559,7 @@ pub fn draw_object_drag_ghost(
             Align2::LEFT_CENTER,
             label,
             font_id,
-            palette.icon_color.gamma_multiply(0.7),
+            palette.icon_color.gamma_multiply(0.2),
         );
 
         ui.ctx().set_cursor_icon(CursorIcon::Grab);

--- a/src/gui/windows/containers/enums.rs
+++ b/src/gui/windows/containers/enums.rs
@@ -26,6 +26,14 @@ pub enum ItemViewerAction {
         sources: Vec<PathBuf>,
         target_dir: PathBuf,
     },
+    MoveFilesToBreadcrumbDirectory {
+        sources: Vec<PathBuf>,
+        target_dir: PathBuf,
+    },
+    MoveFilesToTabDirectory {
+        sources: Vec<PathBuf>,
+        target_dir: PathBuf,
+    },
 }
 
 #[derive(Clone, Debug)]

--- a/src/gui/windows/containers/explorer.rs
+++ b/src/gui/windows/containers/explorer.rs
@@ -87,7 +87,15 @@ pub fn draw_explorer(
             egui::Frame::NONE.show(ui, |ui| {
                 ui.add_space(8.0);
                 let scroll_to_id = *pending_tab_scroll_id;
-                tabs_action = draw_tabs(ui, tab_infos_cache, active_id, palette, hwnd, scroll_to_id);
+                tabs_action = draw_tabs(
+                    ui,
+                    tab_infos_cache,
+                    active_id,
+                    palette,
+                    hwnd,
+                    scroll_to_id,
+                    drag_state,
+                );
                 if scroll_to_id.is_some() {
                     *pending_tab_scroll_id = None;
                 }
@@ -110,7 +118,14 @@ pub fn draw_explorer(
                         .iter()
                         .any(|fav| fav.path == tab.nav.current);
 
-                    Some(draw_tabbar(ui, icon_cache, tab, palette, is_favorited))
+                    Some(draw_tabbar(
+                        ui,
+                        icon_cache,
+                        tab,
+                        palette,
+                        is_favorited,
+                        drag_state,
+                    ))
                 };
 
                 ui.add_space(4.0);
@@ -119,6 +134,7 @@ pub fn draw_explorer(
                 let status_bottom_gap = 4.0;
                 let item_viewer_height =
                     (ui.available_height() - status_height - status_bottom_gap).max(0.0);
+                let mut hovered_drop_target: Option<PathBuf> = None;
 
                 ui.allocate_ui_with_layout(
                     egui::vec2(ui.available_width(), item_viewer_height),
@@ -145,6 +161,7 @@ pub fn draw_explorer(
                             &mut tabbar_action,
                             drag_state,
                             item_viewer_filter_state,
+                            &mut hovered_drop_target,
                             is_loading,
                             explorer_state,
                             theme_customizer,
@@ -153,56 +170,83 @@ pub fn draw_explorer(
                     },
                 );
 
-                let mut dir_count = 0usize;
-                let mut file_count = 0usize;
-                for &idx in item_viewer_filter_state.cached_indices.iter() {
-                    if display_files[idx].is_dir {
-                        dir_count += 1;
-                    } else {
-                        file_count += 1;
+                let pointer_released = ui
+                    .ctx()
+                    .input(|i| i.pointer.any_released() && i.pointer.interact_pos().is_some());
+
+                if drag_state.active && pointer_released && !drag_state.source_items.is_empty() {
+                    if let Some(target_dir) = tabs_action.move_files_to_tab_dir.clone() {
+                        if pending_action.is_none() {
+                            pending_action = Some(ItemViewerAction::MoveFilesToTabDirectory {
+                                sources: drag_state.source_items.clone(),
+                                target_dir,
+                            });
+                        }
+                    } else if let Some(target_dir) = tabbar_action
+                        .as_ref()
+                        .and_then(|a| a.move_files_to_breadcrumb_dir.clone())
+                    {
+                        if pending_action.is_none() {
+                            pending_action =
+                                Some(ItemViewerAction::MoveFilesToBreadcrumbDirectory {
+                                    sources: drag_state.source_items.clone(),
+                                    target_dir,
+                                });
+                        }
+                    } else if let Some(target_dir) = hovered_drop_target {
+                        if pending_action.is_none() {
+                            pending_action = Some(ItemViewerAction::MoveItems {
+                                sources: drag_state.source_items.clone(),
+                                target_dir,
+                            });
+                        }
                     }
+
+                    drag_state.active = false;
+                    drag_state.start_pos = None;
+                    drag_state.source_items.clear();
                 }
 
-                let status_frame = egui::Frame::NONE
-                    .fill(egui::Color32::TRANSPARENT)
-                    .inner_margin(egui::Margin {
-                        left: 10,
-                        right: 10,
-                        top: 2,
-                        bottom: 2,
-                    });
+                if !is_drive_view {
+                    let mut dir_count = 0usize;
+                    let mut file_count = 0usize;
+                    for &idx in item_viewer_filter_state.cached_indices.iter() {
+                        if display_files[idx].is_dir {
+                            dir_count += 1;
+                        } else {
+                            file_count += 1;
+                        }
+                    }
 
-                status_frame.show(ui, |ui| {
-                    ui.allocate_ui_with_layout(
-                        egui::vec2(ui.available_width(), status_height),
-                        egui::Layout::right_to_left(egui::Align::Center),
-                        |ui| {
-                            let text_color = ui.visuals().text_color();
-                            let text_size = palette.text_size;
-                            let selected_count = explorer_state.selected_paths.len();
-                            let selected_label =
-                                if selected_count == 1 { "Item" } else { "Items" };
+                    let status_frame = egui::Frame::NONE
+                        .fill(egui::Color32::TRANSPARENT)
+                        .inner_margin(egui::Margin {
+                            left: 10,
+                            right: 10,
+                            top: 2,
+                            bottom: 2,
+                        });
 
-                            ui.label(
-                                egui::RichText::new(format!("{} {}", regular::FILE, file_count))
+                    status_frame.show(ui, |ui| {
+                        ui.allocate_ui_with_layout(
+                            egui::vec2(ui.available_width(), status_height),
+                            egui::Layout::right_to_left(egui::Align::Center),
+                            |ui| {
+                                let text_color = ui.visuals().text_color();
+                                let text_size = palette.text_size;
+                                let selected_count = explorer_state.selected_paths.len();
+                                let selected_label =
+                                    if selected_count == 1 { "Item" } else { "Items" };
+
+                                ui.label(
+                                    egui::RichText::new(format!(
+                                        "{} {}",
+                                        regular::FILE,
+                                        file_count
+                                    ))
                                     .size(text_size)
                                     .color(text_color),
-                            );
-                            ui.label(
-                                egui::RichText::new("|")
-                                    .size(text_size)
-                                    .color(text_color.linear_multiply(0.6)),
-                            );
-                            ui.label(
-                                egui::RichText::new(format!(
-                                    "{} {}",
-                                    regular::FOLDER_SIMPLE,
-                                    dir_count
-                                ))
-                                .size(text_size)
-                                .color(text_color),
-                            );
-                            if selected_count > 0 {
+                                );
                                 ui.label(
                                     egui::RichText::new("|")
                                         .size(text_size)
@@ -210,15 +254,31 @@ pub fn draw_explorer(
                                 );
                                 ui.label(
                                     egui::RichText::new(format!(
-                                        "{selected_count} {selected_label} Selected"
+                                        "{} {}",
+                                        regular::FOLDER_SIMPLE,
+                                        dir_count
                                     ))
+                                    .size(text_size)
+                                    .color(text_color),
+                                );
+                                if selected_count > 0 {
+                                    ui.label(
+                                        egui::RichText::new("|")
+                                            .size(text_size)
+                                            .color(text_color.linear_multiply(0.6)),
+                                    );
+                                    ui.label(
+                                        egui::RichText::new(format!(
+                                            "{selected_count} {selected_label} Selected"
+                                        ))
                                         .size(text_size)
                                         .color(text_color),
-                                );
-                            }
-                        },
-                    );
-                });
+                                    );
+                                }
+                            },
+                        );
+                    });
+                }
 
                 ui.add_space(status_bottom_gap);
             });

--- a/src/gui/windows/containers/explorer.rs
+++ b/src/gui/windows/containers/explorer.rs
@@ -1,0 +1,231 @@
+use crate::core::fs::{FileItem, MY_PC_PATH};
+use crate::gui::icons::IconCache;
+use crate::gui::theme::ThemePalette;
+use crate::gui::utils::SortColumn;
+use crate::gui::windows::containers::enums::ItemViewerAction;
+use crate::gui::windows::containers::itemviewer::draw_item_viewer;
+use crate::gui::windows::containers::structs::{
+    DragState, ExplorerState, FilterState, ItemViewerFolderSizeState, RenameState, TabInfo,
+    TabState, TabbarAction, TabsAction,
+};
+use crate::gui::windows::containers::tabs::{draw_tabbar, draw_tabs};
+use crate::gui::windows::mainwindow_imp::tab_title_for;
+use crate::gui::windows::structs::{SettingsWindow, SidebarState, ThemeCustomizer};
+use eframe::egui;
+use egui_phosphor::regular;
+use std::collections::HashMap;
+use std::collections::HashSet;
+use std::path::PathBuf;
+use windows::Win32::Foundation::HWND;
+
+pub fn draw_explorer(
+    ui: &mut egui::Ui,
+    icon_cache: &IconCache,
+    palette: &ThemePalette,
+    hwnd: Option<HWND>,
+    tabs: &mut Vec<TabState>,
+    active_tab: usize,
+    tab_infos_cache: &mut Vec<TabInfo>,
+    tab_infos_dirty: &mut bool,
+    pending_tab_scroll_id: &mut Option<u64>,
+    sidebar_state: &SidebarState,
+    files: &Vec<FileItem>,
+    folder_sizes: &HashMap<PathBuf, ItemViewerFolderSizeState>,
+    clipboard_has_files: bool,
+    clipboard_set: &HashSet<PathBuf>,
+    clipboard_is_cut: bool,
+    sort_column: SortColumn,
+    sort_ascending: bool,
+    rename_state: &mut Option<RenameState>,
+    file_type_cache: &mut HashMap<String, String>,
+    file_size_text_cache: &mut HashMap<PathBuf, (u64, String)>,
+    folder_size_text_cache: &mut HashMap<PathBuf, (u64, bool, String)>,
+    drive_size_text_cache: &mut HashMap<PathBuf, (u64, u64, String)>,
+    external_drag_to_internal_hover: &mut bool,
+    drag_state: &mut DragState,
+    item_viewer_filter_state: &mut FilterState,
+    is_loading: bool,
+    explorer_state: &mut ExplorerState,
+    theme_customizer: &mut ThemeCustomizer,
+    settings_window: &mut SettingsWindow,
+) -> (TabsAction, Option<TabbarAction>, Option<ItemViewerAction>) {
+    let mut tabs_action = TabsAction::default();
+    let mut tabbar_action: Option<TabbarAction> = None;
+    let mut pending_action: Option<ItemViewerAction> = None;
+
+    let tabs_width = ui.available_width();
+    ui.allocate_ui_with_layout(
+        egui::vec2(tabs_width, ui.available_height()),
+        egui::Layout::top_down(egui::Align::Min),
+        |ui| {
+            let old_spacing = ui.spacing().item_spacing;
+            ui.spacing_mut().item_spacing.y = 0.0;
+
+            if *tab_infos_dirty || tab_infos_cache.len() != tabs.len() {
+                *tab_infos_cache = tabs
+                    .iter()
+                    .map(|tab| TabInfo {
+                        id: tab.id,
+                        title: tab_title_for(&tab.nav),
+                        full_path: if tab.nav.is_root() {
+                            PathBuf::from(MY_PC_PATH)
+                        } else {
+                            tab.nav.current.clone()
+                        },
+                        is_pinned: settings_window
+                            .current_settings
+                            .pinned_tabs
+                            .iter()
+                            .any(|p| p == &tab.nav.current),
+                    })
+                    .collect();
+                *tab_infos_dirty = false;
+            }
+
+            let active_id = tabs[active_tab].id;
+
+            egui::Frame::NONE.show(ui, |ui| {
+                ui.add_space(8.0);
+                let scroll_to_id = *pending_tab_scroll_id;
+                tabs_action = draw_tabs(ui, tab_infos_cache, active_id, palette, hwnd, scroll_to_id);
+                if scroll_to_id.is_some() {
+                    *pending_tab_scroll_id = None;
+                }
+            });
+
+            let container = egui::Frame::NONE
+                .stroke(egui::Stroke::NONE)
+                .fill(egui::Color32::TRANSPARENT)
+                .inner_margin(egui::Margin::symmetric(10, 8));
+
+            let active_index = active_tab;
+            let is_drive_view = tabs[active_index].nav.is_root();
+            let display_files = files;
+
+            container.show(ui, |ui| {
+                tabbar_action = {
+                    let tab = &mut tabs[active_index];
+                    let is_favorited = sidebar_state
+                        .favorites
+                        .iter()
+                        .any(|fav| fav.path == tab.nav.current);
+
+                    Some(draw_tabbar(ui, icon_cache, tab, palette, is_favorited))
+                };
+
+                ui.add_space(4.0);
+
+                let status_height = palette.text_size + 6.0;
+                let status_bottom_gap = 4.0;
+                let item_viewer_height =
+                    (ui.available_height() - status_height - status_bottom_gap).max(0.0);
+
+                ui.allocate_ui_with_layout(
+                    egui::vec2(ui.available_width(), item_viewer_height),
+                    egui::Layout::top_down(egui::Align::Min),
+                    |ui| {
+                        pending_action = draw_item_viewer(
+                            ui,
+                            display_files,
+                            folder_sizes,
+                            clipboard_has_files,
+                            clipboard_set,
+                            clipboard_is_cut,
+                            is_drive_view,
+                            sort_column,
+                            sort_ascending,
+                            icon_cache,
+                            rename_state,
+                            palette,
+                            file_type_cache,
+                            file_size_text_cache,
+                            folder_size_text_cache,
+                            drive_size_text_cache,
+                            external_drag_to_internal_hover,
+                            &mut tabbar_action,
+                            drag_state,
+                            item_viewer_filter_state,
+                            is_loading,
+                            explorer_state,
+                            theme_customizer,
+                            settings_window,
+                        );
+                    },
+                );
+
+                let mut dir_count = 0usize;
+                let mut file_count = 0usize;
+                for &idx in item_viewer_filter_state.cached_indices.iter() {
+                    if display_files[idx].is_dir {
+                        dir_count += 1;
+                    } else {
+                        file_count += 1;
+                    }
+                }
+
+                let status_frame = egui::Frame::NONE
+                    .fill(egui::Color32::TRANSPARENT)
+                    .inner_margin(egui::Margin {
+                        left: 10,
+                        right: 10,
+                        top: 2,
+                        bottom: 2,
+                    });
+
+                status_frame.show(ui, |ui| {
+                    ui.allocate_ui_with_layout(
+                        egui::vec2(ui.available_width(), status_height),
+                        egui::Layout::right_to_left(egui::Align::Center),
+                        |ui| {
+                            let text_color = ui.visuals().text_color();
+                            let text_size = palette.text_size;
+                            let selected_count = explorer_state.selected_paths.len();
+                            let selected_label =
+                                if selected_count == 1 { "Item" } else { "Items" };
+
+                            ui.label(
+                                egui::RichText::new(format!("{} {}", regular::FILE, file_count))
+                                    .size(text_size)
+                                    .color(text_color),
+                            );
+                            ui.label(
+                                egui::RichText::new("|")
+                                    .size(text_size)
+                                    .color(text_color.linear_multiply(0.6)),
+                            );
+                            ui.label(
+                                egui::RichText::new(format!(
+                                    "{} {}",
+                                    regular::FOLDER_SIMPLE,
+                                    dir_count
+                                ))
+                                .size(text_size)
+                                .color(text_color),
+                            );
+                            if selected_count > 0 {
+                                ui.label(
+                                    egui::RichText::new("|")
+                                        .size(text_size)
+                                        .color(text_color.linear_multiply(0.6)),
+                                );
+                                ui.label(
+                                    egui::RichText::new(format!(
+                                        "{selected_count} {selected_label} Selected"
+                                    ))
+                                        .size(text_size)
+                                        .color(text_color),
+                                );
+                            }
+                        },
+                    );
+                });
+
+                ui.add_space(status_bottom_gap);
+            });
+
+            ui.spacing_mut().item_spacing = old_spacing;
+        },
+    );
+
+    (tabs_action, tabbar_action, pending_action)
+}

--- a/src/gui/windows/containers/itemviewer.rs
+++ b/src/gui/windows/containers/itemviewer.rs
@@ -476,7 +476,7 @@ pub fn draw_item_viewer(
                 rect,
                 egui::CornerRadius::same(palette.medium_radius),
                 egui::Stroke::new(1.5, palette.primary_active),
-                egui::StrokeKind::Inside,
+                egui::StrokeKind::Outside,
             );
         }
 

--- a/src/gui/windows/containers/itemviewer.rs
+++ b/src/gui/windows/containers/itemviewer.rs
@@ -40,6 +40,7 @@ pub fn draw_item_viewer(
     tabbar_action: &mut Option<TabbarAction>,
     drag_state: &mut DragState,
     filter_state: &mut FilterState,
+    hovered_drop_target_out: &mut Option<PathBuf>,
     is_loading: bool,
     explorer_state: &mut ExplorerState,
     theme_customizer_window: &mut ThemeCustomizer,
@@ -480,29 +481,7 @@ pub fn draw_item_viewer(
             );
         }
 
-        let pointer_released = ui
-            .ctx()
-            .input(|i| i.pointer.any_released() && i.pointer.interact_pos().is_some());
-
-        if drag_state.active && pointer_released {
-            if let Some(target_dir) = hovered_drop_target {
-                // Drop into hovered folder
-                action = Some(ItemViewerAction::MoveItems {
-                    sources: drag_state.source_items.clone(),
-                    target_dir,
-                });
-            } else {
-                // Optional: drop into current directory
-                // action = Some(ItemViewerAction::MoveItems {
-                //     sources: drag_state.source_items.clone(),
-                //     target_dir: current_directory.clone(),
-                // });
-            }
-
-            drag_state.active = false;
-            drag_state.start_pos = None;
-            drag_state.source_items.clear();
-        }
+        *hovered_drop_target_out = hovered_drop_target.clone();
 
         if let Some(a) = handle_keyboard_navigation(
             ui.ctx(),
@@ -674,7 +653,10 @@ fn handle_context_menu_actions(
 
     // Add the button
     if ui
-        .add_enabled(enable_open_in_tab, egui::Button::new("Open in new tab"))
+        .add_enabled(
+            enable_open_in_tab,
+            egui::Button::new("Open in new tab (middle-click"),
+        )
         .clicked()
     {
         if let Some(path) = explorer_state.selected_paths.iter().next() {
@@ -708,7 +690,10 @@ fn handle_context_menu_actions(
 
     ui.separator();
 
-    if ui.add_enabled(!is_cut, egui::Button::new("Cut")).clicked() {
+    if ui
+        .add_enabled(!is_cut, egui::Button::new("Cut (ctrl+x)"))
+        .clicked()
+    {
         let paths = if !explorer_state.selected_paths.is_empty() {
             explorer_state.selected_paths.iter().cloned().collect()
         } else {
@@ -720,7 +705,7 @@ fn handle_context_menu_actions(
         )));
         ui.close();
     }
-    if ui.button("Copy").clicked() {
+    if ui.button("Copy (ctrl+c)").clicked() {
         let paths = if !explorer_state.selected_paths.is_empty() {
             explorer_state.selected_paths.iter().cloned().collect()
         } else {
@@ -733,7 +718,7 @@ fn handle_context_menu_actions(
         ui.close();
     }
     if ui
-        .add_enabled(paste_enabled, egui::Button::new("Paste"))
+        .add_enabled(paste_enabled, egui::Button::new("Paste (ctrl+v)"))
         .clicked()
     {
         *action = Some(ItemViewerAction::Context(ItemViewerContextAction::Paste));
@@ -747,7 +732,7 @@ fn handle_context_menu_actions(
         ui.close();
     }
 
-    if ui.button("Delete").clicked() {
+    if ui.button("Delete (del)").clicked() {
         let paths = if !explorer_state.selected_paths.is_empty() {
             explorer_state.selected_paths.iter().cloned().collect()
         } else {

--- a/src/gui/windows/containers/mod.rs
+++ b/src/gui/windows/containers/mod.rs
@@ -1,4 +1,5 @@
 pub mod enums;
+pub mod explorer;
 pub mod itemviewer;
 pub mod sidebar;
 pub mod structs;

--- a/src/gui/windows/containers/sidebar.rs
+++ b/src/gui/windows/containers/sidebar.rs
@@ -318,6 +318,13 @@ pub fn draw_sidebar(
                         action.open_new_tab = Some(PathBuf::from(MY_PC_PATH));
                     }
 
+                    resp.context_menu(|ui| {
+                        if ui.button("Open in new tab (middle-click)").clicked() {
+                            action.open_new_tab = Some(PathBuf::from(MY_PC_PATH));
+                            ui.close();
+                        }
+                    });
+
                     if let Some(home) = dirs::home_dir() {
                         let resp = draw_sidebar_item(
                             ui,
@@ -334,8 +341,14 @@ pub fn draw_sidebar(
                             action.nav_to = Some(home.clone());
                         }
                         if resp.middle_clicked() {
-                            action.open_new_tab = Some(home);
+                            action.open_new_tab = Some(home.clone());
                         }
+                        resp.context_menu(|ui| {
+                            if ui.button("Open in new tab (middle-click)").clicked() {
+                                action.open_new_tab = Some(home.clone());
+                                ui.close();
+                            }
+                        });
                     }
 
                     ui.add_space(6.0);
@@ -430,6 +443,10 @@ pub fn draw_sidebar(
                         }
 
                         resp.context_menu(|ui| {
+                            if ui.button("Open in new tab (middle-click)").clicked() {
+                                action.open_new_tab = Some(favorite.path.clone());
+                                ui.close();
+                            }
                             if ui.button("Remove Favorite").clicked() {
                                 action.remove_favorite = Some(favorite.path.clone());
                                 ui.close();

--- a/src/gui/windows/containers/structs.rs
+++ b/src/gui/windows/containers/structs.rs
@@ -26,6 +26,7 @@ pub struct TabsAction {
     pub close: Option<u64>,
     pub open_new: bool,
     pub toggle_pin: Option<PathBuf>,
+    pub move_files_to_tab_dir: Option<PathBuf>,
 }
 
 pub struct TabState {
@@ -48,6 +49,7 @@ pub struct TabbarAction {
     pub nav_to: Option<PathBuf>,
     pub refresh_current_directory: bool,
     pub is_breadcrumb_path_edit_active: bool,
+    pub move_files_to_breadcrumb_dir: Option<PathBuf>,
 }
 
 #[derive(Clone, Copy)]

--- a/src/gui/windows/containers/tabs.rs
+++ b/src/gui/windows/containers/tabs.rs
@@ -6,7 +6,9 @@ use crate::gui::utils::{
     clear_clipboard_files, clickable_icon, expand_environment_variables, truncate_item_text,
 };
 use crate::gui::windows::containers::enums::TabbarNavAction;
-use crate::gui::windows::containers::structs::{TabInfo, TabState, TabbarAction, TabsAction};
+use crate::gui::windows::containers::structs::{
+    DragState, TabInfo, TabState, TabbarAction, TabsAction,
+};
 use crate::gui::windows::windowsoverrides::handle_draw_windows_buttons;
 use eframe::egui;
 use egui::{FontFamily, FontId};
@@ -21,8 +23,13 @@ pub fn draw_tabs(
     palette: &ThemePalette,
     hwnd: Option<HWND>,
     scroll_to_id: Option<u64>,
+    drag_state: &DragState,
 ) -> TabsAction {
     let mut action: TabsAction = TabsAction::default();
+    let pointer_pos = ui.input(|i| i.pointer.interact_pos().or_else(|| i.pointer.hover_pos()));
+    let pointer_released =
+        ui.input(|i| i.pointer.any_released() && i.pointer.interact_pos().is_some());
+    let mut tab_drop_target: Option<PathBuf> = None;
     let controls_width = 64.0;
     let full_width = ui.available_width();
     let tabs_width = (full_width - controls_width).max(0.0);
@@ -54,6 +61,30 @@ pub fn draw_tabs(
                                     if Some(tab.id) == scroll_to_id {
                                         resp.scroll_to_me(Some(egui::Align::Center));
                                     }
+
+                                    if drag_state.active && tab.id != active_id {
+                                        if let Some(pointer) = pointer_pos {
+                                            if rect.contains(pointer) {
+                                                let painter = ui
+                                                    .ctx()
+                                                    .layer_painter(egui::LayerId::new(
+                                                        egui::Order::Background,
+                                                        ui.id().with("tab_drop_bg").with(tab.id),
+                                                    ))
+                                                    .with_clip_rect(ui.clip_rect());
+                                                painter.rect_filled(
+                                                    rect,
+                                                    egui::CornerRadius::same(palette.medium_radius),
+                                                    palette.primary_hover,
+                                                );
+
+                                                if pointer_released {
+                                                    tab_drop_target = Some(tab.full_path.clone());
+                                                }
+                                            }
+                                        }
+                                    }
+
                                     handle_draw_tab_new_allocated(
                                         ui,
                                         tab,
@@ -110,6 +141,7 @@ pub fn draw_tabs(
             );
         },
     );
+    action.move_files_to_tab_dir = tab_drop_target;
     action
 }
 
@@ -535,8 +567,13 @@ pub fn draw_tabbar(
     tab: &mut TabState,
     palette: &ThemePalette,
     is_favorited: bool,
+    drag_state: &DragState,
 ) -> TabbarAction {
     let mut action = TabbarAction::default();
+    let pointer_pos = ui.input(|i| i.pointer.interact_pos().or_else(|| i.pointer.hover_pos()));
+    let pointer_released =
+        ui.input(|i| i.pointer.any_released() && i.pointer.interact_pos().is_some());
+    let mut breadcrumb_drop_target: Option<PathBuf> = None;
 
     ui.horizontal(|ui| {
         let toolbar_action = toolbar_buttons(ui, palette, is_favorited, tab.nav.is_root());
@@ -744,11 +781,40 @@ pub fn draw_tabbar(
 
                 let resp = inner.response.union(inner.inner);
 
+                if drag_state.active {
+                    if let Some(pointer) = pointer_pos {
+                        if resp.rect.contains(pointer) {
+                            let painter = ui
+                                .ctx()
+                                .layer_painter(egui::LayerId::new(
+                                    egui::Order::Background,
+                                    ui.id().with("breadcrumb_drop_bg").with(path),
+                                ))
+                                .with_clip_rect(ui.clip_rect());
+                            painter.rect_filled(
+                                resp.rect,
+                                egui::CornerRadius::same(palette.medium_radius),
+                                palette.primary_hover,
+                            );
+
+                            if pointer_released {
+                                if label == "..." {
+                                    if let Some((_, root_path)) = segments.first() {
+                                        breadcrumb_drop_target = Some(root_path.clone());
+                                    }
+                                } else {
+                                    breadcrumb_drop_target = Some(path.clone());
+                                }
+                            }
+                        }
+                    }
+                }
+
                 if resp.hovered() {
                     ui.ctx().set_cursor_icon(egui::CursorIcon::PointingHand);
                 }
 
-                if resp.clicked() {
+                if !drag_state.active && resp.clicked() {
                     // If "..." clicked, navigate to root
                     if label == "..." {
                         if let Some((_, root_path)) = segments.first() {
@@ -783,6 +849,7 @@ pub fn draw_tabbar(
         }
     });
 
+    action.move_files_to_breadcrumb_dir = breadcrumb_drop_target;
     action
 }
 

--- a/src/gui/windows/mainwindow.rs
+++ b/src/gui/windows/mainwindow.rs
@@ -11,7 +11,9 @@ use crate::gui::windows::containers::structs::{
     SidebarAction, TabInfo, TabState,
 };
 use crate::gui::windows::containers::topbar::draw_topbar;
-use crate::gui::windows::mainwindow_imp::{handle_draw_customizetheme_window, handle_pending_actions};
+use crate::gui::windows::mainwindow_imp::{
+    handle_draw_customizetheme_window, handle_pending_actions,
+};
 use crate::gui::windows::structs::{
     AboutWindow, AppSettings, Navigation, SettingsWindow, SidebarState, ThemeCustomizer,
 };
@@ -222,7 +224,6 @@ impl MainWindow {
     pub fn mark_tab_infos_dirty(&mut self) {
         self.tab_infos_dirty = true;
     }
-
 }
 
 impl Drop for MainWindow {

--- a/src/gui/windows/mainwindow.rs
+++ b/src/gui/windows/mainwindow.rs
@@ -1,20 +1,17 @@
-use crate::core::fs::{FileItem, MY_PC_PATH};
+use crate::core::fs::FileItem;
 use crate::core::indexer::{load_app_settings, load_favorites, load_theme_settings};
 use crate::gui::icons::IconCache;
 use crate::gui::theme::{ThemeMode, apply_theme, get_palette, set_palette};
 use crate::gui::utils::SortColumn;
 use crate::gui::windows::containers::enums::ItemViewerAction;
-use crate::gui::windows::containers::itemviewer::draw_item_viewer;
+use crate::gui::windows::containers::explorer::draw_explorer;
 use crate::gui::windows::containers::sidebar::draw_sidebar;
 use crate::gui::windows::containers::structs::{
     DragState, ExplorerState, FavoriteItem, FilterState, ItemViewerFolderSizeState, RenameState,
     SidebarAction, TabInfo, TabState,
 };
-use crate::gui::windows::containers::tabs::{draw_tabbar, draw_tabs};
 use crate::gui::windows::containers::topbar::draw_topbar;
-use crate::gui::windows::mainwindow_imp::{
-    handle_draw_customizetheme_window, handle_pending_actions, tab_title_for,
-};
+use crate::gui::windows::mainwindow_imp::{handle_draw_customizetheme_window, handle_pending_actions};
 use crate::gui::windows::structs::{
     AboutWindow, AppSettings, Navigation, SettingsWindow, SidebarState, ThemeCustomizer,
 };
@@ -226,28 +223,6 @@ impl MainWindow {
         self.tab_infos_dirty = true;
     }
 
-    fn rebuild_tab_infos(&mut self) {
-        self.tab_infos_cache = self
-            .tabs
-            .iter()
-            .map(|tab| TabInfo {
-                id: tab.id,
-                title: tab_title_for(&tab.nav),
-                full_path: if tab.nav.is_root() {
-                    PathBuf::from(MY_PC_PATH)
-                } else {
-                    tab.nav.current.clone()
-                },
-                is_pinned: self
-                    .settings_window
-                    .current_settings
-                    .pinned_tabs
-                    .iter()
-                    .any(|p| p == &tab.nav.current),
-            })
-            .collect();
-        self.tab_infos_dirty = false;
-    }
 }
 
 impl Drop for MainWindow {
@@ -408,100 +383,43 @@ impl eframe::App for MainWindow {
                                     .min(sidebar_width_max);
                         }
 
-                        // --- Tabs column ---
-                        let tabs_width = ui.available_width();
-                        ui.allocate_ui_with_layout(
-                            egui::vec2(tabs_width, ui.available_height() - 16.0),
-                            egui::Layout::top_down(egui::Align::Min),
-                            |ui| {
-                                let old_spacing = ui.spacing().item_spacing;
-                                ui.spacing_mut().item_spacing.y = 0.0;
+                        // --- Explorer column ---
+                        let (next_tabs_action, next_tabbar_action, next_pending_action) =
+                            draw_explorer(
+                                ui,
+                                &icon_cache,
+                                &palette,
+                                self.hwnd,
+                                &mut self.tabs,
+                                self.active_tab,
+                                &mut self.tab_infos_cache,
+                                &mut self.tab_infos_dirty,
+                                &mut self.pending_tab_scroll_id,
+                                &self.sidebar_state,
+                                &self.files,
+                                &self.folder_sizes,
+                                self.clipboard_has_files,
+                                &self.clipboard_set,
+                                self.clipboard_is_cut,
+                                self.sort_column,
+                                self.sort_ascending,
+                                &mut self.rename_state,
+                                &mut self.file_type_cache,
+                                &mut self.file_size_text_cache,
+                                &mut self.folder_size_text_cache,
+                                &mut self.drive_size_text_cache,
+                                &mut self.external_drag_to_internal_hover,
+                                &mut self.drag_state,
+                                &mut self.item_viewer_filter_state,
+                                self.is_loading,
+                                &mut self.explorer_state,
+                                &mut self.theme_customizer,
+                                &mut self.settings_window,
+                            );
 
-                                if self.tab_infos_dirty
-                                    || self.tab_infos_cache.len() != self.tabs.len()
-                                {
-                                    self.rebuild_tab_infos();
-                                }
-                                let active_id = self.tabs[self.active_tab].id;
-
-                                egui::Frame::NONE.show(ui, |ui| {
-                                    ui.add_space(8.0);
-                                    let scroll_to_id = self.pending_tab_scroll_id;
-                                    tabs_action = Some(draw_tabs(
-                                        ui,
-                                        &self.tab_infos_cache,
-                                        active_id,
-                                        &palette,
-                                        self.hwnd,
-                                        scroll_to_id,
-                                    ));
-                                    if scroll_to_id.is_some() {
-                                        self.pending_tab_scroll_id = None;
-                                    }
-                                });
-
-                                let container = egui::Frame::NONE
-                                    .stroke(egui::Stroke::NONE)
-                                    .fill(egui::Color32::TRANSPARENT)
-                                    .inner_margin(egui::Margin::symmetric(10, 8));
-
-                                let active_index = self.active_tab;
-                                let is_drive_view = self.current_nav().is_root();
-                                let display_files = &self.files;
-
-                                container.show(ui, |ui| {
-                                    tabbar_action = {
-                                        let tab = &mut self.tabs[active_index];
-                                        let is_favorited = self
-                                            .sidebar_state
-                                            .favorites
-                                            .iter()
-                                            .any(|fav| fav.path == tab.nav.current);
-
-                                        Some(draw_tabbar(
-                                            ui,
-                                            &icon_cache,
-                                            tab,
-                                            &palette,
-                                            is_favorited,
-                                        ))
-                                    };
-
-                                    ui.add_space(4.0);
-
-                                    pending_action = draw_item_viewer(
-                                        ui,
-                                        display_files,
-                                        &self.folder_sizes,
-                                        self.clipboard_has_files,
-                                        &self.clipboard_set,
-                                        self.clipboard_is_cut,
-                                        is_drive_view,
-                                        self.sort_column,
-                                        self.sort_ascending,
-                                        &icon_cache,
-                                        &mut self.rename_state,
-                                        &palette,
-                                        &mut self.file_type_cache,
-                                        &mut self.file_size_text_cache,
-                                        &mut self.folder_size_text_cache,
-                                        &mut self.drive_size_text_cache,
-                                        &mut self.external_drag_to_internal_hover,
-                                        &mut tabbar_action,
-                                        &mut self.drag_state,
-                                        &mut self.item_viewer_filter_state,
-                                        self.is_loading,
-                                        &mut self.explorer_state,
-                                        &mut self.theme_customizer,
-                                        &mut self.settings_window,
-                                    );
-
-                                    ui.add_space(16.0);
-                                });
-
-                                ui.spacing_mut().item_spacing = old_spacing;
-                            },
-                        );
+                        tabs_action = Some(next_tabs_action);
+                        tabbar_action = next_tabbar_action;
+                        pending_action = next_pending_action;
                     },
                 );
             });

--- a/src/gui/windows/mainwindow_imp.rs
+++ b/src/gui/windows/mainwindow_imp.rs
@@ -1168,6 +1168,90 @@ pub fn handle_pending_actions(pending_action: Option<ItemViewerAction>, explorer
                 explorer.explorer_state.selection_focus = None;
                 explorer.load_path();
             }
+            ItemViewerAction::MoveFilesToBreadcrumbDirectory {
+                sources,
+                target_dir,
+            } => {
+                unsafe {
+                    let file_op: IFileOperation =
+                        CoCreateInstance(&FileOperation, None, CLSCTX_ALL).unwrap();
+
+                    // Optional: show UI + allow TeraCopy hooks
+                    file_op
+                        .SetOperationFlags(
+                            FOF_SIMPLEPROGRESS | FOF_ALLOWUNDO | FOFX_SHOWELEVATIONPROMPT,
+                        )
+                        .ok();
+
+                    // Convert target dir to IShellItem
+                    let target_item: IShellItem = SHCreateItemFromParsingName(
+                        &HSTRING::from(target_dir.to_string_lossy().to_string()),
+                        None,
+                    )
+                    .unwrap();
+
+                    for source in sources {
+                        let source_item: IShellItem = SHCreateItemFromParsingName(
+                            &HSTRING::from(source.to_string_lossy().to_string()),
+                            None,
+                        )
+                        .unwrap();
+
+                        file_op
+                            .MoveItem(&source_item, &target_item, None, None)
+                            .ok();
+                    }
+
+                    file_op.PerformOperations().ok();
+                }
+
+                explorer.explorer_state.selected_paths.clear();
+                explorer.explorer_state.selection_anchor = None;
+                explorer.explorer_state.selection_focus = None;
+                explorer.load_path();
+            }
+            ItemViewerAction::MoveFilesToTabDirectory {
+                sources,
+                target_dir,
+            } => {
+                unsafe {
+                    let file_op: IFileOperation =
+                        CoCreateInstance(&FileOperation, None, CLSCTX_ALL).unwrap();
+
+                    // Optional: show UI + allow TeraCopy hooks
+                    file_op
+                        .SetOperationFlags(
+                            FOF_SIMPLEPROGRESS | FOF_ALLOWUNDO | FOFX_SHOWELEVATIONPROMPT,
+                        )
+                        .ok();
+
+                    // Convert target dir to IShellItem
+                    let target_item: IShellItem = SHCreateItemFromParsingName(
+                        &HSTRING::from(target_dir.to_string_lossy().to_string()),
+                        None,
+                    )
+                    .unwrap();
+
+                    for source in sources {
+                        let source_item: IShellItem = SHCreateItemFromParsingName(
+                            &HSTRING::from(source.to_string_lossy().to_string()),
+                            None,
+                        )
+                        .unwrap();
+
+                        file_op
+                            .MoveItem(&source_item, &target_item, None, None)
+                            .ok();
+                    }
+
+                    file_op.PerformOperations().ok();
+                }
+
+                explorer.explorer_state.selected_paths.clear();
+                explorer.explorer_state.selection_anchor = None;
+                explorer.explorer_state.selection_focus = None;
+                explorer.load_path();
+            }
         }
     }
 }


### PR DESCRIPTION
## 🆕 What's New

- Directory status bar that displays number of files and folders
- Status bar displays number of selected items
- You can now drag and drop objects into breadcrumb directories or into any tab
- Accessibility hints in context menus (eg. Copy shows ctrl+c)
- Added context menus for sidebar items to help with hinting at mouse button shortcuts