### PR TITLE
feat: add copy path for single selected items

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "EdenExplorer"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "bincode",
  "crossbeam-channel",

--- a/README.md
+++ b/README.md
@@ -5,6 +5,11 @@
 <h1 align="center">EdenExplorer</h1>
 
 <p align="center">
+  <a href="https://thetalabs.ca/eden-explorer/">
+    <img src="https://img.shields.io/badge/🚀%20LIVE%20NOW!-Official%20Website%20Launched!-2ecc71?style=for-the-badge&link=https://thetalabs.ca/eden-explorer/" alt="Official Website Launched">
+  </a>
+</p>
+<p align="center">
   <img src="https://img.shields.io/badge/Public%20Alpha-Now%20Available-2ecc71?style=for-the-badge" />
 </p>
 
@@ -294,10 +299,12 @@
 - [ ] Image previews using Spacebar - GPU texture via wgpu / egui_wgpu_backend
 - [ ] Support network devices
 - [ ] Drag and drop files from EdenExplorer into Windows objects (Desktop, File Explorer, applications, etc.)
+- [ ] New shortcut and context menu command for getting a file's Full Path (using ctrl+shift+c for example).
 
 ## 🐛 Known Bugs
 - Hitting "Shift" after already shift-selecting files drops the entire file selection
 - Dragging EdenExplorer across multiple monitors causes strange visual glitches
+- If you filter objects in the item viewer then try to select an object among the filtered list, it removes the filter and doesn't select anything
 
 ## Star History
 

--- a/src/gui/utils.rs
+++ b/src/gui/utils.rs
@@ -373,6 +373,48 @@ pub fn clipboard_has_files() -> bool {
     has
 }
 
+pub fn copy_text_to_clipboard(text: &str) -> bool {
+    use windows::Win32::Foundation::HANDLE;
+    use windows::Win32::System::DataExchange::{
+        CloseClipboard, EmptyClipboard, OpenClipboard, SetClipboardData,
+    };
+    use windows::Win32::System::Memory::{GlobalAlloc, GlobalLock, GlobalUnlock};
+
+    if unsafe { OpenClipboard(None).is_err() } {
+        return false;
+    }
+
+    let _ = unsafe { EmptyClipboard() };
+
+    // Convert string to wide string (UTF-16)
+    let wide_text: Vec<u16> = text.encode_utf16().chain(std::iter::once(0)).collect();
+    let text_size = wide_text.len() * std::mem::size_of::<u16>();
+
+    let hglobal = match unsafe { GlobalAlloc(GMEM_MOVEABLE, text_size) } {
+        Ok(h) => h,
+        Err(_) => {
+            let _ = unsafe { CloseClipboard() };
+            return false;
+        }
+    };
+
+    let ptr = unsafe { GlobalLock(hglobal) };
+    if !ptr.is_null() {
+        unsafe {
+            std::ptr::copy_nonoverlapping(wide_text.as_ptr(), ptr as *mut u16, wide_text.len());
+            let _ = GlobalUnlock(hglobal);
+            // CF_UNICODETEXT is 13
+            let _ = SetClipboardData(13, Some(HANDLE(hglobal.0)));
+        }
+    } else {
+        let _ = unsafe { CloseClipboard() };
+        return false;
+    }
+
+    let _ = unsafe { CloseClipboard() };
+    true
+}
+
 pub fn get_file_type_name<'a>(ext: &str, cache: &'a mut HashMap<String, String>) -> &'a str {
     use std::collections::hash_map::Entry;
 

--- a/src/gui/windows/containers/enums.rs
+++ b/src/gui/windows/containers/enums.rs
@@ -39,6 +39,7 @@ pub enum ItemViewerAction {
 #[derive(Clone, Debug)]
 pub enum ItemViewerContextAction {
     Copy(Vec<PathBuf>),
+    CopyPath(Vec<PathBuf>),
     Cut(Vec<PathBuf>),
     Paste,
     RenameRequest(PathBuf, String),

--- a/src/gui/windows/containers/itemviewer.rs
+++ b/src/gui/windows/containers/itemviewer.rs
@@ -766,6 +766,18 @@ fn handle_context_menu_actions(
         )));
         ui.close();
     }
+    if ui.button("Copy Path (ctrl+shift+c)").clicked() {
+        let paths = if !explorer_state.selected_paths.is_empty() {
+            explorer_state.selected_paths.iter().cloned().collect()
+        } else {
+            vec![file.path.clone()]
+        };
+
+        *action = Some(ItemViewerAction::Context(
+            ItemViewerContextAction::CopyPath(paths),
+        ));
+        ui.close();
+    }
     if ui
         .add_enabled(paste_enabled, egui::Button::new("Paste (ctrl+v)"))
         .clicked()
@@ -1457,6 +1469,15 @@ fn handle_global_actions(
         if i.modifiers.command && i.key_released(egui::Key::V) {
             // Any other key functions won't work with egui v0.33.x
             action = Some(ItemViewerAction::Context(ItemViewerContextAction::Paste));
+        }
+        if i.modifiers.command && i.modifiers.shift && i.key_pressed(egui::Key::C) {
+            // Copy path shortcut - only enabled when exactly one item is selected
+            if explorer_state.selected_paths.len() == 1 {
+                let path = explorer_state.selected_paths.iter().next().unwrap().clone();
+                action = Some(ItemViewerAction::Context(
+                    ItemViewerContextAction::CopyPath(vec![path]),
+                ));
+            }
         }
         if i.key_pressed(egui::Key::Delete) {
             let paths: Vec<PathBuf> = if !explorer_state.selected_paths.is_empty() {

--- a/src/gui/windows/containers/itemviewer.rs
+++ b/src/gui/windows/containers/itemviewer.rs
@@ -1370,11 +1370,24 @@ fn handle_global_actions(
         }
 
         if response.clicked_elsewhere() {
-            ui.memory_mut(|mem| {
-                mem.data
-                    .remove::<egui::text_edit::TextEditState>(text_edit_id)
-            });
-            *filter_state = FilterState::default();
+            // Check if click is within the item viewer area (table)
+            let click_pos = ui.input(|i| i.pointer.interact_pos());
+            let should_clear_filter = if let Some(pos) = click_pos {
+                let item_viewer_rect = ui.available_rect_before_wrap();
+                // Don't clear filter if clicking within the item viewer area
+                !item_viewer_rect.contains(pos)
+            } else {
+                // If no click position, clear filter (fallback behavior)
+                true
+            };
+
+            if should_clear_filter {
+                ui.memory_mut(|mem| {
+                    mem.data
+                        .remove::<egui::text_edit::TextEditState>(text_edit_id)
+                });
+                *filter_state = FilterState::default();
+            }
         }
 
         return None;
@@ -1753,6 +1766,17 @@ fn handle_keyboard_navigation(
         let anchor = explorer_state.selection_anchor.unwrap_or(current_idx);
         let focus = explorer_state.selection_focus.unwrap_or(current_idx);
 
+        // Validate that anchor and focus are within bounds
+        let anchor_valid = anchor < filtered_indices.len();
+        let focus_valid = focus < filtered_indices.len();
+
+        if !anchor_valid || !focus_valid {
+            // Reset to current position if indices are invalid
+            explorer_state.selection_anchor = Some(current_idx);
+            explorer_state.selection_focus = Some(current_idx);
+            return None;
+        }
+
         let mut new_focus = focus;
 
         if ctx.input(|i| i.key_pressed(egui::Key::ArrowDown)) {
@@ -1832,17 +1856,25 @@ fn handle_row_click(
     if modifiers.shift {
         if let Some(anchor_idx) = explorer_state.selection_anchor {
             let current_idx = row_idx;
-            let range_start = anchor_idx.min(current_idx);
-            let range_end = anchor_idx.max(current_idx);
 
-            let range_paths: Vec<PathBuf> = filtered_indices[range_start..=range_end]
-                .iter()
-                .map(|&i| files[i].path.clone())
-                .collect();
+            // Validate that anchor_idx is still within bounds of filtered_indices
+            if anchor_idx < filtered_indices.len() {
+                let range_start = anchor_idx.min(current_idx);
+                let range_end = anchor_idx.max(current_idx);
 
-            explorer_state.selection_focus = Some(current_idx);
+                let range_paths: Vec<PathBuf> = filtered_indices[range_start..=range_end]
+                    .iter()
+                    .map(|&i| files[i].path.clone())
+                    .collect();
 
-            Some(ItemViewerAction::RangeSelect(range_paths))
+                explorer_state.selection_focus = Some(current_idx);
+                Some(ItemViewerAction::RangeSelect(range_paths))
+            } else {
+                // Anchor is out of bounds, treat as simple selection
+                explorer_state.selection_anchor = Some(row_idx);
+                explorer_state.selection_focus = Some(row_idx);
+                Some(ItemViewerAction::Select(file.path.clone()))
+            }
         } else {
             explorer_state.selection_anchor = Some(row_idx);
             explorer_state.selection_focus = Some(row_idx);

--- a/src/gui/windows/mainwindow_imp.rs
+++ b/src/gui/windows/mainwindow_imp.rs
@@ -303,6 +303,16 @@ impl MainWindow {
                 let _ = set_clipboard_files(&paths, false);
                 mark_clipboard_dirty();
             }
+            ItemViewerContextAction::CopyPath(paths) => {
+                use crate::gui::utils::copy_text_to_clipboard;
+
+                // Convert paths to strings and join with newlines
+                let path_strings: Vec<String> =
+                    paths.iter().map(|p| p.display().to_string()).collect();
+
+                let text = path_strings.join("\r\n");
+                let _ = copy_text_to_clipboard(&text);
+            }
             ItemViewerContextAction::Paste => {
                 if let Err(e) = self.paste_clipboard_native() {
                     eprintln!("Paste failed: {}", e);

--- a/src/gui/windows/mainwindow_imp.rs
+++ b/src/gui/windows/mainwindow_imp.rs
@@ -1029,24 +1029,53 @@ pub fn handle_pending_actions(pending_action: Option<ItemViewerAction>, explorer
                 // Set selection_focus to the edge of the range that is farthest from the anchor
                 if let Some(anchor_idx) = explorer.explorer_state.selection_anchor {
                     if let (Some(first_path), Some(last_path)) = (paths.first(), paths.last()) {
-                        let first_idx = explorer
-                            .files
-                            .iter()
-                            .position(|f| &f.path == first_path)
-                            .unwrap_or(anchor_idx);
-                        let last_idx = explorer
-                            .files
-                            .iter()
-                            .position(|f| &f.path == last_path)
-                            .unwrap_or(anchor_idx);
+                        // Check if we're in a filtered view
+                        let is_filtered = explorer.item_viewer_filter_state.active
+                            && !explorer.item_viewer_filter_state.query.is_empty();
 
-                        // If moving down, focus the last item; if moving up, focus the first item
-                        explorer.explorer_state.selection_focus =
-                            Some(if anchor_idx <= first_idx {
-                                last_idx // moved down
-                            } else {
-                                first_idx // moved up
-                            });
+                        if is_filtered {
+                            // Use filtered indices
+                            let first_idx = explorer
+                                .item_viewer_filter_state
+                                .cached_indices
+                                .iter()
+                                .position(|&i| &explorer.files[i].path == first_path)
+                                .unwrap_or(anchor_idx);
+                            let last_idx = explorer
+                                .item_viewer_filter_state
+                                .cached_indices
+                                .iter()
+                                .position(|&i| &explorer.files[i].path == last_path)
+                                .unwrap_or(anchor_idx);
+
+                            // If moving down, focus the last item; if moving up, focus the first item
+                            explorer.explorer_state.selection_focus =
+                                Some(if anchor_idx <= first_idx {
+                                    last_idx // moved down
+                                } else {
+                                    first_idx // moved up
+                                });
+                        } else {
+                            // Use original file indices (unfiltered view)
+                            let first_idx = explorer
+                                .files
+                                .iter()
+                                .position(|f| &f.path == first_path)
+                                .unwrap_or(anchor_idx);
+                            let last_idx = explorer
+                                .files
+                                .iter()
+                                .position(|f| &f.path == last_path)
+                                .unwrap_or(anchor_idx);
+
+                            // If moving down, focus the last item; if moving up, focus the first item
+                            explorer.explorer_state.selection_focus =
+                                Some(if anchor_idx <= first_idx {
+                                    last_idx // moved down
+                                } else {
+                                    first_idx // moved up
+                                });
+                        }
                     }
                 }
             }
@@ -1104,7 +1133,24 @@ pub fn handle_pending_actions(pending_action: Option<ItemViewerAction>, explorer
             ItemViewerAction::ReplaceSelection(path) => {
                 explorer.explorer_state.selected_paths.clear();
                 explorer.explorer_state.selected_paths.insert(path.clone());
-                if let Some(idx) = explorer.files.iter().position(|f| f.path == path) {
+
+                // Check if we're in a filtered view
+                let is_filtered = explorer.item_viewer_filter_state.active
+                    && !explorer.item_viewer_filter_state.query.is_empty();
+
+                let idx = if is_filtered {
+                    // Use filtered indices
+                    explorer
+                        .item_viewer_filter_state
+                        .cached_indices
+                        .iter()
+                        .position(|&i| explorer.files[i].path == path)
+                } else {
+                    // Use original file indices (unfiltered view)
+                    explorer.files.iter().position(|f| f.path == path)
+                };
+
+                if let Some(idx) = idx {
                     explorer.explorer_state.selection_anchor = Some(idx);
                     explorer.explorer_state.selection_focus = Some(idx);
                 }


### PR DESCRIPTION
## 🆕 What's New

- New context menu "Copy Path" that also has the keyboard shortcut of ctrl+shift+c (https://github.com/mtucciarone/EdenExplorer/issues/29)
Big thanks to @gcscript for this request!

## 🐛 What's Fixed

- When in filter mode of objects, selecting any files would remove the filter and users were unable to select filtered files

## 🔗 Related Issues

https://github.com/mtucciarone/EdenExplorer/issues/29