### PR TITLE
feat: two-way drag n drop system with native windows OLE

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "EdenExplorer"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "bincode",
  "chrono",
@@ -26,6 +26,7 @@ dependencies = [
  "serde",
  "serde_json",
  "windows 0.61.3",
+ "windows-core 0.61.2",
  "winres",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,8 @@ windows = { version = "0.61.3", features = [
     "Win32_System_DataExchange",
     "Win32_System_Memory",
     "Win32_System_Ole",
+    "Win32_System_Com_StructuredStorage",
+    "Win32_System_SystemServices",
     "Win32_System_Registry",
     "Win32_System_WindowsProgramming",
     "Win32_System_Com",
@@ -44,6 +46,7 @@ windows = { version = "0.61.3", features = [
     "Win32_NetworkManagement_NetManagement",
     "Win32_UI_Input_KeyboardAndMouse",
 ] }
+windows-core = "0.61.2"
 crossbeam-channel = "0.5.15"
 dirs = "6.0"
 bincode = "1.3"

--- a/README.md
+++ b/README.md
@@ -296,11 +296,11 @@
 - [x] Enable/Disable Windows shell integration. By enabling, the context menu will populate with default Windows registry context menu items
 - [x] New context menu command (Copy Path) with keyboard shortcut of Ctrl+Shift+C
 - [x] Column sorting saves across sessions
+- [x] Drag and drop files from EdenExplorer into native Operating System (Windows) objects (Desktop, File Explorer, applications, etc.)
 
 ### 🚀 Upcoming Features
 - [ ] Image previews using Spacebar - GPU texture via wgpu / egui_wgpu_backend
 - [ ] Support network devices
-- [ ] Drag and drop files from EdenExplorer into Windows objects (Desktop, File Explorer, applications, etc.)
 - [ ] Enhanced theme customization, such as custom layouts, mix/match UI elements, styles, etc
 
 ## 🐛 Known Bugs

--- a/src/gui/dragdrop.rs
+++ b/src/gui/dragdrop.rs
@@ -1,0 +1,34 @@
+use eframe::egui;
+use std::path::PathBuf;
+
+#[derive(Clone, Debug, Default)]
+pub struct DropTargetRegion {
+    pub target: Option<PathBuf>,
+    pub rect: Option<egui::Rect>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct DropTargets {
+    pub item_target: DropTargetRegion,
+    pub tab_target: DropTargetRegion,
+    pub breadcrumb_target: DropTargetRegion,
+}
+
+#[derive(Clone, Debug)]
+pub enum NativeDropCommand {
+    ImportFiles(Vec<PathBuf>),
+    MoveFiles {
+        sources: Vec<PathBuf>,
+        target_dir: PathBuf,
+    },
+}
+
+pub trait DragDropBackend {
+    fn begin_file_drag(&self, paths: &[PathBuf]) -> bool;
+    fn is_drag_active(&self) -> bool;
+    fn is_inbound_drag_active(&self) -> bool;
+    fn hovered_drop_target(&self) -> Option<PathBuf>;
+    fn set_scale_factor(&self, scale_factor: f32);
+    fn update_drop_targets(&self, targets: DropTargets);
+    fn poll_command(&self) -> Option<NativeDropCommand>;
+}

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -1,4 +1,5 @@
 // gui/mod.rs
+pub mod dragdrop;
 pub mod icons;
 pub mod theme;
 pub mod utils;

--- a/src/gui/windows/containers/explorer.rs
+++ b/src/gui/windows/containers/explorer.rs
@@ -1,4 +1,5 @@
 use crate::core::fs::{FileItem, MY_PC_PATH};
+use crate::gui::dragdrop::{DragDropBackend, DropTargets};
 use crate::gui::icons::IconCache;
 use crate::gui::theme::ThemePalette;
 use crate::gui::utils::SortColumn;
@@ -44,11 +45,16 @@ pub fn draw_explorer(
     drive_size_text_cache: &mut HashMap<PathBuf, (u64, u64, String)>,
     external_drag_to_internal_hover: &mut bool,
     drag_state: &mut DragState,
+    drag_active: bool,
+    native_drag_active: bool,
+    drag_hover_target: Option<PathBuf>,
+    dragdrop: Option<&dyn DragDropBackend>,
     item_viewer_filter_state: &mut FilterState,
     is_loading: bool,
     explorer_state: &mut ExplorerState,
     theme_customizer: &mut ThemeCustomizer,
     settings_window: &mut SettingsWindow,
+    drop_targets: &mut DropTargets,
 ) -> (TabsAction, Option<TabbarAction>, Option<ItemViewerAction>) {
     let mut tabs_action = TabsAction::default();
     let mut tabbar_action: Option<TabbarAction> = None;
@@ -96,6 +102,8 @@ pub fn draw_explorer(
                     hwnd,
                     scroll_to_id,
                     drag_state,
+                    drag_active,
+                    drag_hover_target.clone(),
                 );
                 if scroll_to_id.is_some() {
                     *pending_tab_scroll_id = None;
@@ -126,6 +134,8 @@ pub fn draw_explorer(
                         palette,
                         is_favorited,
                         drag_state,
+                        drag_active,
+                        drag_hover_target.clone(),
                     ))
                 };
 
@@ -136,6 +146,7 @@ pub fn draw_explorer(
                 let item_viewer_height =
                     (ui.available_height() - status_height - status_bottom_gap).max(0.0);
                 let mut hovered_drop_target: Option<PathBuf> = None;
+                let mut hovered_drop_target_rect: Option<egui::Rect> = None;
 
                 ui.allocate_ui_with_layout(
                     egui::vec2(ui.available_width(), item_viewer_height),
@@ -164,8 +175,13 @@ pub fn draw_explorer(
                                     external_drag_to_internal_hover,
                                     &mut tabbar_action,
                                     drag_state,
+                                    drag_active,
+                                    native_drag_active,
+                                    drag_hover_target.clone(),
+                                    dragdrop,
                                     item_viewer_filter_state,
                                     &mut hovered_drop_target,
+                                    &mut hovered_drop_target_rect,
                                     is_loading,
                                     explorer_state,
                                     theme_customizer,
@@ -176,42 +192,16 @@ pub fn draw_explorer(
                     },
                 );
 
-                let pointer_released = ui
-                    .ctx()
-                    .input(|i| i.pointer.any_released() && i.pointer.interact_pos().is_some());
-
-                if drag_state.active && pointer_released && !drag_state.source_items.is_empty() {
-                    if let Some(target_dir) = tabs_action.move_files_to_tab_dir.clone() {
-                        if pending_action.is_none() {
-                            pending_action = Some(ItemViewerAction::MoveFilesToTabDirectory {
-                                sources: drag_state.source_items.clone(),
-                                target_dir,
-                            });
-                        }
-                    } else if let Some(target_dir) = tabbar_action
-                        .as_ref()
-                        .and_then(|a| a.move_files_to_breadcrumb_dir.clone())
-                    {
-                        if pending_action.is_none() {
-                            pending_action =
-                                Some(ItemViewerAction::MoveFilesToBreadcrumbDirectory {
-                                    sources: drag_state.source_items.clone(),
-                                    target_dir,
-                                });
-                        }
-                    } else if let Some(target_dir) = hovered_drop_target {
-                        if pending_action.is_none() {
-                            pending_action = Some(ItemViewerAction::MoveItems {
-                                sources: drag_state.source_items.clone(),
-                                target_dir,
-                            });
-                        }
-                    }
-
-                    drag_state.active = false;
-                    drag_state.start_pos = None;
-                    drag_state.source_items.clear();
-                }
+                drop_targets.item_target.target = hovered_drop_target.clone();
+                drop_targets.item_target.rect = hovered_drop_target_rect;
+                drop_targets.tab_target.target = tabs_action.move_files_to_tab_dir.clone();
+                drop_targets.tab_target.rect = tabs_action.move_files_to_tab_dir_rect;
+                drop_targets.breadcrumb_target.target = tabbar_action
+                    .as_ref()
+                    .and_then(|a| a.move_files_to_breadcrumb_dir.clone());
+                drop_targets.breadcrumb_target.rect = tabbar_action
+                    .as_ref()
+                    .and_then(|a| a.move_files_to_breadcrumb_dir_rect);
 
                 if !is_drive_view {
                     let mut dir_count = 0usize;

--- a/src/gui/windows/containers/itemviewer.rs
+++ b/src/gui/windows/containers/itemviewer.rs
@@ -1,5 +1,6 @@
 use crate::core::drives::is_raw_physical_drive_path;
 use crate::core::fs::FileItem;
+use crate::gui::dragdrop::DragDropBackend;
 use crate::gui::icons::IconCache;
 use crate::gui::theme::{ThemePalette, apply_checkbox_colors};
 use crate::gui::utils::{
@@ -43,8 +44,13 @@ pub fn draw_item_viewer(
     external_drag_to_internal_hover: &mut bool,
     tabbar_action: &mut Option<TabbarAction>,
     drag_state: &mut DragState,
+    drag_active: bool,
+    native_drag_active: bool,
+    drag_hover_target: Option<PathBuf>,
+    dragdrop: Option<&dyn DragDropBackend>,
     filter_state: &mut FilterState,
     hovered_drop_target_out: &mut Option<PathBuf>,
+    hovered_drop_target_rect_out: &mut Option<egui::Rect>,
     is_loading: bool,
     explorer_state: &mut ExplorerState,
     theme_customizer_window: &mut ThemeCustomizer,
@@ -62,21 +68,6 @@ pub fn draw_item_viewer(
     let mut any_row_hovered = false;
 
     if files.is_empty() {
-        // Handle drag and drop for empty folders
-        if ui.ctx().input(|i| !i.raw.dropped_files.is_empty()) {
-            let dropped_paths: Vec<PathBuf> = ui.ctx().input(|i| {
-                i.raw
-                    .dropped_files
-                    .iter()
-                    .filter_map(|f| f.path.clone())
-                    .collect()
-            });
-
-            if !dropped_paths.is_empty() {
-                action = Some(ItemViewerAction::FilesDropped(dropped_paths));
-            }
-        }
-
         ui.centered_and_justified(|ui| {
             if is_loading {
                 ui.add(egui::Spinner::new().size(28.0));
@@ -115,7 +106,7 @@ pub fn draw_item_viewer(
         }
     }
 
-    if drag_state.active {
+    if drag_active {
         let label = if drag_state.source_items.len() == 1 {
             drag_state.source_items[0]
                 .file_name()
@@ -148,12 +139,21 @@ pub fn draw_item_viewer(
     let mut current_hovered_drop_target: Option<PathBuf> = None;
     let mut current_hovered_drop_target_rect: Option<egui::Rect> = None;
     let mut best_hovered_row: Option<(f32, bool, PathBuf, egui::Rect)> = None;
-    let drag_hover_active = ui
+    let drag_hover_active = ui.ctx().input(|i| {
+        drag_active
+            || native_drag_active
+            || i.raw.hovered_files.iter().any(|file| file.path.is_some())
+    });
+    let external_file_hover = ui
         .ctx()
-        .input(|i| drag_state.active || i.raw.hovered_files.iter().any(|file| file.path.is_some()));
+        .input(|i| i.raw.hovered_files.iter().any(|file| file.path.is_some()));
     let pointer_pos = ui
         .ctx()
         .input(|i| i.pointer.interact_pos().or_else(|| i.pointer.hover_pos()));
+    let pointer_released = ui
+        .ctx()
+        .input(|i| i.pointer.any_released() && i.pointer.interact_pos().is_some());
+    let hovered_target_ref = drag_hover_target.as_ref();
 
     if !files.is_empty() {
         let modifiers = ui.ctx().input(|i| i.modifiers);
@@ -366,7 +366,12 @@ pub fn draw_item_viewer(
                     let row_resp = row.response();
 
                     if drag_hover_active {
-                        if let Some(pointer) = pointer_pos {
+                        if let Some(target) = hovered_target_ref {
+                            if &file.path == target && file.is_dir {
+                                current_hovered_drop_target = Some(file.path.clone());
+                                current_hovered_drop_target_rect = Some(row_resp.rect);
+                            }
+                        } else if let Some(pointer) = pointer_pos {
                             if row_resp.rect.contains(pointer) {
                                 let is_dir = file.is_dir;
                                 let row_top = row_resp.rect.top();
@@ -394,20 +399,27 @@ pub fn draw_item_viewer(
                         drag_state.active = false; // threshold not passed yet
                         drag_state.source_items.clear();
 
-                        // ✅ LOCK drag payload immediately
-                        drag_state.source_items =
-                            if explorer_state.selected_paths.contains(&file.path) {
-                                explorer_state.selected_paths.iter().cloned().collect()
-                            } else {
-                                vec![file.path.clone()]
-                            };
+                        if explorer_state.selected_paths.contains(&file.path) {
+                            drag_state.source_items =
+                                explorer_state.selected_paths.iter().cloned().collect();
+                        } else {
+                            // Click-drag on a row should promote that row into the selection.
+                            explorer_state.selected_paths.clear();
+                            explorer_state.selected_paths.insert(file.path.clone());
+                            explorer_state.selection_anchor = Some(idx);
+                            explorer_state.selection_focus = Some(idx);
+                            drag_state.source_items = vec![file.path.clone()];
+                        }
                     }
 
                     if let (Some(start), Some(current)) = (
                         drag_state.start_pos,
                         row_resp.ctx.input(|i| i.pointer.hover_pos()),
                     ) {
-                        if !drag_state.active && start.distance(current) > 4.0 {
+                        if !drag_state.active
+                            && !drag_state.source_items.is_empty()
+                            && start.distance(current) > 4.0
+                        {
                             drag_state.active = true;
                         }
                     }
@@ -467,6 +479,18 @@ pub fn draw_item_viewer(
                     }
                 }
 
+                if drag_state.active && pointer_released {
+                    if let Some(target_dir) = current_hovered_drop_target.clone() {
+                        action = Some(ItemViewerAction::MoveItems {
+                            sources: drag_state.source_items.clone(),
+                            target_dir,
+                        });
+                        drag_state.active = false;
+                        drag_state.start_pos = None;
+                        drag_state.source_items.clear();
+                    }
+                }
+
                 *hovered_drop_target = current_hovered_drop_target;
                 hovered_drop_target_rect = current_hovered_drop_target_rect;
             });
@@ -492,6 +516,7 @@ pub fn draw_item_viewer(
         }
 
         *hovered_drop_target_out = hovered_drop_target.clone();
+        *hovered_drop_target_rect_out = hovered_drop_target_rect;
 
         if let Some(a) = handle_keyboard_navigation(
             ui.ctx(),
@@ -504,26 +529,7 @@ pub fn draw_item_viewer(
         }
 
         // --- Drag and Drop Detection ---
-        // Check for external drag and drop
-
-        if ui.ctx().input(|i| !i.raw.dropped_files.is_empty()) {
-            let dropped_paths: Vec<PathBuf> = ui.ctx().input(|i| {
-                i.raw
-                    .dropped_files
-                    .iter()
-                    .filter_map(|f| f.path.clone())
-                    .collect()
-            });
-
-            if !dropped_paths.is_empty() {
-                action = Some(ItemViewerAction::FilesDropped(dropped_paths));
-            }
-        }
-
-        // Update drag hover state
-        *external_drag_to_internal_hover = ui
-            .ctx()
-            .input(|i| i.raw.hovered_files.iter().any(|f| f.path.is_some()));
+        *external_drag_to_internal_hover = native_drag_active || external_file_hover;
 
         // 👇 Fill remaining space so empty area is interactable
         let remaining_rect = ui.available_rect_before_wrap();

--- a/src/gui/windows/containers/structs.rs
+++ b/src/gui/windows/containers/structs.rs
@@ -35,6 +35,7 @@ pub struct TabsAction {
     pub open_new: bool,
     pub toggle_pin: Option<PathBuf>,
     pub move_files_to_tab_dir: Option<PathBuf>,
+    pub move_files_to_tab_dir_rect: Option<egui::Rect>,
 }
 
 pub struct TabState {
@@ -58,6 +59,7 @@ pub struct TabbarAction {
     pub refresh_current_directory: bool,
     pub is_breadcrumb_path_edit_active: bool,
     pub move_files_to_breadcrumb_dir: Option<PathBuf>,
+    pub move_files_to_breadcrumb_dir_rect: Option<egui::Rect>,
 }
 
 #[derive(Clone, Copy)]

--- a/src/gui/windows/containers/tabs.rs
+++ b/src/gui/windows/containers/tabs.rs
@@ -65,12 +65,15 @@ pub fn draw_tabs(
     palette: &ThemePalette,
     hwnd: Option<HWND>,
     scroll_to_id: Option<u64>,
-    drag_state: &DragState,
+    drag_state: &mut DragState,
+    drag_active: bool,
+    drag_hover_target: Option<PathBuf>,
 ) -> TabsAction {
     let mut action: TabsAction = TabsAction::default();
     let pointer_pos = ui.input(|i| i.pointer.interact_pos().or_else(|| i.pointer.hover_pos()));
     let pointer_released =
         ui.input(|i| i.pointer.any_released() && i.pointer.interact_pos().is_some());
+    let hovered_target_ref = drag_hover_target.as_ref();
     let mut tab_drop_target: Option<PathBuf> = None;
     let controls_width = 64.0;
     let full_width = ui.available_width();
@@ -104,25 +107,31 @@ pub fn draw_tabs(
                                         resp.scroll_to_me(Some(egui::Align::Center));
                                     }
 
-                                    if drag_state.active && tab.id != active_id {
-                                        if let Some(pointer) = pointer_pos {
-                                            if rect.contains(pointer) {
-                                                let painter = ui
-                                                    .ctx()
-                                                    .layer_painter(egui::LayerId::new(
-                                                        egui::Order::Background,
-                                                        ui.id().with("tab_drop_bg").with(tab.id),
-                                                    ))
-                                                    .with_clip_rect(ui.clip_rect());
-                                                painter.rect_filled(
-                                                    rect,
-                                                    egui::CornerRadius::same(palette.medium_radius),
-                                                    palette.primary_hover,
-                                                );
+                                    if drag_active && tab.id != active_id {
+                                        let hovered = hovered_target_ref
+                                            .map(|target| target == &tab.full_path)
+                                            .unwrap_or_else(|| {
+                                                pointer_pos
+                                                    .map(|pointer| rect.contains(pointer))
+                                                    .unwrap_or(false)
+                                            });
+                                        if hovered {
+                                            let painter = ui
+                                                .ctx()
+                                                .layer_painter(egui::LayerId::new(
+                                                    egui::Order::Background,
+                                                    ui.id().with("tab_drop_bg").with(tab.id),
+                                                ))
+                                                .with_clip_rect(ui.clip_rect());
+                                            painter.rect_filled(
+                                                rect,
+                                                egui::CornerRadius::same(palette.medium_radius),
+                                                palette.primary_hover,
+                                            );
 
-                                                if pointer_released {
-                                                    tab_drop_target = Some(tab.full_path.clone());
-                                                }
+                                            if pointer_released {
+                                                tab_drop_target = Some(tab.full_path.clone());
+                                                action.move_files_to_tab_dir_rect = Some(rect);
                                             }
                                         }
                                     }
@@ -626,13 +635,16 @@ pub fn draw_tabbar(
     tab: &mut TabState,
     palette: &ThemePalette,
     is_favorited: bool,
-    drag_state: &DragState,
+    drag_state: &mut DragState,
+    drag_active: bool,
+    drag_hover_target: Option<PathBuf>,
 ) -> TabbarAction {
     let mut action = TabbarAction::default();
     let tabbar_rect = ui.available_rect_before_wrap();
     let pointer_pos = ui.input(|i| i.pointer.interact_pos().or_else(|| i.pointer.hover_pos()));
     let pointer_released =
         ui.input(|i| i.pointer.any_released() && i.pointer.interact_pos().is_some());
+    let hovered_target_ref = drag_hover_target.as_ref();
     let mut breadcrumb_drop_target: Option<PathBuf> = None;
     let pointer_in_tabbar = pointer_pos
         .map(|pos| tabbar_rect.contains(pos))
@@ -853,30 +865,44 @@ pub fn draw_tabbar(
 
                 let resp = inner.response.union(inner.inner);
 
-                if drag_state.active {
-                    if let Some(pointer) = pointer_pos {
-                        if resp.rect.contains(pointer) {
-                            let painter = ui
-                                .ctx()
-                                .layer_painter(egui::LayerId::new(
-                                    egui::Order::Background,
-                                    ui.id().with("breadcrumb_drop_bg").with(path),
-                                ))
-                                .with_clip_rect(ui.clip_rect());
-                            painter.rect_filled(
-                                resp.rect,
-                                egui::CornerRadius::same(palette.medium_radius),
-                                palette.primary_hover,
-                            );
+                if drag_active {
+                    let breadcrumb_target_path = if label == "..." {
+                        segments.first().map(|(_, root_path)| root_path)
+                    } else {
+                        Some(path)
+                    };
+                    let hovered = breadcrumb_target_path
+                        .and_then(|target_path| {
+                            hovered_target_ref.map(|target| target == target_path)
+                        })
+                        .unwrap_or_else(|| {
+                            pointer_pos
+                                .map(|pointer| resp.rect.contains(pointer))
+                                .unwrap_or(false)
+                        });
+                    if hovered {
+                        let painter = ui
+                            .ctx()
+                            .layer_painter(egui::LayerId::new(
+                                egui::Order::Background,
+                                ui.id().with("breadcrumb_drop_bg").with(path),
+                            ))
+                            .with_clip_rect(ui.clip_rect());
+                        painter.rect_filled(
+                            resp.rect,
+                            egui::CornerRadius::same(palette.medium_radius),
+                            palette.primary_hover,
+                        );
 
-                            if pointer_released {
-                                if label == "..." {
-                                    if let Some((_, root_path)) = segments.first() {
-                                        breadcrumb_drop_target = Some(root_path.clone());
-                                    }
-                                } else {
-                                    breadcrumb_drop_target = Some(path.clone());
+                        if pointer_released {
+                            if label == "..." {
+                                if let Some((_, root_path)) = segments.first() {
+                                    breadcrumb_drop_target = Some(root_path.clone());
+                                    action.move_files_to_breadcrumb_dir_rect = Some(resp.rect);
                                 }
+                            } else {
+                                breadcrumb_drop_target = Some(path.clone());
+                                action.move_files_to_breadcrumb_dir_rect = Some(resp.rect);
                             }
                         }
                     }
@@ -886,7 +912,7 @@ pub fn draw_tabbar(
                     ui.ctx().set_cursor_icon(egui::CursorIcon::PointingHand);
                 }
 
-                if !drag_state.active && resp.clicked() {
+                if !drag_active && resp.clicked() {
                     // If "..." clicked, navigate to root
                     if label == "..." {
                         if let Some((_, root_path)) = segments.first() {

--- a/src/gui/windows/dragdrop.rs
+++ b/src/gui/windows/dragdrop.rs
@@ -1,0 +1,421 @@
+use crate::gui::dragdrop::{DragDropBackend, DropTargets, NativeDropCommand};
+use crate::gui::windows::mainwindow_imp::create_data_object;
+use crate::gui::windows::windowsoverrides::request_repaint;
+use eframe::egui;
+use std::collections::VecDeque;
+use std::path::PathBuf;
+use std::ptr::null_mut;
+use std::sync::{Arc, Mutex, RwLock};
+use windows::Win32::Foundation::{
+    DRAGDROP_S_CANCEL, DRAGDROP_S_DROP, DRAGDROP_S_USEDEFAULTCURSORS, HWND, POINT,
+};
+use windows::Win32::Graphics::Gdi::ScreenToClient;
+use windows::Win32::System::Com::{
+    DVASPECT_CONTENT, FORMATETC, IDataObject, STGMEDIUM, TYMED_HGLOBAL,
+};
+use windows::Win32::System::Ole::{
+    CF_HDROP, DoDragDrop, IDropSource, IDropSource_Impl, IDropTarget, IDropTarget_Impl,
+    ReleaseStgMedium,
+};
+use windows::Win32::System::Ole::{DROPEFFECT, DROPEFFECT_COPY, DROPEFFECT_MOVE};
+use windows::Win32::System::Ole::{RegisterDragDrop, RevokeDragDrop};
+use windows::Win32::System::SystemServices::{MK_LBUTTON, MODIFIERKEYS_FLAGS};
+use windows::Win32::UI::Shell::DragQueryFileW;
+use windows::Win32::UI::Shell::HDROP;
+use windows::core::{BOOL, Error, HRESULT, Result, implement};
+
+lazy_static::lazy_static! {
+    static ref ACTIVE_SHARED: RwLock<Option<Arc<DropShared>>> = RwLock::new(None);
+    static ref ACTIVE_HWND: RwLock<Option<isize>> = RwLock::new(None);
+}
+
+struct DropShared {
+    targets: RwLock<DropTargets>,
+    commands: Mutex<VecDeque<NativeDropCommand>>,
+    drag_active: RwLock<bool>,
+    inbound_drag_active: RwLock<bool>,
+    hovered_target: RwLock<Option<PathBuf>>,
+    scale_factor: RwLock<f32>,
+}
+
+impl DropShared {
+    fn new() -> Self {
+        Self {
+            targets: RwLock::new(DropTargets::default()),
+            commands: Mutex::new(VecDeque::new()),
+            drag_active: RwLock::new(false),
+            inbound_drag_active: RwLock::new(false),
+            hovered_target: RwLock::new(None),
+            scale_factor: RwLock::new(1.0),
+        }
+    }
+
+    fn push_command(&self, command: NativeDropCommand) {
+        if let Ok(mut queue) = self.commands.lock() {
+            queue.push_back(command);
+        }
+    }
+
+    fn pop_command(&self) -> Option<NativeDropCommand> {
+        self.commands.lock().ok()?.pop_front()
+    }
+
+    fn targets(&self) -> DropTargets {
+        self.targets.read().map(|t| t.clone()).unwrap_or_default()
+    }
+
+    fn set_targets(&self, targets: DropTargets) {
+        if let Ok(mut current) = self.targets.write() {
+            *current = targets;
+        }
+    }
+
+    fn set_drag_active(&self, active: bool) {
+        if let Ok(mut current) = self.drag_active.write() {
+            *current = active;
+        }
+    }
+
+    fn is_drag_active(&self) -> bool {
+        self.drag_active.read().map(|v| *v).unwrap_or(false)
+    }
+
+    fn set_inbound_drag_active(&self, active: bool) {
+        if let Ok(mut current) = self.inbound_drag_active.write() {
+            *current = active;
+        }
+    }
+
+    fn is_inbound_drag_active(&self) -> bool {
+        self.inbound_drag_active.read().map(|v| *v).unwrap_or(false)
+    }
+
+    fn set_hovered_target(&self, target: Option<PathBuf>) {
+        if let Ok(mut current) = self.hovered_target.write() {
+            *current = target;
+        }
+    }
+
+    fn hovered_target(&self) -> Option<PathBuf> {
+        self.hovered_target.read().ok().and_then(|v| v.clone())
+    }
+
+    fn set_scale_factor(&self, scale_factor: f32) {
+        if let Ok(mut current) = self.scale_factor.write() {
+            *current = scale_factor.max(0.1);
+        }
+    }
+
+    fn scale_factor(&self) -> f32 {
+        self.scale_factor.read().map(|v| *v).unwrap_or(1.0).max(0.1)
+    }
+}
+
+#[implement(IDropSource)]
+struct FileDropSource;
+
+impl IDropSource_Impl for FileDropSource_Impl {
+    fn QueryContinueDrag(&self, fescapepressed: BOOL, grfkeystate: MODIFIERKEYS_FLAGS) -> HRESULT {
+        if fescapepressed.as_bool() {
+            return DRAGDROP_S_CANCEL;
+        }
+
+        if !grfkeystate.contains(MK_LBUTTON) {
+            return DRAGDROP_S_DROP;
+        }
+
+        HRESULT(0)
+    }
+
+    fn GiveFeedback(&self, _dweffect: DROPEFFECT) -> HRESULT {
+        DRAGDROP_S_USEDEFAULTCURSORS
+    }
+}
+
+#[implement(IDropTarget)]
+struct WindowDropTarget;
+
+fn active_shared() -> Option<Arc<DropShared>> {
+    ACTIVE_SHARED.read().ok().and_then(|shared| shared.clone())
+}
+
+fn active_hwnd() -> Option<HWND> {
+    ACTIVE_HWND
+        .read()
+        .ok()
+        .and_then(|hwnd| hwnd.map(|raw| HWND(raw as *mut core::ffi::c_void)))
+}
+
+fn hit_test_target_at(pt: windows::Win32::Foundation::POINTL) -> Option<PathBuf> {
+    let shared = active_shared()?;
+    let hwnd = active_hwnd()?;
+    let scale = shared.scale_factor();
+    let mut client_pt = POINT { x: pt.x, y: pt.y };
+    unsafe {
+        if !ScreenToClient(hwnd, &mut client_pt).as_bool() {
+            return None;
+        }
+    }
+    let pos = egui::pos2(client_pt.x as f32 / scale, client_pt.y as f32 / scale);
+    let targets = shared.targets();
+
+    let ordered = [
+        &targets.breadcrumb_target,
+        &targets.tab_target,
+        &targets.item_target,
+    ];
+
+    for region in ordered {
+        if let (Some(target), Some(rect)) = (&region.target, region.rect) {
+            if rect.contains(pos) {
+                return Some(target.clone());
+            }
+        }
+    }
+
+    None
+}
+
+impl WindowDropTarget {
+    fn current_effect(target: Option<PathBuf>) -> DROPEFFECT {
+        if target.is_some() {
+            DROPEFFECT_MOVE
+        } else {
+            DROPEFFECT_COPY
+        }
+    }
+}
+
+impl IDropTarget_Impl for WindowDropTarget_Impl {
+    fn DragEnter(
+        &self,
+        _pdataobj: windows::core::Ref<'_, IDataObject>,
+        _grfkeystate: MODIFIERKEYS_FLAGS,
+        _pt: &windows::Win32::Foundation::POINTL,
+        pdweffect: *mut DROPEFFECT,
+    ) -> Result<()> {
+        let target = hit_test_target_at(*_pt);
+        if let Some(shared) = active_shared() {
+            shared.set_drag_active(true);
+            shared.set_inbound_drag_active(true);
+            shared.set_hovered_target(target.clone());
+        }
+        request_repaint();
+        unsafe {
+            *pdweffect = WindowDropTarget::current_effect(target);
+        }
+        Ok(())
+    }
+
+    fn DragOver(
+        &self,
+        _grfkeystate: MODIFIERKEYS_FLAGS,
+        _pt: &windows::Win32::Foundation::POINTL,
+        pdweffect: *mut DROPEFFECT,
+    ) -> Result<()> {
+        let target = hit_test_target_at(*_pt);
+        if let Some(shared) = active_shared() {
+            shared.set_hovered_target(target.clone());
+            shared.set_inbound_drag_active(true);
+        }
+        request_repaint();
+        unsafe {
+            *pdweffect = WindowDropTarget::current_effect(target);
+        }
+        Ok(())
+    }
+
+    fn DragLeave(&self) -> Result<()> {
+        if let Some(shared) = active_shared() {
+            shared.set_drag_active(false);
+            shared.set_inbound_drag_active(false);
+            shared.set_hovered_target(None);
+        }
+        request_repaint();
+        Ok(())
+    }
+
+    fn Drop(
+        &self,
+        pdataobj: windows::core::Ref<'_, IDataObject>,
+        _grfkeystate: MODIFIERKEYS_FLAGS,
+        _pt: &windows::Win32::Foundation::POINTL,
+        pdweffect: *mut DROPEFFECT,
+    ) -> Result<()> {
+        let target = hit_test_target_at(*_pt);
+        request_repaint();
+        let Some(shared) = active_shared() else {
+            return Ok(());
+        };
+        let sources = read_paths_from_data_object(pdataobj)?;
+
+        let command = if let Some(target_dir) = target.clone() {
+            NativeDropCommand::MoveFiles {
+                sources,
+                target_dir,
+            }
+        } else {
+            NativeDropCommand::ImportFiles(sources)
+        };
+
+        shared.push_command(command);
+        shared.set_drag_active(false);
+        shared.set_inbound_drag_active(false);
+        shared.set_hovered_target(None);
+
+        unsafe {
+            *pdweffect = WindowDropTarget::current_effect(target);
+        }
+        Ok(())
+    }
+}
+
+fn read_paths_from_data_object(
+    data_object: windows::core::Ref<'_, IDataObject>,
+) -> Result<Vec<PathBuf>> {
+    unsafe {
+        let data_object = data_object.unwrap();
+        let format = FORMATETC {
+            cfFormat: CF_HDROP.0,
+            ptd: null_mut(),
+            dwAspect: DVASPECT_CONTENT.0,
+            lindex: -1,
+            tymed: TYMED_HGLOBAL.0 as u32,
+        };
+
+        let mut medium: STGMEDIUM = data_object.GetData(&format)?;
+        if medium.tymed != TYMED_HGLOBAL.0 as u32 {
+            ReleaseStgMedium(&mut medium);
+            return Err(Error::from_win32());
+        }
+
+        let hdrop = HDROP(unsafe { medium.u.hGlobal.0 });
+        let count = DragQueryFileW(hdrop, 0xFFFFFFFF, None);
+        let mut paths = Vec::with_capacity(count as usize);
+
+        for i in 0..count {
+            let len = DragQueryFileW(hdrop, i, None);
+            if len == 0 {
+                continue;
+            }
+
+            let mut buf = vec![0u16; (len + 1) as usize];
+            let copied = DragQueryFileW(hdrop, i, Some(&mut buf));
+            if copied > 0 {
+                paths.push(PathBuf::from(String::from_utf16_lossy(
+                    &buf[..copied as usize],
+                )));
+            }
+        }
+
+        ReleaseStgMedium(&mut medium);
+        Ok(paths)
+    }
+}
+
+pub struct WindowsDragDropBackend {
+    hwnd: Option<HWND>,
+    shared: Arc<DropShared>,
+    drop_target: Option<IDropTarget>,
+}
+
+impl WindowsDragDropBackend {
+    pub fn new(hwnd: Option<HWND>) -> Self {
+        let shared = Arc::new(DropShared::new());
+        if let Ok(mut active) = ACTIVE_SHARED.write() {
+            *active = Some(shared.clone());
+        }
+        if let Ok(mut active) = ACTIVE_HWND.write() {
+            *active = hwnd.map(|h| h.0 as isize);
+        }
+
+        let drop_target = hwnd.and_then(|hwnd| {
+            let target: IDropTarget = WindowDropTarget.into();
+
+            unsafe {
+                if RegisterDragDrop(hwnd, &target).is_ok() {
+                    Some(target)
+                } else {
+                    None
+                }
+            }
+        });
+
+        Self {
+            hwnd,
+            shared,
+            drop_target,
+        }
+    }
+
+    pub fn uninstall(&mut self) {
+        if let Some(hwnd) = self.hwnd.take() {
+            let _ = unsafe { RevokeDragDrop(hwnd) };
+        }
+        self.drop_target = None;
+        if let Ok(mut active) = ACTIVE_SHARED.write() {
+            *active = None;
+        }
+        if let Ok(mut active) = ACTIVE_HWND.write() {
+            *active = None;
+        }
+    }
+}
+
+impl Drop for WindowsDragDropBackend {
+    fn drop(&mut self) {
+        self.uninstall();
+    }
+}
+
+impl DragDropBackend for WindowsDragDropBackend {
+    fn begin_file_drag(&self, paths: &[PathBuf]) -> bool {
+        if paths.is_empty() {
+            return false;
+        }
+
+        let Some(data_object) = create_data_object(paths) else {
+            return false;
+        };
+
+        let drop_source: IDropSource = FileDropSource.into();
+        let mut effect = DROPEFFECT(0);
+        self.shared.set_drag_active(true);
+        let result = unsafe {
+            DoDragDrop(
+                &data_object,
+                &drop_source,
+                DROPEFFECT_COPY | DROPEFFECT_MOVE,
+                &mut effect,
+            )
+        };
+        self.shared.set_drag_active(false);
+        self.shared.set_hovered_target(None);
+
+        result.is_ok()
+    }
+
+    fn is_drag_active(&self) -> bool {
+        self.shared.is_drag_active()
+    }
+
+    fn is_inbound_drag_active(&self) -> bool {
+        self.shared.is_inbound_drag_active()
+    }
+
+    fn hovered_drop_target(&self) -> Option<PathBuf> {
+        self.shared.hovered_target()
+    }
+
+    fn set_scale_factor(&self, scale_factor: f32) {
+        self.shared.set_scale_factor(scale_factor);
+    }
+
+    fn update_drop_targets(&self, targets: DropTargets) {
+        self.shared.set_targets(targets);
+    }
+
+    fn poll_command(&self) -> Option<NativeDropCommand> {
+        self.shared.pop_command()
+    }
+}

--- a/src/gui/windows/mainwindow.rs
+++ b/src/gui/windows/mainwindow.rs
@@ -4,6 +4,7 @@ use crate::core::fs::{parallel_directory_scan, scan_dir_async};
 use crate::core::indexer::{
     load_app_settings, load_favorites, load_theme_settings, save_app_settings,
 };
+use crate::gui::dragdrop::{DragDropBackend, DropTargets};
 use crate::gui::icons::IconCache;
 use crate::gui::theme::{ThemeMode, apply_theme, get_default_palette, get_palette, set_palette};
 use crate::gui::utils::SortColumn;
@@ -33,6 +34,9 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 use windows::Win32::Foundation::HWND;
+use windows::Win32::Foundation::{POINT, RECT};
+use windows::Win32::Graphics::Gdi::ClientToScreen;
+use windows::Win32::UI::WindowsAndMessaging::{GetClientRect, GetCursorPos};
 
 pub struct MainWindow {
     // MainWindow General Variables
@@ -59,6 +63,7 @@ pub struct MainWindow {
     pub(crate) rename_state: Option<RenameState>,
     pub(crate) sort_column: SortColumn,
     pub(crate) drag_state: DragState,
+    pub(crate) dragdrop: Option<Box<dyn DragDropBackend>>,
     pub(crate) sort_ascending: bool,
     pub(crate) file_type_cache: HashMap<String, String>,
     pub(crate) explorer_state: ExplorerState,
@@ -164,6 +169,7 @@ impl Default for MainWindow {
             theme_dirty: true,
             window_override_set: false,
             drag_state: DragState::default(),
+            dragdrop: None,
             sort_column: loaded_settings.sort_column,
             sort_ascending: loaded_settings.sort_ascending,
             icon_cache: None,
@@ -244,6 +250,9 @@ impl MainWindow {
             unsafe {
                 install_wndproc(hwnd);
             }
+            app.dragdrop = Some(Box::new(
+                crate::gui::windows::dragdrop::WindowsDragDropBackend::new(Some(hwnd)),
+            ));
         }
 
         app.hwnd = hwnd;
@@ -274,22 +283,18 @@ impl eframe::App for MainWindow {
 
         // Main layout: sidebar + tabs column
         let mut pending_action: Option<ItemViewerAction> = None;
-
-        // 🔥 Detect external drag-over (files hovering)
-        self.external_drag_to_internal_hover = ctx.input(|i| !i.raw.hovered_files.is_empty());
-
-        // 🔥 Detect dropped files from OS
-        let dropped_files: Vec<PathBuf> = ctx.input(|i| {
-            i.raw
-                .dropped_files
-                .iter()
-                .filter_map(|f| f.path.clone())
-                .collect()
-        });
-
-        if !dropped_files.is_empty() {
-            // Send into your existing system
-            pending_action = Some(ItemViewerAction::FilesDropped(dropped_files));
+        let mut drop_targets = DropTargets::default();
+        let dragdrop = self.dragdrop.as_deref();
+        let native_drag_active = dragdrop
+            .map(|backend| backend.is_drag_active())
+            .unwrap_or(false);
+        let native_inbound_drag_active = dragdrop
+            .map(|backend| backend.is_inbound_drag_active())
+            .unwrap_or(false);
+        let drag_hover_target = dragdrop.and_then(|backend| backend.hovered_drop_target());
+        let drag_active = self.drag_state.active || native_drag_active;
+        if let Some(backend) = dragdrop {
+            backend.set_scale_factor(ctx.pixels_per_point());
         }
 
         if self.theme_dirty {
@@ -489,11 +494,16 @@ impl eframe::App for MainWindow {
                                 &mut self.drive_size_text_cache,
                                 &mut self.external_drag_to_internal_hover,
                                 &mut self.drag_state,
+                                drag_active,
+                                native_inbound_drag_active,
+                                drag_hover_target.clone(),
+                                dragdrop,
                                 &mut self.item_viewer_filter_state,
                                 self.is_loading,
                                 &mut self.explorer_state,
                                 &mut self.theme_customizer,
                                 &mut self.settings_window,
+                                &mut drop_targets,
                             );
 
                         tabs_action = Some(next_tabs_action);
@@ -504,13 +514,116 @@ impl eframe::App for MainWindow {
             });
         });
 
+        if let Some(backend) = self.dragdrop.as_ref() {
+            backend.update_drop_targets(drop_targets);
+        }
+
+        if pending_action.is_none() {
+            let dropped_paths: Vec<PathBuf> = ctx.input(|i| {
+                i.raw
+                    .dropped_files
+                    .iter()
+                    .filter_map(|file| file.path.clone())
+                    .collect()
+            });
+            if !dropped_paths.is_empty() {
+                pending_action = Some(ItemViewerAction::FilesDropped(dropped_paths));
+            }
+        }
+
+        if pending_action.is_none() && self.drag_state.active && !native_drag_active {
+            let pointer_inside = if let Some(hwnd) = self.hwnd {
+                unsafe {
+                    let mut screen_pt = POINT::default();
+                    if GetCursorPos(&mut screen_pt).is_err() {
+                        false
+                    } else {
+                        let mut client_rect = RECT::default();
+                        if GetClientRect(hwnd, &mut client_rect).is_err() {
+                            false
+                        } else {
+                            let mut top_left = POINT {
+                                x: client_rect.left,
+                                y: client_rect.top,
+                            };
+                            let mut bottom_right = POINT {
+                                x: client_rect.right,
+                                y: client_rect.bottom,
+                            };
+                            let _ = ClientToScreen(hwnd, &mut top_left);
+                            let _ = ClientToScreen(hwnd, &mut bottom_right);
+                            screen_pt.x >= top_left.x
+                                && screen_pt.x < bottom_right.x
+                                && screen_pt.y >= top_left.y
+                                && screen_pt.y < bottom_right.y
+                        }
+                    }
+                }
+            } else {
+                true
+            };
+
+            if !pointer_inside {
+                if let Some(backend) = self.dragdrop.as_ref() {
+                    if backend.begin_file_drag(&self.drag_state.source_items) {
+                        self.drag_state.active = false;
+                        self.drag_state.start_pos = None;
+                        self.drag_state.source_items.clear();
+                        self.load_path();
+                    }
+                }
+            }
+        }
+
+        let drag_sources = if self.drag_state.source_items.is_empty() {
+            None
+        } else {
+            Some(self.drag_state.source_items.clone())
+        };
+        let tabs_move_target = tabs_action
+            .as_ref()
+            .and_then(|a| a.move_files_to_tab_dir.as_ref())
+            .is_some();
+        let tabbar_move_target = tabbar_action
+            .as_ref()
+            .and_then(|a| a.move_files_to_breadcrumb_dir.as_ref())
+            .is_some();
+
         self.handle_directory_batch_recieve(ctx);
         self.handle_directory_size_updates(ctx);
         self.handle_throttle_size_requests(ctx);
         self.handle_topbar_action(topbar_action);
         self.handle_sidebar_action(sidebar_action);
-        self.handle_tabs_action(tabs_action);
-        self.handle_tabbar_action(tabbar_action);
+        self.handle_tabs_action(tabs_action, drag_sources.as_deref());
+        self.handle_tabbar_action(tabbar_action, drag_sources.as_deref());
+
+        if tabs_move_target || tabbar_move_target {
+            self.drag_state.active = false;
+            self.drag_state.start_pos = None;
+            self.drag_state.source_items.clear();
+        }
+
+        if pending_action.is_none() {
+            if let Some(command) = self
+                .dragdrop
+                .as_ref()
+                .and_then(|backend| backend.poll_command())
+            {
+                pending_action = Some(match command {
+                    crate::gui::dragdrop::NativeDropCommand::ImportFiles(paths) => {
+                        ItemViewerAction::FilesDropped(paths)
+                    }
+                    crate::gui::dragdrop::NativeDropCommand::MoveFiles {
+                        sources,
+                        target_dir,
+                    } => ItemViewerAction::MoveItems {
+                        sources,
+                        target_dir,
+                    },
+                });
+            }
+        }
+
         handle_pending_actions(pending_action, self);
         handle_draw_customizetheme_window(
             ctx,

--- a/src/gui/windows/mainwindow_imp.rs
+++ b/src/gui/windows/mainwindow_imp.rs
@@ -602,7 +602,11 @@ impl MainWindow {
         draw_about_window(ctx, &mut self.about_window, palette);
     }
 
-    pub fn handle_tabbar_action(&mut self, tabbar_action: Option<TabbarAction>) {
+    pub fn handle_tabbar_action(
+        &mut self,
+        tabbar_action: Option<TabbarAction>,
+        drag_sources: Option<&[PathBuf]>,
+    ) {
         if let Some(action) = tabbar_action.as_ref().and_then(|t| t.nav.as_ref()) {
             match action {
                 TabbarNavAction::Back => self.current_nav_mut().go_back(),
@@ -623,6 +627,14 @@ impl MainWindow {
                 .unwrap_or(false)
             {
                 self.load_path();
+            }
+            if let Some(target_dir) = tabbar_action
+                .as_ref()
+                .and_then(|t| t.move_files_to_breadcrumb_dir.as_ref())
+            {
+                if let Some(sources) = drag_sources {
+                    self.move_selected_paths_to_dir(sources, target_dir.clone());
+                }
             }
             if tabbar_action
                 .as_ref()
@@ -656,7 +668,11 @@ impl MainWindow {
         }
     }
 
-    pub fn handle_tabs_action(&mut self, tabs_action: Option<TabsAction>) {
+    pub fn handle_tabs_action(
+        &mut self,
+        tabs_action: Option<TabsAction>,
+        drag_sources: Option<&[PathBuf]>,
+    ) {
         if let Some(action) = tabs_action {
             if let Some(id) = action.activate {
                 self.active_tab = self.tabs.iter().position(|t| t.id == id).unwrap();
@@ -749,7 +765,52 @@ impl MainWindow {
 
                 self.mark_tab_infos_dirty();
             }
+            if let Some(target_dir) = action.move_files_to_tab_dir.as_ref() {
+                if let Some(sources) = drag_sources {
+                    self.move_selected_paths_to_dir(sources, target_dir.clone());
+                }
+            }
         }
+    }
+
+    fn move_selected_paths_to_dir(&mut self, sources: &[PathBuf], target_dir: PathBuf) {
+        if sources.is_empty() {
+            return;
+        }
+
+        unsafe {
+            let file_op: IFileOperation =
+                CoCreateInstance(&FileOperation, None, CLSCTX_ALL).unwrap();
+
+            file_op
+                .SetOperationFlags(FOF_SIMPLEPROGRESS | FOF_ALLOWUNDO | FOFX_SHOWELEVATIONPROMPT)
+                .ok();
+
+            let target_item: IShellItem = SHCreateItemFromParsingName(
+                &HSTRING::from(target_dir.to_string_lossy().to_string()),
+                None,
+            )
+            .unwrap();
+
+            for source in sources {
+                let source_item: IShellItem = SHCreateItemFromParsingName(
+                    &HSTRING::from(source.to_string_lossy().to_string()),
+                    None,
+                )
+                .unwrap();
+
+                file_op
+                    .MoveItem(&source_item, &target_item, None, None)
+                    .ok();
+            }
+
+            file_op.PerformOperations().ok();
+        }
+
+        self.explorer_state.selected_paths.clear();
+        self.explorer_state.selection_anchor = None;
+        self.explorer_state.selection_focus = None;
+        self.load_path();
     }
 
     pub fn handle_sidebar_action(&mut self, sidebar_action: Option<SidebarAction>) {

--- a/src/gui/windows/mod.rs
+++ b/src/gui/windows/mod.rs
@@ -2,6 +2,7 @@ pub mod containers; // small reusable components
 
 pub mod about;
 pub mod customizetheme;
+pub mod dragdrop;
 pub mod enums;
 pub mod mainwindow;
 pub mod mainwindow_imp;

--- a/src/gui/windows/windowsoverrides.rs
+++ b/src/gui/windows/windowsoverrides.rs
@@ -45,6 +45,14 @@ pub fn set_egui_ctx(ctx: &Context) {
     *EGUI_CTX.write().unwrap() = Some(ctx.clone());
 }
 
+pub fn request_repaint() {
+    if let Ok(ctx) = EGUI_CTX.read() {
+        if let Some(ctx) = ctx.as_ref() {
+            ctx.request_repaint();
+        }
+    }
+}
+
 pub fn consume_clipboard_dirty() -> bool {
     CLIPBOARD_DIRTY.swap(false, Ordering::AcqRel)
 }


### PR DESCRIPTION
## 🆕 What's New

- Ability to drag objects from EdenExplorer into the Operating System, such as the Desktop/Apps
- Introduced OLE for drag and drop for two-way interactions, ie. from OS to EdenExplorer and EdenExplorer to OS