### PR TITLE
feat: add directory navigation memory and handle invalid file names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "EdenExplorer"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "bincode",
  "chrono",

--- a/README.md
+++ b/README.md
@@ -298,6 +298,7 @@
 - [x] New context menu command (Copy Path) with keyboard shortcut of Ctrl+Shift+C
 - [x] Column sorting saves across sessions
 - [x] Drag and drop files from EdenExplorer into native Operating System (Windows) objects (Desktop, File Explorer, applications, etc.)
+- [x] Full navigation history is saved and restored with Back/Forward/Up buttons
 
 ### 🚀 Upcoming Features
 - [ ] Image previews using Spacebar - GPU texture via wgpu / egui_wgpu_backend
@@ -307,8 +308,6 @@
 ## 🐛 Known Bugs
 - Hitting "Shift" after already shift-selecting files drops the entire file selection
 - Dragging EdenExplorer across multiple monitors causes strange visual glitches
-- Typing an invalid character into a folder/file during rename/creation causes a strange reaction from Windows service layer
-- If you navigate into a folder and then press "backspace" or navigate back, you lose the folder selection
 
 ## Star History
 

--- a/src/gui/windows/containers/itemviewer.rs
+++ b/src/gui/windows/containers/itemviewer.rs
@@ -24,6 +24,44 @@ use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use windows::Win32::Foundation::HWND;
 
+/// Checks if a filename contains valid characters for real-time validation
+/// Used during typing to immediately filter invalid characters
+fn filename_has_valid_characters_realtime(name: &str) -> bool {
+    if name.is_empty() {
+        return false;
+    }
+
+    // Check maximum length
+    if name.len() > 255 {
+        return false;
+    }
+
+    // Windows reserved characters that cannot be used in filenames
+    let invalid_chars = ['<', '>', ':', '"', '/', '\\', '|', '?', '*'];
+
+    // Check for invalid characters
+    for ch in name.chars() {
+        if invalid_chars.contains(&ch) {
+            return false;
+        }
+    }
+
+    // Windows reserved names (case-insensitive)
+    let reserved_names = [
+        "CON", "PRN", "AUX", "NUL", "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8",
+        "COM9", "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9",
+    ];
+
+    let name_upper = name.to_uppercase();
+    for reserved in &reserved_names {
+        if name_upper == *reserved {
+            return false;
+        }
+    }
+
+    true
+}
+
 pub fn draw_item_viewer(
     ui: &mut egui::Ui,
     files: &Vec<FileItem>,
@@ -1282,6 +1320,10 @@ fn handle_editing_file_name(
         visuals.override_text_color = Some(get_row_color(is_selected, palette));
 
         let edit_id = ui.id().with("rename_input").with(&file.path);
+
+        // Store original length to detect changes
+        let original_len = rename_state.new_name.len();
+
         let edit_response = ui.add(
             egui::TextEdit::singleline(&mut rename_state.new_name)
                 .id(edit_id)
@@ -1298,6 +1340,75 @@ fn handle_editing_file_name(
             }
         }
 
+        // Real-time character validation
+        if rename_state.new_name.len() != original_len {
+            // Use the real-time validation function for each character typed
+            if !filename_has_valid_characters_realtime(&rename_state.new_name) {
+                // Remove invalid characters by keeping only valid ones
+                let invalid_chars = ['<', '>', ':', '"', '/', '\\', '|', '?', '*'];
+                let mut cleaned_name = String::new();
+
+                for ch in rename_state.new_name.chars() {
+                    if !invalid_chars.contains(&ch) {
+                        cleaned_name.push(ch);
+                    }
+                }
+
+                // Check for reserved names
+                let reserved_names = [
+                    "CON", "PRN", "AUX", "NUL", "COM1", "COM2", "COM3", "COM4", "COM5", "COM6",
+                    "COM7", "COM8", "COM9", "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7",
+                    "LPT8", "LPT9",
+                ];
+
+                let name_upper = cleaned_name.to_uppercase();
+                for reserved in &reserved_names {
+                    if name_upper == *reserved {
+                        cleaned_name.clear(); // Clear the invalid reserved name
+                    }
+                }
+
+                rename_state.new_name = cleaned_name;
+                rename_state.validation_error_show = true; // Show error popup
+            } else {
+                // If valid, clear any existing error
+                if rename_state.validation_error_show {
+                    rename_state.validation_error_show = false;
+                }
+            }
+        }
+
+        // Show validation tooltip if error flag is set
+        if rename_state.validation_error_show {
+            let tooltip_text = "Invalid filename characters detected!\n\
+                Characters not allowed: < > : \" / \\ | ? *\n\
+                Reserved names: CON, PRN, AUX, NUL, COM1-9, LPT1-9\n\
+                Maximum length: 255 characters";
+
+            // Calculate position above the input field
+            let popup_pos = egui::pos2(edit_response.rect.left(), edit_response.rect.top() - 60.0);
+
+            // Show error message positioned above the input field
+            egui::Area::new(ui.id().with("error_popup"))
+                .pivot(egui::Align2::LEFT_BOTTOM)
+                .current_pos(popup_pos)
+                .show(ui.ctx(), |ui| {
+                    ui.set_min_width(350.0);
+                    egui::Frame::popup(ui.style())
+                        .fill(egui::Color32::from_rgb(40, 40, 40))
+                        .stroke(egui::Stroke::new(1.0, egui::Color32::RED))
+                        .show(ui, |ui| {
+                            ui.add_space(8.0);
+                            ui.vertical_centered(|ui| {
+                                ui.colored_label(egui::Color32::RED, tooltip_text);
+                            });
+                            ui.add_space(8.0);
+                        });
+                });
+
+            // TODO: Add Windows alert sound when API compatibility is resolved
+        }
+
         // ✅ Input handling (same pattern as tabs)
         let enter = ui.input(|i| i.key_pressed(egui::Key::Enter));
         let escape = ui.input(|i| i.key_pressed(egui::Key::Escape));
@@ -1305,14 +1416,23 @@ fn handle_editing_file_name(
         if enter {
             let new_name = rename_state.new_name.trim().to_string();
 
+            // Clear validation error on successful action
+            rename_state.validation_error_show = false;
+
             action = Some(ItemViewerAction::Context(
                 ItemViewerContextAction::RenameRequest(file.path.clone(), new_name),
             ));
         } else if escape {
+            // Clear validation error on cancel
+            rename_state.validation_error_show = false;
+
             action = Some(ItemViewerAction::Context(
                 ItemViewerContextAction::RenameCancel,
             ));
         } else if edit_response.lost_focus() {
+            // Clear validation error on focus loss
+            rename_state.validation_error_show = false;
+
             // 👈 matches Windows: clicking away cancels rename
             action = Some(ItemViewerAction::Context(
                 ItemViewerContextAction::RenameCancel,

--- a/src/gui/windows/containers/itemviewer.rs
+++ b/src/gui/windows/containers/itemviewer.rs
@@ -217,7 +217,7 @@ pub fn draw_item_viewer(
             if let Some(idx) = filter_state
                 .cached_indices
                 .iter()
-                .position(|&i| files[i].path == *new_path)
+                .position(|&i| &files[i].path == new_path)
             {
                 table = table.scroll_to_row(idx, Some(egui::Align::Center));
 
@@ -228,6 +228,25 @@ pub fn draw_item_viewer(
                 explorer_state.selection_focus = Some(idx);
 
                 explorer_state.newly_created_path = None;
+            }
+        }
+
+        // If we have a navigation selection, scroll to it and select it
+        if let Some(nav_path) = &explorer_state.navigation_selection {
+            if let Some(idx) = filter_state
+                .cached_indices
+                .iter()
+                .position(|&i| &files[i].path == nav_path)
+            {
+                table = table.scroll_to_row(idx, Some(egui::Align::Center));
+
+                // Auto-select the navigation item
+                explorer_state.selected_paths.clear();
+                explorer_state.selected_paths.insert(nav_path.clone());
+                explorer_state.selection_anchor = Some(idx);
+                explorer_state.selection_focus = Some(idx);
+
+                explorer_state.navigation_selection = None;
             }
         }
 

--- a/src/gui/windows/containers/structs.rs
+++ b/src/gui/windows/containers/structs.rs
@@ -72,6 +72,7 @@ pub struct RenameState {
     pub path: PathBuf,
     pub new_name: String,
     pub should_focus: bool,
+    pub validation_error_show: bool,
 }
 
 #[derive(Clone)]

--- a/src/gui/windows/containers/structs.rs
+++ b/src/gui/windows/containers/structs.rs
@@ -1,6 +1,7 @@
 use crate::gui::windows::containers::enums::TabbarNavAction;
 use crate::gui::windows::shell_context_menu::ShellContextMenu;
 use crate::gui::windows::structs::Navigation;
+use std::collections::HashMap;
 use std::collections::HashSet;
 use std::path::PathBuf;
 
@@ -13,6 +14,8 @@ pub struct ExplorerState {
     pub non_ntfs_popup_path: Option<PathBuf>,
     pub windows_context_menu_expanded: bool,
     pub windows_context_menu_cache: Option<WindowsContextMenuCache>,
+    pub navigation_history: HashMap<PathBuf, PathBuf>, // parent_dir -> last_visited_child
+    pub navigation_selection: Option<PathBuf>,         // path to select after navigation loads
 }
 
 pub struct WindowsContextMenuCache {

--- a/src/gui/windows/mainwindow_imp.rs
+++ b/src/gui/windows/mainwindow_imp.rs
@@ -706,14 +706,52 @@ impl MainWindow {
     ) {
         if let Some(action) = tabbar_action.as_ref().and_then(|t| t.nav.as_ref()) {
             match action {
-                TabbarNavAction::Back => self.current_nav_mut().go_back(),
+                TabbarNavAction::Back => {
+                    // Store current path in navigation history before going back
+                    if let Some(parent) = self.current_nav().get_parent() {
+                        self.explorer_state
+                            .navigation_history
+                            .insert(parent, self.current_nav().current.clone());
+                    }
+                    self.current_nav_mut().go_back();
+                }
                 TabbarNavAction::Forward => self.current_nav_mut().go_forward(),
-                TabbarNavAction::Up => self.current_nav_mut().go_up(),
+                TabbarNavAction::Up => {
+                    // Store current path in navigation history before going up
+                    if let Some(parent) = self.current_nav().get_parent() {
+                        self.explorer_state
+                            .navigation_history
+                            .insert(parent, self.current_nav().current.clone());
+                    }
+                    self.current_nav_mut().go_up();
+                }
             }
             self.mark_tab_infos_dirty();
             self.load_path();
+
+            // Restore selection for Back and Up actions
+            if matches!(action, TabbarNavAction::Back | TabbarNavAction::Up) {
+                let current_path = self.current_nav().current.clone();
+                if let Some(last_visited) =
+                    self.explorer_state.navigation_history.get(&current_path)
+                {
+                    self.explorer_state.navigation_selection = Some(last_visited.clone());
+                } else {
+                    self.explorer_state.navigation_selection = None;
+                }
+                self.explorer_state.selection_anchor = None;
+                self.explorer_state.selected_paths.clear();
+                self.explorer_state.selection_focus = None;
+            }
         } else {
             if let Some(path) = tabbar_action.as_ref().and_then(|t| t.nav_to.as_ref()) {
+                // Store current path in navigation history before navigating
+                if let Some(parent) = self.current_nav().get_parent() {
+                    self.explorer_state
+                        .navigation_history
+                        .insert(parent, self.current_nav().current.clone());
+                }
+
                 self.current_nav_mut().go_to(path.clone());
                 self.mark_tab_infos_dirty();
                 self.load_path();
@@ -933,6 +971,13 @@ impl MainWindow {
                 self.persist_favorites();
             }
             if let Some(path) = action.nav_to {
+                // Store current path in navigation history before navigating
+                if let Some(parent) = self.current_nav().get_parent() {
+                    self.explorer_state
+                        .navigation_history
+                        .insert(parent, self.current_nav().current.clone());
+                }
+
                 self.current_nav_mut().go_to(path);
                 self.mark_tab_infos_dirty();
                 self.load_path();
@@ -1292,6 +1337,15 @@ pub fn handle_pending_actions(pending_action: Option<ItemViewerAction>, explorer
                 explorer.explorer_state.selected_paths.insert(path.clone());
                 explorer.item_viewer_filter_state.dirty = true;
                 explorer.item_viewer_filter_state.cached_indices.clear();
+
+                // Store current path in navigation history before navigating
+                if let Some(parent) = explorer.current_nav().get_parent() {
+                    explorer
+                        .explorer_state
+                        .navigation_history
+                        .insert(parent, explorer.current_nav().current.clone());
+                }
+
                 explorer.current_nav_mut().go_to(path);
                 explorer.mark_tab_infos_dirty();
                 explorer.load_path();
@@ -1384,9 +1438,29 @@ pub fn handle_pending_actions(pending_action: Option<ItemViewerAction>, explorer
                 explorer.dropped_files_pending_ui_refresh = true;
             }
             ItemViewerAction::BackNavigation => {
+                // Store current path in navigation history before going back
+                if let Some(parent) = explorer.current_nav().get_parent() {
+                    explorer
+                        .explorer_state
+                        .navigation_history
+                        .insert(parent, explorer.current_nav().current.clone());
+                }
+
                 explorer.current_nav_mut().go_back();
                 explorer.mark_tab_infos_dirty();
                 explorer.load_path();
+
+                // Restore selection: select the folder we just came from
+                let current_path = explorer.current_nav().current.clone();
+                if let Some(last_visited) = explorer
+                    .explorer_state
+                    .navigation_history
+                    .get(&current_path)
+                {
+                    explorer.explorer_state.navigation_selection = Some(last_visited.clone());
+                } else {
+                    explorer.explorer_state.navigation_selection = None;
+                }
                 explorer.explorer_state.selection_anchor = None;
                 explorer.explorer_state.selected_paths.clear();
                 explorer.explorer_state.selection_focus = None;

--- a/src/gui/windows/mainwindow_imp.rs
+++ b/src/gui/windows/mainwindow_imp.rs
@@ -40,6 +40,64 @@ use windows::Win32::UI::WindowsAndMessaging::*;
 use windows::{Win32::System::Com::*, Win32::UI::Shell::*, core::*};
 
 impl MainWindow {
+    /// Comprehensive validation for submitted filenames
+    /// Used when user submits/commits the filename (Enter, create new file/folder)
+    fn is_submitted_filename_valid(name: &str) -> bool {
+        if name.is_empty() {
+            return false;
+        }
+
+        if name.len() > 255 {
+            return false;
+        }
+
+        // Cannot be "." or ".."
+        if name == "." || name == ".." {
+            return false;
+        }
+
+        // Cannot start or end with space
+        if name.starts_with(' ') || name.ends_with(' ') {
+            return false;
+        }
+
+        // Cannot end with dot
+        if name.ends_with('.') {
+            return false;
+        }
+
+        // Invalid characters
+        let invalid_chars = ['<', '>', ':', '"', '/', '\\', '|', '?', '*'];
+        if name.chars().any(|c| invalid_chars.contains(&c)) {
+            return false;
+        }
+
+        // Control characters (0x00–0x1F)
+        if name.chars().any(|c| c < '\u{20}') {
+            return false;
+        }
+
+        // Reserved names (check base name before extension)
+        let reserved_names = [
+            "CON", "PRN", "AUX", "NUL", "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7",
+            "COM8", "COM9", "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9",
+        ];
+
+        let base = name.split('.').next().unwrap_or("");
+        let base_upper = base.to_uppercase();
+
+        if reserved_names.contains(&base_upper.as_str()) {
+            return false;
+        }
+
+        // Optional: max length
+        if name.len() > 255 {
+            return false;
+        }
+
+        true
+    }
+
     pub fn current_nav(&self) -> &Navigation {
         &self.tabs[self.active_tab].nav
     }
@@ -209,27 +267,41 @@ impl MainWindow {
         let mut name = "New Folder".to_string();
         let mut counter = 1;
         let mut path = base.join(&name);
+
+        // Find a valid, non-existent name
         while path.exists() {
             counter += 1;
             name = format!("New Folder ({})", counter);
             path = base.join(&name);
         }
 
-        if std::fs::create_dir(&path).is_ok() {
-            let path_for_selection = path.clone();
-            self.load_path();
-            // Immediately start renaming the new folder
+        // Validate the final name before creating
+        if Self::is_submitted_filename_valid(&name) {
+            if std::fs::create_dir(&path).is_ok() {
+                let path_for_selection = path.clone();
+                self.load_path();
+                // Immediately start renaming the new folder
+                self.rename_state = Some(RenameState {
+                    path: path.clone(),
+                    new_name: name,
+                    should_focus: true,
+                    validation_error_show: false,
+                });
+                // Select the new folder
+                self.explorer_state.selected_paths.clear();
+                self.explorer_state
+                    .selected_paths
+                    .insert(path_for_selection.clone());
+                self.explorer_state.newly_created_path = Some(path_for_selection.clone());
+            }
+        } else {
+            // Don't create the folder, just start rename with invalid name so user can fix it
             self.rename_state = Some(RenameState {
-                path: path.clone(),
+                path: base.clone(), // Use parent directory as the path since we're not creating yet
                 new_name: name,
                 should_focus: true,
+                validation_error_show: true, // Show error immediately
             });
-            // Select the new folder
-            self.explorer_state.selected_paths.clear();
-            self.explorer_state
-                .selected_paths
-                .insert(path_for_selection.clone());
-            self.explorer_state.newly_created_path = Some(path_for_selection.clone());
         }
     }
 
@@ -242,28 +314,42 @@ impl MainWindow {
         let mut name = "New File.txt".to_string();
         let mut counter = 1;
         let mut path = base.join(&name);
+
+        // Find a valid, non-existent name
         while path.exists() {
             counter += 1;
             name = format!("New File ({}).txt", counter);
             path = base.join(&name);
         }
 
-        // Create an empty file
-        if std::fs::write(&path, "").is_ok() {
-            let path_for_selection = path.clone();
-            self.load_path();
-            // Immediately start renaming the new file
+        // Validate the final name before creating
+        if Self::is_submitted_filename_valid(&name) {
+            // Create an empty file
+            if std::fs::write(&path, "").is_ok() {
+                let path_for_selection = path.clone();
+                self.load_path();
+                // Immediately start renaming the new file
+                self.rename_state = Some(RenameState {
+                    path: path.clone(),
+                    new_name: name,
+                    should_focus: true,
+                    validation_error_show: false,
+                });
+                // Select the new file
+                self.explorer_state.selected_paths.clear();
+                self.explorer_state
+                    .selected_paths
+                    .insert(path_for_selection.clone());
+                self.explorer_state.newly_created_path = Some(path_for_selection.clone());
+            }
+        } else {
+            // Don't create the file, just start rename with invalid name so user can fix it
             self.rename_state = Some(RenameState {
-                path: path.clone(),
+                path: base.clone(), // Use parent directory as the path since we're not creating yet
                 new_name: name,
                 should_focus: true,
+                validation_error_show: true, // Show error immediately
             });
-            // Select the new file
-            self.explorer_state.selected_paths.clear();
-            self.explorer_state
-                .selected_paths
-                .insert(path_for_selection.clone());
-            self.explorer_state.newly_created_path = Some(path_for_selection.clone());
         }
     }
 
@@ -351,6 +437,17 @@ impl MainWindow {
 
                 if trimmed.is_empty() {
                     self.rename_state = None;
+                    return;
+                }
+
+                // Validate the new name for Windows filename rules
+                if !Self::is_submitted_filename_valid(trimmed) {
+                    // Don't cancel the rename, keep user in input state with error shown
+                    if let Some(rename_state) = &mut self.rename_state {
+                        rename_state.new_name = trimmed.to_string();
+                        rename_state.should_focus = true;
+                        rename_state.validation_error_show = true;
+                    }
                     return;
                 }
 
@@ -1239,6 +1336,7 @@ pub fn handle_pending_actions(pending_action: Option<ItemViewerAction>, explorer
                     path,
                     new_name: name,
                     should_focus: true,
+                    validation_error_show: false,
                 });
             }
             ItemViewerAction::ReplaceSelection(path) => {

--- a/src/gui/windows/navigation.rs
+++ b/src/gui/windows/navigation.rs
@@ -25,6 +25,24 @@ impl Navigation {
         }
     }
 
+    /// Get the parent directory of the current path
+    pub fn get_parent(&self) -> Option<PathBuf> {
+        if self.current.to_string_lossy() == MY_PC_PATH {
+            return None;
+        }
+
+        if let Some(parent) = self.current.parent() {
+            if parent.as_os_str().is_empty() {
+                Some(PathBuf::from(MY_PC_PATH))
+            } else {
+                Some(parent.to_path_buf())
+            }
+        } else {
+            // Drive root (e.g., "C:\\") has no parent in PathBuf.
+            Some(PathBuf::from(MY_PC_PATH))
+        }
+    }
+
     pub fn go_back(&mut self) {
         if let Some(prev) = self.back.pop() {
             self.forward.push(self.current.clone());


### PR DESCRIPTION
## 🆕 What's New

- As you navigate down directories, EdenExplorer will save where you've been so that when we you go up/back directories, the current selected item is the directory where you just came from. This makes arrow key navigation aligned with typical Windows behavior which makes it much more powerful 

## 🐛 What's Fixed

- File names were not being 100% validated during input and submission. Now, EdenExplorer checks as you type for invalid characters or filename limits and presents an error. The same applies for when you try to submit the filename change