### PR TITLE
Fix incorrect ordering when sorting by Modified/Created date columns

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "EdenExplorer"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "bincode",
  "chrono",

--- a/src/core/fs.rs
+++ b/src/core/fs.rs
@@ -285,16 +285,24 @@ pub fn scan_dir_async(
                         Some(*entry.EndOfFile.QuadPart() as u64)
                     };
 
-                    let modified_time = filetime_to_string(
-                        *entry.LastWriteTime.QuadPart(),
-                        date_style,
-                        time_format_24h,
-                    );
-                    let created_time = filetime_to_string(
-                        *entry.CreationTime.QuadPart(),
-                        date_style,
-                        time_format_24h,
-                    );
+                    let modified_time_filetime = *entry.LastWriteTime.QuadPart();
+                    let created_time_filetime = *entry.CreationTime.QuadPart();
+
+                    let modified_time =
+                        filetime_to_string(modified_time_filetime, date_style, time_format_24h);
+                    let created_time =
+                        filetime_to_string(created_time_filetime, date_style, time_format_24h);
+
+                    let modified_time_raw = if modified_time_filetime == 0 {
+                        None
+                    } else {
+                        Some(modified_time_filetime)
+                    };
+                    let created_time_raw = if created_time_filetime == 0 {
+                        None
+                    } else {
+                        Some(created_time_filetime)
+                    };
 
                     let item = FileItem::new(
                         name,
@@ -304,6 +312,8 @@ pub fn scan_dir_async(
                         file_size,
                         modified_time,
                         created_time,
+                        modified_time_raw,
+                        created_time_raw,
                     );
 
                     let _ = tx.send(item);
@@ -410,6 +420,8 @@ pub struct FileItem {
     pub file_size: Option<u64>,
     pub modified_time: Option<String>,
     pub created_time: Option<String>,
+    pub modified_time_raw: Option<i64>,
+    pub created_time_raw: Option<i64>,
 
     // Optional drive info (only populated for drive roots)
     pub total_space: Option<u64>,
@@ -425,6 +437,8 @@ impl FileItem {
         file_size: Option<u64>,
         modified_time: Option<String>,
         created_time: Option<String>,
+        modified_time_raw: Option<i64>,
+        created_time_raw: Option<i64>,
     ) -> Self {
         Self {
             name,
@@ -434,6 +448,8 @@ impl FileItem {
             file_size,
             modified_time,
             created_time,
+            modified_time_raw,
+            created_time_raw,
             total_space: None,
             free_space: None,
         }
@@ -447,6 +463,8 @@ impl FileItem {
         file_size: Option<u64>,
         modified_time: Option<String>,
         created_time: Option<String>,
+        modified_time_raw: Option<i64>,
+        created_time_raw: Option<i64>,
         total: u64,
         free: u64,
     ) -> Self {
@@ -458,6 +476,8 @@ impl FileItem {
             file_size,
             modified_time,
             created_time,
+            modified_time_raw,
+            created_time_raw,
             total_space: Some(total),
             free_space: Some(free),
         }

--- a/src/core/portable.rs
+++ b/src/core/portable.rs
@@ -414,7 +414,17 @@ fn enumerate_portable_children(
         cache_object_info(device_id, &path_object_id, &name, parent_override);
 
         // Portable devices don't provide reliable time information, so use None
-        let item = FileItem::new(name, virtual_path, is_dir, is_hidden, file_size, None, None);
+        let item = FileItem::new(
+            name,
+            virtual_path,
+            is_dir,
+            is_hidden,
+            file_size,
+            None,
+            None,
+            None,
+            None,
+        );
         pending.push(item.clone());
 
         if is_root {

--- a/src/core/utils/sorting.rs
+++ b/src/core/utils/sorting.rs
@@ -20,8 +20,8 @@ pub fn sort_files(files: &mut Vec<FileItem>, column: SortColumn, ascending: bool
         let ord = match column {
             SortColumn::Name => a.name.to_lowercase().cmp(&b.name.to_lowercase()),
             SortColumn::Size => a.file_size.unwrap_or(0).cmp(&b.file_size.unwrap_or(0)),
-            SortColumn::Modified => a.modified_time.cmp(&b.modified_time),
-            SortColumn::Created => a.created_time.cmp(&b.created_time),
+            SortColumn::Modified => a.modified_time_raw.cmp(&b.modified_time_raw),
+            SortColumn::Created => a.created_time_raw.cmp(&b.created_time_raw),
             SortColumn::Type => match (a.is_dir, b.is_dir) {
                 (true, false) => Less,
                 (false, true) => Greater,

--- a/src/gui/windows/containers/tags.rs
+++ b/src/gui/windows/containers/tags.rs
@@ -269,6 +269,8 @@ pub fn draw_tags(
                                                 file_size: None,
                                                 modified_time: None,
                                                 created_time: None,
+                                                modified_time_raw: None,
+                                                created_time_raw: None,
                                                 total_space: None,
                                                 free_space: None,
                                             };
@@ -289,6 +291,8 @@ pub fn draw_tags(
                                                     file_size: None,
                                                     modified_time: None,
                                                     created_time: None,
+                                                    modified_time_raw: None,
+                                                    created_time_raw: None,
                                                     total_space: None,
                                                     free_space: None,
                                                 };

--- a/src/gui/windows/mainwindow_imp.rs
+++ b/src/gui/windows/mainwindow_imp.rs
@@ -252,11 +252,12 @@ impl MainWindow {
                 let path = d.path;
                 if let (Some(total), Some(free)) = (d.total_space, d.free_space) {
                     view.files.push(FileItem::with_drive_info(
-                        label, path, true, false, None, None, None, total, free,
+                        label, path, true, false, None, None, None, None, None, total, free,
                     ));
                 } else {
-                    view.files
-                        .push(FileItem::new(label, path, true, false, None, None, None));
+                    view.files.push(FileItem::new(
+                        label, path, true, false, None, None, None, None, None,
+                    ));
                 }
             }
 


### PR DESCRIPTION
## Problem

Sorting by the Modified or Created column produces incorrect
ordering - e.g. a file from 12/10/2024 sorts above one from 6/30/2026.

## Cause

The Modified/Created columns were sorted by comparing the formatted
display text as plain strings, instead of comparing the actual timestamps.

## Fix

Store the raw file timestamp alongside the existing display string on
`FileItem`, and sort on that instead. The display string itself is
unchanged, so this only fixes sort order, not what's shown in the UI.

No extra processing is added: the raw timestamp is already read during
the original directory scan (it's the same value used to build the
display string), so this just keeps a copy of data that was already
being fetched instead of discarding it.

## Scope

Folders still always sort above files regardless of column or
direction - that's a separate, hardcoded behavior and is left as-is
here. It's related to the open multi-criteria sorting issue, but
fixing that is out of scope for this PR.

## Testing

- `cargo fmt --all -- --check`, `cargo clippy --all-targets
  --all-features`, `cargo build --release`, and `cargo test` all pass
  locally.
- Manually verified: sorting a folder with files spanning multiple
  months/years by Modified (ascending and descending) now produces
  true chronological order; spot-checked Created column the same way.
