### PR TITLE
feat: refactor settings UI and fix windows submenu

### DIFF
--- a/locales/en-US/main.ftl
+++ b/locales/en-US/main.ftl
@@ -64,7 +64,6 @@ settings_windowsize_width = Width
 settings_windowsize_height = Height
 settings_windowsize_reset_hover = Reset to default
 tooltip_settings_windowsize = Sets the window size EdenExplorer opens with. Full Screen matches your monitor's resolution.
-settings_contextmenu = Context Menu
 settings_contextmenu_enable = Enable Windows context menu items
 tooltip_settings_contextmenu = Adds a Windows section to the right-click menu with shell actions.
 settings_favorites_reset = Reset Sidebar Favorites

--- a/locales/id-ID/main.ftl
+++ b/locales/id-ID/main.ftl
@@ -62,7 +62,6 @@ settings_windowsize_width = Lebar
 settings_windowsize_height = Tinggi
 settings_windowsize_reset_hover = Atur ulang ke default
 tooltip_settings_windowsize = Mengatur ukuran jendela saat EdenExplorer dibuka. Layar Penuh menyesuaikan resolusi monitor Anda.
-settings_contextmenu = Menu Konteks
 settings_contextmenu_enable = Aktifkan item menu konteks Windows
 tooltip_settings_contextmenu = Menambahkan bagian Windows ke menu klik kanan dengan aksi shell.
 settings_favorites_reset = Reset Favorit Sidebar

--- a/locales/ja-JP/main.ftl
+++ b/locales/ja-JP/main.ftl
@@ -62,7 +62,6 @@ settings_windowsize_width = 幅
 settings_windowsize_height = 高さ
 settings_windowsize_reset_hover = デフォルトに戻す
 tooltip_settings_windowsize = EdenExplorerの起動時のウィンドウサイズを設定します。フルスクリーンはモニターの解像度に合わせます。
-settings_contextmenu = コンテキストメニュー
 settings_contextmenu_enable = Windowsコンテキストメニュー項目を有効化
 tooltip_settings_contextmenu = 右クリックメニューにShell操作を含むWindowsセクションを追加します。
 settings_favorites_reset = サイドバーのお気に入りをリセット

--- a/locales/zh-CN/main.ftl
+++ b/locales/zh-CN/main.ftl
@@ -62,7 +62,6 @@ settings_windowsize_width = 宽度
 settings_windowsize_height = 高度
 settings_windowsize_reset_hover = 恢复默认值
 tooltip_settings_windowsize = 设置 EdenExplorer 启动时的窗口大小。全屏将匹配您显示器的分辨率。
-settings_contextmenu = 右键菜单
 settings_contextmenu_enable = 启用 Windows 右键菜单项
 tooltip_settings_contextmenu = 在右键菜单中添加带有 Shell 操作的 Windows 部分。
 settings_favorites_reset = 重置侧边栏收藏夹

--- a/locales/zh-HK/main.ftl
+++ b/locales/zh-HK/main.ftl
@@ -62,7 +62,6 @@ settings_windowsize_width = 寬度
 settings_windowsize_height = 高度
 settings_windowsize_reset_hover = 重設為預設值
 tooltip_settings_windowsize = 設定 EdenExplorer 啟動時的視窗大小。全螢幕會配合您顯示器的解像度。
-settings_contextmenu = 右鍵選單
 settings_contextmenu_enable = 啟用 Windows 右鍵選單項目
 tooltip_settings_contextmenu = 在右鍵選單中加入包含 Shell 操作的 Windows 區段。
 settings_favorites_reset = 重設側邊欄我的最愛

--- a/locales/zh-TW/main.ftl
+++ b/locales/zh-TW/main.ftl
@@ -62,7 +62,6 @@ settings_windowsize_width = 寬度
 settings_windowsize_height = 高度
 settings_windowsize_reset_hover = 重設為預設值
 tooltip_settings_windowsize = 設定 EdenExplorer 啟動時的視窗大小。全螢幕會配合您顯示器的解析度。
-settings_contextmenu = 右鍵選單
 settings_contextmenu_enable = 啟用 Windows 右鍵選單項目
 tooltip_settings_contextmenu = 在右鍵選單中新增包含 Shell 操作的 Windows 區段。
 settings_favorites_reset = 重設側邊欄我的最愛

--- a/src/core/utils/text.rs
+++ b/src/core/utils/text.rs
@@ -1,4 +1,6 @@
+use crate::gui::theme::ThemePalette;
 use eframe::egui;
+use egui::FontId;
 use lazy_static::lazy_static;
 use lru::LruCache;
 use std::env;
@@ -189,4 +191,41 @@ mod tests {
             assert_eq!(expanded, format!("{}\\{}", appdata, windir));
         }
     }
+}
+
+pub fn apply_context_menu_typography(ui: &mut egui::Ui, palette: &ThemePalette) {
+    let mut style = (*ui.ctx().style()).clone();
+    style.text_styles = [
+        (
+            egui::TextStyle::Body,
+            FontId::proportional(palette.context_menu_text_size),
+        ),
+        (
+            egui::TextStyle::Button,
+            FontId::proportional(palette.context_menu_text_size),
+        ),
+        (
+            egui::TextStyle::Small,
+            FontId::proportional(palette.context_menu_text_size),
+        ),
+        (
+            egui::TextStyle::Heading,
+            FontId::proportional(palette.context_menu_text_size + 2.0),
+        ),
+    ]
+    .into();
+    style.spacing.button_padding = egui::vec2(4.0, 2.0);
+    style.spacing.item_spacing = egui::vec2(6.0, 2.0);
+    style.spacing.menu_margin = egui::Margin::same(4);
+    style.spacing.interact_size = egui::vec2(
+        style.spacing.interact_size.x,
+        palette.context_menu_text_size + 6.0,
+    );
+    style.visuals.widgets.inactive.bg_fill = egui::Color32::TRANSPARENT;
+    style.visuals.widgets.inactive.weak_bg_fill = egui::Color32::TRANSPARENT;
+    style.visuals.widgets.hovered.bg_fill = palette.primary;
+    style.visuals.widgets.hovered.weak_bg_fill = palette.primary;
+    style.visuals.widgets.active.bg_fill = palette.primary;
+    style.visuals.widgets.active.weak_bg_fill = palette.primary;
+    ui.set_style(style);
 }

--- a/src/core/utils/widgets.rs
+++ b/src/core/utils/widgets.rs
@@ -242,3 +242,38 @@ pub fn draw_checkbox(
 
     response
 }
+
+pub fn draw_dropdown(
+    ui: &mut egui::Ui,
+    palette: &ThemePalette,
+    id: impl std::hash::Hash,
+    width: f32,
+    selected_text: impl Into<egui::WidgetText>,
+    add_contents: impl FnOnce(&mut egui::Ui),
+) {
+    ui.scope(|ui| {
+        // Closed combo styling...
+        let visuals = ui.visuals_mut();
+
+        visuals.widgets.hovered.bg_fill = palette.primary_hover;
+        visuals.widgets.active.bg_fill = palette.primary_active;
+
+        egui::ComboBox::from_id_salt(id)
+            .width(width)
+            .selected_text(selected_text)
+            .show_ui(ui, |ui| {
+                // Popup styling
+                ui.style_mut().text_styles.insert(
+                    egui::TextStyle::Body,
+                    egui::FontId::proportional(palette.text_size),
+                );
+
+                ui.style_mut().text_styles.insert(
+                    egui::TextStyle::Button,
+                    egui::FontId::proportional(palette.text_size),
+                );
+
+                add_contents(ui);
+            });
+    });
+}

--- a/src/core/utils/widgets.rs
+++ b/src/core/utils/widgets.rs
@@ -273,6 +273,8 @@ pub fn draw_dropdown(
                     egui::FontId::proportional(palette.text_size),
                 );
 
+                ui.style_mut().visuals.selection.stroke.color = palette.text_header_section;
+
                 add_contents(ui);
             });
     });

--- a/src/gui/windows/containers/explorer.rs
+++ b/src/gui/windows/containers/explorer.rs
@@ -22,7 +22,6 @@ const RIGHT_MARGIN: f32 = 8.0;
 const COLUMN_SPACING: f32 = 20.0;
 const FILES_COLUMN_WIDTH: f32 = 56.0;
 const FOLDERS_COLUMN_WIDTH: f32 = 56.0;
-const SELECTED_COLUMN_WIDTH: f32 = 170.0;
 const STATUS_ICON_GAP: f32 = 4.0;
 
 /// Draws one view's breadcrumb + item viewer + status bar (the content of
@@ -218,8 +217,6 @@ pub fn draw_tab_content(
                             &font_id,
                             text_color,
                         );
-
-                        // right -= SELECTED_COLUMN_WIDTH + COLUMN_SPACING;
                     }
                 }
             });

--- a/src/gui/windows/containers/itemviewer_helper.rs
+++ b/src/gui/windows/containers/itemviewer_helper.rs
@@ -3,6 +3,7 @@ use crate::core::fs::FileItem;
 use crate::core::fs::MY_PC_PATH;
 use crate::core::portable;
 use crate::core::utils::files::filename_has_valid_characters_realtime;
+use crate::core::utils::text::apply_context_menu_typography;
 use crate::core::utils::widgets::draw_checkbox;
 use crate::gui::i18n::I18n;
 use crate::gui::icons::IconCache;
@@ -70,43 +71,6 @@ pub fn compute_layout(
         header_height: row_height,
         is_drive_view,
     }
-}
-
-fn apply_context_menu_typography(ui: &mut egui::Ui, palette: &ThemePalette) {
-    let mut style = (*ui.ctx().style()).clone();
-    style.text_styles = [
-        (
-            egui::TextStyle::Body,
-            FontId::proportional(palette.context_menu_text_size),
-        ),
-        (
-            egui::TextStyle::Button,
-            FontId::proportional(palette.context_menu_text_size),
-        ),
-        (
-            egui::TextStyle::Small,
-            FontId::proportional(palette.context_menu_text_size),
-        ),
-        (
-            egui::TextStyle::Heading,
-            FontId::proportional(palette.context_menu_text_size + 2.0),
-        ),
-    ]
-    .into();
-    style.spacing.button_padding = egui::vec2(4.0, 2.0);
-    style.spacing.item_spacing = egui::vec2(6.0, 2.0);
-    style.spacing.menu_margin = egui::Margin::same(4);
-    style.spacing.interact_size = egui::vec2(
-        style.spacing.interact_size.x,
-        palette.context_menu_text_size + 6.0,
-    );
-    style.visuals.widgets.inactive.bg_fill = egui::Color32::TRANSPARENT;
-    style.visuals.widgets.inactive.weak_bg_fill = egui::Color32::TRANSPARENT;
-    style.visuals.widgets.hovered.bg_fill = palette.primary;
-    style.visuals.widgets.hovered.weak_bg_fill = palette.primary;
-    style.visuals.widgets.active.bg_fill = palette.primary;
-    style.visuals.widgets.active.weak_bg_fill = palette.primary;
-    ui.set_style(style);
 }
 
 pub fn handle_context_menu_actions(

--- a/src/gui/windows/containers/itemviewer_helper.rs
+++ b/src/gui/windows/containers/itemviewer_helper.rs
@@ -72,6 +72,43 @@ pub fn compute_layout(
     }
 }
 
+fn apply_context_menu_typography(ui: &mut egui::Ui, palette: &ThemePalette) {
+    let mut style = (*ui.ctx().style()).clone();
+    style.text_styles = [
+        (
+            egui::TextStyle::Body,
+            FontId::proportional(palette.context_menu_text_size),
+        ),
+        (
+            egui::TextStyle::Button,
+            FontId::proportional(palette.context_menu_text_size),
+        ),
+        (
+            egui::TextStyle::Small,
+            FontId::proportional(palette.context_menu_text_size),
+        ),
+        (
+            egui::TextStyle::Heading,
+            FontId::proportional(palette.context_menu_text_size + 2.0),
+        ),
+    ]
+    .into();
+    style.spacing.button_padding = egui::vec2(4.0, 2.0);
+    style.spacing.item_spacing = egui::vec2(6.0, 2.0);
+    style.spacing.menu_margin = egui::Margin::same(4);
+    style.spacing.interact_size = egui::vec2(
+        style.spacing.interact_size.x,
+        palette.context_menu_text_size + 6.0,
+    );
+    style.visuals.widgets.inactive.bg_fill = egui::Color32::TRANSPARENT;
+    style.visuals.widgets.inactive.weak_bg_fill = egui::Color32::TRANSPARENT;
+    style.visuals.widgets.hovered.bg_fill = palette.primary;
+    style.visuals.widgets.hovered.weak_bg_fill = palette.primary;
+    style.visuals.widgets.active.bg_fill = palette.primary;
+    style.visuals.widgets.active.weak_bg_fill = palette.primary;
+    ui.set_style(style);
+}
+
 pub fn handle_context_menu_actions(
     ui: &mut egui::Ui,
     i18n: &I18n,
@@ -88,40 +125,7 @@ pub fn handle_context_menu_actions(
     hwnd: Option<HWND>,
 ) {
     // Apply context-menu-specific typography
-    let mut style = (*ui.ctx().style()).clone();
-    style.text_styles = [
-        (
-            egui::TextStyle::Body,
-            FontId::proportional(_palette.context_menu_text_size),
-        ),
-        (
-            egui::TextStyle::Button,
-            FontId::proportional(_palette.context_menu_text_size),
-        ),
-        (
-            egui::TextStyle::Small,
-            FontId::proportional(_palette.context_menu_text_size),
-        ),
-        (
-            egui::TextStyle::Heading,
-            FontId::proportional(_palette.context_menu_text_size + 2.0),
-        ),
-    ]
-    .into();
-    style.spacing.button_padding = egui::vec2(4.0, 2.0);
-    style.spacing.item_spacing = egui::vec2(6.0, 2.0);
-    style.spacing.menu_margin = egui::Margin::same(4);
-    style.spacing.interact_size = egui::vec2(
-        style.spacing.interact_size.x,
-        _palette.context_menu_text_size + 6.0,
-    );
-    style.visuals.widgets.inactive.bg_fill = egui::Color32::TRANSPARENT;
-    style.visuals.widgets.inactive.weak_bg_fill = egui::Color32::TRANSPARENT;
-    style.visuals.widgets.hovered.bg_fill = _palette.primary;
-    style.visuals.widgets.hovered.weak_bg_fill = _palette.primary;
-    style.visuals.widgets.active.bg_fill = _palette.primary;
-    style.visuals.widgets.active.weak_bg_fill = _palette.primary;
-    ui.set_style(style);
+    apply_context_menu_typography(ui, _palette);
 
     // Match Explorer behavior: right-click selects if not already selected
     if !is_selected {
@@ -269,23 +273,15 @@ pub fn handle_context_menu_actions(
         .windows_context_menu_enabled
     {
         ui.separator();
-
-        let toggle_label = if explorer_state.windows_context_menu_expanded {
+        let selected_paths = context_paths.clone();
+        let toggle_label = if explorer_state.windows_context_menu_cache.is_some() {
             i18n.tr("contextmenu_hide_windows_menu_items")
         } else {
             i18n.tr("contextmenu_show_windows_menu_items")
         };
 
-        if ui.button(toggle_label).clicked() {
-            explorer_state.windows_context_menu_expanded =
-                !explorer_state.windows_context_menu_expanded;
-            if !explorer_state.windows_context_menu_expanded {
-                explorer_state.windows_context_menu_cache = None;
-            }
-        }
-
-        if explorer_state.windows_context_menu_expanded {
-            let selected_paths = context_paths.clone();
+        ui.menu_button(toggle_label, |ui| {
+            apply_context_menu_typography(ui, _palette);
 
             if let Some(hwnd) = hwnd {
                 let cache_miss = explorer_state
@@ -340,7 +336,7 @@ pub fn handle_context_menu_actions(
             } else {
                 ui.label(i18n.tr("contextmenu_windows_menu_available_missing"));
             }
-        }
+        });
     }
 }
 

--- a/src/gui/windows/containers/sidebar.rs
+++ b/src/gui/windows/containers/sidebar.rs
@@ -2,14 +2,15 @@ use crate::core::drives::{
     DriveInfo, consume_drive_list_dirty, get_drive_infos, is_raw_physical_drive_path,
 };
 use crate::core::fs::MY_PC_PATH;
+use crate::core::utils::text::apply_context_menu_typography;
 use crate::gui::i18n::I18n;
-// use crate::core::networkdevices::NetworkDevicesState;
 use crate::gui::icons::IconCache;
 use crate::gui::theme::ThemePalette;
 use crate::gui::utils::{draw_object_drag_ghost, drive_usage_color, truncate_item_text};
 use crate::gui::windows::containers::structs::SidebarAction;
 use crate::gui::windows::structs::SidebarState;
 use eframe::egui;
+use egui::containers::{Popup, PopupCloseBehavior};
 use egui::{FontFamily, FontId, ScrollArea};
 use egui_phosphor::regular;
 use std::path::PathBuf;
@@ -320,12 +321,15 @@ pub fn draw_sidebar(
                         action.open_new_tab = Some(PathBuf::from(MY_PC_PATH));
                     }
 
-                    resp.context_menu(|ui| {
-                        if ui.button(&i18n.tr("inputs_newtab")).clicked() {
-                            action.open_new_tab = Some(PathBuf::from(MY_PC_PATH));
-                            ui.close();
-                        }
-                    });
+                    Popup::context_menu(&resp)
+                        .close_behavior(PopupCloseBehavior::CloseOnClickOutside)
+                        .show(|ui| {
+                            apply_context_menu_typography(ui, palette);
+                            if ui.button(&i18n.tr("inputs_newtab")).clicked() {
+                                action.open_new_tab = Some(PathBuf::from(MY_PC_PATH));
+                                ui.close();
+                            }
+                        });
 
                     if let Some(home) = dirs::home_dir() {
                         let resp = draw_sidebar_item(
@@ -345,12 +349,15 @@ pub fn draw_sidebar(
                         if resp.middle_clicked() {
                             action.open_new_tab = Some(home.clone());
                         }
-                        resp.context_menu(|ui| {
-                            if ui.button(&i18n.tr("inputs_newtab")).clicked() {
-                                action.open_new_tab = Some(home.clone());
-                                ui.close();
-                            }
-                        });
+                        Popup::context_menu(&resp)
+                            .close_behavior(PopupCloseBehavior::CloseOnClickOutside)
+                            .show(|ui| {
+                                apply_context_menu_typography(ui, palette);
+                                if ui.button(&i18n.tr("inputs_newtab")).clicked() {
+                                    action.open_new_tab = Some(home.clone());
+                                    ui.close();
+                                }
+                            });
                     }
 
                     ui.add_space(6.0);
@@ -444,16 +451,19 @@ pub fn draw_sidebar(
                             action.open_new_tab = Some(favorite.path.clone());
                         }
 
-                        resp.context_menu(|ui| {
-                            if ui.button(&i18n.tr("inputs_newtab")).clicked() {
-                                action.open_new_tab = Some(favorite.path.clone());
-                                ui.close();
-                            }
-                            if ui.button(&i18n.tr("remove_favorite")).clicked() {
-                                action.remove_favorite = Some(favorite.path.clone());
-                                ui.close();
-                            }
-                        });
+                        Popup::context_menu(&resp)
+                            .close_behavior(PopupCloseBehavior::CloseOnClickOutside)
+                            .show(|ui| {
+                                apply_context_menu_typography(ui, palette);
+                                if ui.button(&i18n.tr("inputs_newtab")).clicked() {
+                                    action.open_new_tab = Some(favorite.path.clone());
+                                    ui.close();
+                                }
+                                if ui.button(&i18n.tr("remove_favorite")).clicked() {
+                                    action.remove_favorite = Some(favorite.path.clone());
+                                    ui.close();
+                                }
+                            });
 
                         if let Some(drop) = drop_index {
                             if drop == i {

--- a/src/gui/windows/containers/structs.rs
+++ b/src/gui/windows/containers/structs.rs
@@ -19,7 +19,6 @@ pub struct ExplorerState {
     pub selection_focus: Option<usize>,
     pub pending_selection_paths: Option<Vec<PathBuf>>, // select after refresh
     pub non_ntfs_popup_path: Option<PathBuf>,
-    pub windows_context_menu_expanded: bool,
     pub windows_context_menu_cache: Option<WindowsContextMenuCache>,
     pub navigation_history: HashMap<PathBuf, PathBuf>, // parent_dir -> last_visited_child
     pub navigation_selection: Option<PathBuf>,         // path to select after navigation loads

--- a/src/gui/windows/customizetheme.rs
+++ b/src/gui/windows/customizetheme.rs
@@ -5,6 +5,7 @@ use crate::gui::theme::{
     regenerate_base_derived_colors,
 };
 use crate::gui::utils::rgba_color_edit_button;
+use crate::gui::utils::widgets::draw_dropdown;
 use crate::gui::windows::enums::ThemeCustomizerAction;
 use crate::gui::windows::structs::ThemeCustomizer;
 use eframe::egui;
@@ -319,6 +320,7 @@ pub fn draw_theme_customizer(
                                     |ui| {
                                         if let Some(new_font) = font_selector(
                                             ui,
+                                            palette,
                                             "theme_font_selector",
                                             &editing_palette.font_name,
                                         ) {
@@ -341,6 +343,7 @@ pub fn draw_theme_customizer(
                                     |ui| {
                                         if let Some(new_font) = font_selector(
                                             ui,
+                                            palette,
                                             "theme_mono_font_selector",
                                             &editing_palette.mono_font_name,
                                         ) {
@@ -471,17 +474,25 @@ fn color_picker(
     rgba_color_edit_button(ui, color).changed()
 }
 
-fn font_selector(ui: &mut egui::Ui, label: &str, current_font: &str) -> Option<String> {
+fn font_selector(
+    ui: &mut egui::Ui,
+    palette: &ThemePalette,
+    label: &str,
+    current_font: &str,
+) -> Option<String> {
     let fonts = get_font_list();
 
     ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
         let mut selected_text = current_font.to_string();
         let mut changed = false;
 
-        egui::ComboBox::from_id_source(egui::Id::new(label))
-            .width(200.0)
-            .selected_text(&selected_text)
-            .show_ui(ui, |ui| {
+        draw_dropdown(
+            ui,
+            palette,
+            egui::Id::new(label),
+            200.0,
+            selected_text.clone(),
+            |ui| {
                 egui::ScrollArea::vertical()
                     .max_height(200.0)
                     .show(ui, |ui| {
@@ -498,7 +509,8 @@ fn font_selector(ui: &mut egui::Ui, label: &str, current_font: &str) -> Option<S
                             }
                         }
                     });
-            });
+            },
+        );
 
         if changed { Some(selected_text) } else { None }
     })

--- a/src/gui/windows/mainwindow.rs
+++ b/src/gui/windows/mainwindow.rs
@@ -1,3 +1,4 @@
+use crate::core::indexer::WindowSizeMode;
 use crate::core::indexer::{
     load_app_settings, load_favorites, load_tags, load_theme_settings, save_app_settings,
 };
@@ -341,15 +342,16 @@ impl eframe::App for MainWindow {
 
                 if size_changed {
                     // Update the window size mode in settings
-                    let is_fullscreen = ctx.input(|i| i.viewport().fullscreen.unwrap_or(false));
-                    self.settings_window.current_settings.window_size_mode = if is_fullscreen {
-                        crate::core::indexer::WindowSizeMode::FullScreen
-                    } else {
-                        crate::core::indexer::WindowSizeMode::Custom {
-                            width: current_size.0,
-                            height: current_size.1,
+                    match &mut self.settings_window.current_settings.window_size_mode {
+                        WindowSizeMode::Custom { width, height } => {
+                            *width = current_size.0;
+                            *height = current_size.1;
                         }
-                    };
+                        WindowSizeMode::FullScreen => {
+                            // Keep the mode as FullScreen.
+                            // Don't overwrite it just because the window was resized.
+                        }
+                    }
 
                     // Save the updated settings
                     save_app_settings(

--- a/src/gui/windows/mainwindow_imp.rs
+++ b/src/gui/windows/mainwindow_imp.rs
@@ -827,9 +827,22 @@ impl MainWindow {
                         &self.settings_window.current_settings.language,
                         self.settings_window.current_settings.date_style,
                     );
+
+                    if let Some(hwnd) = self.hwnd {
+                        crate::gui::windows::windowsoverrides::set_window_mode(
+                            hwnd,
+                            &self.settings_window.current_settings.window_size_mode,
+                        );
+                    }
                 }
                 SettingsAction::ResetToDefaults => {
                     self.settings_window.current_settings = Default::default();
+                    if let Some(hwnd) = self.hwnd {
+                        crate::gui::windows::windowsoverrides::set_window_mode(
+                            hwnd,
+                            &self.settings_window.current_settings.window_size_mode,
+                        );
+                    }
                 }
                 SettingsAction::ResetFavourites => {
                     self.sidebar_state.favorites = self.default_favorites();

--- a/src/gui/windows/settings.rs
+++ b/src/gui/windows/settings.rs
@@ -1,7 +1,7 @@
 use crate::core::{
     fs::{DateStyle, MY_PC_PATH},
     indexer::WindowSizeMode,
-    utils::widgets::draw_checkbox,
+    utils::widgets::{draw_checkbox, draw_dropdown},
 };
 use crate::gui::i18n::I18n;
 use crate::gui::theme::ThemePalette;
@@ -35,7 +35,6 @@ impl Default for AppSettings {
     }
 }
 
-// Helper function for info icon with hover text (non-clickable)
 fn info_icon(ui: &mut egui::Ui, hover_text: &str, palette: &ThemePalette) -> egui::Response {
     let resp = ui.add(egui::Label::new(regular::QUESTION).sense(egui::Sense::hover()));
 
@@ -70,17 +69,25 @@ fn info_icon(ui: &mut egui::Ui, hover_text: &str, palette: &ThemePalette) -> egu
     resp
 }
 
-fn right_aligned_cell<R>(
+fn setting_label(
     ui: &mut egui::Ui,
-    add_contents: impl FnOnce(&mut egui::Ui) -> R,
-) -> egui::InnerResponse<R> {
-    let row_height = ui.spacing().interact_size.y;
-    let size = egui::vec2(ui.available_width(), row_height);
+    text: impl Into<egui::WidgetText>,
+    info: Option<(&str, &ThemePalette)>,
+) {
+    let h = ui.spacing().interact_size.y;
+
     ui.allocate_ui_with_layout(
-        size,
-        egui::Layout::right_to_left(egui::Align::Center),
-        add_contents,
-    )
+        egui::vec2(ui.available_width(), h),
+        egui::Layout::left_to_right(egui::Align::Center),
+        |ui| {
+            ui.label(text);
+
+            if let Some((hover_text, palette)) = info {
+                ui.add_space(4.0);
+                info_icon(ui, hover_text, palette);
+            }
+        },
+    );
 }
 
 fn setting_checkbox(
@@ -109,6 +116,58 @@ fn setting_checkbox(
         if label_resp.clicked() {
             *checked = !*checked;
             changed = true;
+        }
+    });
+
+    changed
+}
+
+const SETTINGS_LABEL_WIDTH: f32 = 150.0;
+pub fn setting_row<L, R>(ui: &mut egui::Ui, left: L, right: R)
+where
+    L: FnOnce(&mut egui::Ui),
+    R: FnOnce(&mut egui::Ui),
+{
+    let row_height = ui.spacing().interact_size.y;
+
+    ui.horizontal(|ui| {
+        // Fixed-width label column
+        ui.allocate_ui_with_layout(
+            egui::vec2(SETTINGS_LABEL_WIDTH, row_height),
+            egui::Layout::left_to_right(egui::Align::Center),
+            left,
+        );
+
+        // Flexible spacer
+        ui.add_space(ui.available_width());
+
+        // Right-aligned controls
+        ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), right);
+    });
+}
+
+pub fn combo_box_string(
+    ui: &mut egui::Ui,
+    palette: &ThemePalette,
+    id: impl std::hash::Hash,
+    width: f32,
+    value: &mut String,
+    options: &[(&str, String)],
+) -> bool {
+    let mut changed = false;
+
+    let selected_text = options
+        .iter()
+        .find(|(key, _)| *key == value)
+        .map(|(_, label)| label.as_str())
+        .unwrap_or("");
+
+    draw_dropdown(ui, palette, id, width, selected_text, |ui| {
+        for (key, label) in options {
+            if ui.selectable_label(value == key, label).clicked() {
+                *value = (*key).to_string();
+                changed = true;
+            }
         }
     });
 
@@ -195,97 +254,47 @@ pub fn draw_settings_window(
                         }
                     });
 
-                    egui::Grid::new("settings_language_row")
-                        .num_columns(2)
-                        .min_col_width(120.0)
-                        .spacing([12.0, 8.0])
-                        .show(ui, |ui| {
-                            ui.label(RichText::new(i18n.tr("language")).color(palette.text_normal));
+                    let language_label =
+                        RichText::new(i18n.tr("language")).color(palette.text_normal);
 
-                            right_aligned_cell(ui, |ui| {
-                                let mut selected_locale =
-                                    settings.current_settings.language.clone();
+                    let english = i18n.tr("english");
+                    let japanese = i18n.tr("japanese");
+                    let indonesian = i18n.tr("indonesian");
+                    let chinese_simple = i18n.tr("chinese_simple");
+                    let chinese_traditional = i18n.tr("chinese_traditional");
+                    let chinese_hk = i18n.tr("chinese_traditional_hk");
 
-                                egui::ComboBox::from_id_salt("language_selector")
-                                    .width(SETTINGS_COMBO_WIDTH)
-                                    .selected_text(match selected_locale.as_str() {
-                                        "ja-JP" => i18n.tr("japanese"),
-                                        "id-ID" => i18n.tr("indonesian"),
-                                        "zh-CN" => i18n.tr("chinese_simple"),
-                                        "zh-TW" => i18n.tr("chinese_traditional"),
-                                        "zh-HK" => i18n.tr("chinese_traditional_hk"),
-                                        _ => i18n.tr("english"),
-                                    })
-                                    .show_ui(ui, |ui| {
-                                        if ui
-                                            .selectable_label(
-                                                selected_locale == "en-US",
-                                                i18n.tr("english"),
-                                            )
-                                            .clicked()
-                                        {
-                                            selected_locale = "en-US".to_string();
-                                        }
+                    setting_row(
+                        ui,
+                        |ui| {
+                            setting_label(ui, language_label.clone(), None);
+                        },
+                        |ui| {
+                            let mut selected_locale = settings.current_settings.language.clone();
 
-                                        if ui
-                                            .selectable_label(
-                                                selected_locale == "ja-JP",
-                                                i18n.tr("japanese"),
-                                            )
-                                            .clicked()
-                                        {
-                                            selected_locale = "ja-JP".to_string();
-                                        }
+                            if combo_box_string(
+                                ui,
+                                palette,
+                                "language_selector",
+                                SETTINGS_COMBO_WIDTH,
+                                &mut selected_locale,
+                                &[
+                                    ("en-US", english.clone()),
+                                    ("ja-JP", japanese.clone()),
+                                    ("id-ID", indonesian.clone()),
+                                    ("zh-CN", chinese_simple.clone()),
+                                    ("zh-TW", chinese_traditional.clone()),
+                                    ("zh-HK", chinese_hk.clone()),
+                                ],
+                            ) {
+                                i18n.set_locale(&selected_locale);
+                                settings.current_settings.language = selected_locale;
+                                action = Some(SettingsAction::ApplySettings);
+                            }
+                        },
+                    );
 
-                                        if ui
-                                            .selectable_label(
-                                                selected_locale == "id-ID",
-                                                i18n.tr("indonesian"),
-                                            )
-                                            .clicked()
-                                        {
-                                            selected_locale = "id-ID".to_string();
-                                        }
-
-                                        if ui
-                                            .selectable_label(
-                                                selected_locale == "zh-CN",
-                                                i18n.tr("chinese_simple"),
-                                            )
-                                            .clicked()
-                                        {
-                                            selected_locale = "zh-CN".to_string();
-                                        }
-
-                                        if ui
-                                            .selectable_label(
-                                                selected_locale == "zh-TW",
-                                                i18n.tr("chinese_traditional"),
-                                            )
-                                            .clicked()
-                                        {
-                                            selected_locale = "zh-TW".to_string();
-                                        }
-
-                                        if ui
-                                            .selectable_label(
-                                                selected_locale == "zh-HK",
-                                                i18n.tr("chinese_traditional_hk"),
-                                            )
-                                            .clicked()
-                                        {
-                                            selected_locale = "zh-HK".to_string();
-                                        }
-                                    });
-
-                                if selected_locale != settings.current_settings.language {
-                                    i18n.set_locale(&selected_locale);
-                                    settings.current_settings.language = selected_locale;
-                                    action = Some(SettingsAction::ApplySettings);
-                                }
-                            });
-                            ui.end_row();
-                        });
+                    ui.add_space(8.0);
 
                     // Folder Scanning
                     ui.horizontal(|ui| {
@@ -353,39 +362,17 @@ pub fn draw_settings_window(
                     });
                     ui.add_space(8.0);
                     // Starting Path
-                    ui.label(&i18n.tr("settings_startpath"));
-                    ui.horizontal(|ui| {
-                        let path_text = settings
-                            .current_settings
-                            .start_path
-                            .as_ref()
-                            .map(|p| {
-                                if p.as_os_str() == MY_PC_PATH {
-                                    return i18n.tr("settings_startpath_default");
-                                }
-
-                                let s = p.to_string_lossy();
-
-                                if s.len() > 40 {
-                                    format!("...{}", &s[s.len() - 40..])
-                                } else {
-                                    s.to_string()
-                                }
-                            })
-                            .unwrap_or_else(|| i18n.tr("settings_startpath_default"));
-
-                        ui.add_sized([200.0, 18.0], egui::Label::new(path_text))
-                            .on_hover_text(
-                                settings
-                                    .current_settings
-                                    .start_path
-                                    .as_ref()
-                                    .map(|p| p.to_string_lossy().to_string())
-                                    .unwrap_or_default(),
+                    setting_row(
+                        ui,
+                        |ui| {
+                            setting_label(
+                                ui,
+                                RichText::new(i18n.tr("settings_startpath"))
+                                    .color(palette.text_normal),
+                                None,
                             );
-
-                        // ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-                        right_aligned_cell(ui, |ui| {
+                        },
+                        |ui| {
                             if ui
                                 .button(regular::ARROW_COUNTER_CLOCKWISE)
                                 .on_hover_text(i18n.tr("settings_startpath_reset_hover"))
@@ -406,59 +393,100 @@ pub fn draw_settings_window(
                                     action = Some(SettingsAction::ApplySettings);
                                 }
                             }
-                        });
-                    });
+                        },
+                    );
+
+                    let path_text = settings
+                        .current_settings
+                        .start_path
+                        .as_ref()
+                        .map(|p| {
+                            if p.as_os_str() == MY_PC_PATH {
+                                return i18n.tr("settings_startpath_default");
+                            }
+
+                            let s = p.to_string_lossy();
+
+                            if s.len() > 40 {
+                                format!("...{}", &s[s.len() - 40..])
+                            } else {
+                                s.to_string()
+                            }
+                        })
+                        .unwrap_or_else(|| i18n.tr("settings_startpath_default"));
+
+                    ui.allocate_ui_with_layout(
+                        egui::vec2(ui.available_width(), ui.spacing().interact_size.y),
+                        egui::Layout::left_to_right(egui::Align::Center),
+                        |ui| {
+                            ui.add_sized(
+                                [ui.available_width(), ui.spacing().interact_size.y],
+                                egui::Label::new(path_text),
+                            )
+                            .on_hover_text(
+                                settings
+                                    .current_settings
+                                    .start_path
+                                    .as_ref()
+                                    .map(|p| p.to_string_lossy().to_string())
+                                    .unwrap_or_default(),
+                            );
+                        },
+                    );
+
                     ui.add_space(8.0);
                     // Date Style Section
-                    egui::Grid::new("settings_datestyle_row")
-                        .num_columns(2)
-                        .min_col_width(120.0)
-                        .spacing([12.0, 8.0])
-                        .show(ui, |ui| {
-                            ui.with_layout(egui::Layout::left_to_right(egui::Align::LEFT), |ui| {
-                                ui.label(
-                                    RichText::new(i18n.tr("settings_datestyle"))
-                                        .color(palette.text_normal),
-                                );
-                                info_icon(ui, &i18n.tr("tooltip_settings_datestyle"), palette);
-                            });
-                            right_aligned_cell(ui, |ui| {
-                                let mut selected_style = settings.current_settings.date_style;
+                    setting_row(
+                        ui,
+                        |ui| {
+                            setting_label(
+                                ui,
+                                RichText::new(i18n.tr("settings_datestyle"))
+                                    .color(palette.text_normal),
+                                Some((&i18n.tr("tooltip_settings_datestyle"), palette)),
+                            );
+                        },
+                        |ui| {
+                            let mut selected_style = settings.current_settings.date_style;
 
-                                egui::ComboBox::from_id_salt("date_style_selector")
-                                    .width(SETTINGS_COMBO_WIDTH)
-                                    .selected_text(match selected_style {
-                                        DateStyle::Iso => i18n.tr("settings_datestyle_iso_label"),
-                                        DateStyle::UsShort => {
-                                            i18n.tr("settings_datestyle_us_short_label")
-                                        }
-                                        DateStyle::Long => i18n.tr("settings_datestyle_long_label"),
-                                    })
-                                    .show_ui(ui, |ui| {
-                                        ui.selectable_value(
-                                            &mut selected_style,
-                                            DateStyle::Iso,
-                                            i18n.tr("settings_datestyle_iso"),
-                                        );
-                                        ui.selectable_value(
-                                            &mut selected_style,
-                                            DateStyle::UsShort,
-                                            i18n.tr("settings_datestyle_us_short"),
-                                        );
-                                        ui.selectable_value(
-                                            &mut selected_style,
-                                            DateStyle::Long,
-                                            i18n.tr("settings_datestyle_long"),
-                                        );
-                                    });
+                            draw_dropdown(
+                                ui,
+                                palette,
+                                "date_style_selector",
+                                SETTINGS_COMBO_WIDTH,
+                                match selected_style {
+                                    DateStyle::Iso => i18n.tr("settings_datestyle_iso_label"),
+                                    DateStyle::UsShort => {
+                                        i18n.tr("settings_datestyle_us_short_label")
+                                    }
+                                    DateStyle::Long => i18n.tr("settings_datestyle_long_label"),
+                                },
+                                |ui| {
+                                    ui.selectable_value(
+                                        &mut selected_style,
+                                        DateStyle::Iso,
+                                        i18n.tr("settings_datestyle_iso"),
+                                    );
+                                    ui.selectable_value(
+                                        &mut selected_style,
+                                        DateStyle::UsShort,
+                                        i18n.tr("settings_datestyle_us_short"),
+                                    );
+                                    ui.selectable_value(
+                                        &mut selected_style,
+                                        DateStyle::Long,
+                                        i18n.tr("settings_datestyle_long"),
+                                    );
+                                },
+                            );
 
-                                if selected_style != settings.current_settings.date_style {
-                                    settings.current_settings.date_style = selected_style;
-                                    action = Some(SettingsAction::ApplySettings);
-                                }
-                            });
-                            ui.end_row();
-                        });
+                            if selected_style != settings.current_settings.date_style {
+                                settings.current_settings.date_style = selected_style;
+                                action = Some(SettingsAction::ApplySettings);
+                            }
+                        },
+                    );
+
                     ui.add_space(8.0);
                     // Time Format Section
                     ui.horizontal(|ui| {
@@ -477,125 +505,129 @@ pub fn draw_settings_window(
                     ui.add_space(8.0);
                     // Window Size Section
                     let mut window_size_changed = false;
-                    egui::Grid::new("settings_windowsize_row")
-                        .num_columns(2)
-                        .min_col_width(120.0)
-                        .spacing([12.0, 8.0])
-                        .show(ui, |ui| {
-                            ui.label(
+
+                    setting_row(
+                        ui,
+                        |ui| {
+                            setting_label(
+                                ui,
                                 RichText::new(i18n.tr("settings_windowsize"))
                                     .color(palette.text_normal),
+                                None,
                             );
-                            right_aligned_cell(ui, |ui| {
-                                // ui.with_layout(egui::Layout::right_to_left(egui::Align::RIGHT), |ui| {
-                                let is_fullscreen = matches!(
-                                    settings.current_settings.window_size_mode,
-                                    WindowSizeMode::FullScreen
-                                );
+                        },
+                        |ui| {
+                            let is_fullscreen = matches!(
+                                settings.current_settings.window_size_mode,
+                                WindowSizeMode::FullScreen
+                            );
 
-                                if ui
-                                    .button(regular::ARROW_COUNTER_CLOCKWISE)
-                                    .on_hover_text(i18n.tr("settings_windowsize_reset_hover"))
-                                    .clicked()
-                                {
-                                    settings.current_settings.window_size_mode =
-                                        WindowSizeMode::default();
-                                    window_size_changed = true;
-                                }
+                            draw_dropdown(
+                                ui,
+                                palette,
+                                "window_size_mode_selector",
+                                SETTINGS_COMBO_WIDTH,
+                                if is_fullscreen {
+                                    i18n.tr("settings_windowsize_fullscreen")
+                                } else {
+                                    i18n.tr("settings_windowsize_custom")
+                                },
+                                |ui| {
+                                    if ui
+                                        .selectable_label(
+                                            !is_fullscreen,
+                                            i18n.tr("settings_windowsize_custom"),
+                                        )
+                                        .clicked()
+                                        && is_fullscreen
+                                    {
+                                        settings.current_settings.window_size_mode =
+                                            WindowSizeMode::Custom {
+                                                width: 1200.0,
+                                                height: 800.0,
+                                            };
+                                        window_size_changed = true;
+                                    }
 
-                                // ui.add_space(6.0);
+                                    if ui
+                                        .selectable_label(
+                                            is_fullscreen,
+                                            i18n.tr("settings_windowsize_fullscreen"),
+                                        )
+                                        .clicked()
+                                        && !is_fullscreen
+                                    {
+                                        settings.current_settings.window_size_mode =
+                                            WindowSizeMode::FullScreen;
+                                        window_size_changed = true;
+                                    }
+                                },
+                            );
 
-                                egui::ComboBox::from_id_salt("window_size_mode_selector")
-                                    .width(SETTINGS_COMBO_WIDTH)
-                                    .selected_text(if is_fullscreen {
-                                        i18n.tr("settings_windowsize_fullscreen")
-                                    } else {
-                                        i18n.tr("settings_windowsize_custom")
-                                    })
-                                    .show_ui(ui, |ui| {
-                                        if ui
-                                            .selectable_label(
-                                                !is_fullscreen,
-                                                i18n.tr("settings_windowsize_custom"),
-                                            )
-                                            .clicked()
-                                            && is_fullscreen
-                                        {
-                                            settings.current_settings.window_size_mode =
-                                                WindowSizeMode::Custom {
-                                                    width: 1200.0,
-                                                    height: 800.0,
-                                                };
-                                            window_size_changed = true;
-                                        }
-
-                                        if ui
-                                            .selectable_label(
-                                                is_fullscreen,
-                                                i18n.tr("settings_windowsize_fullscreen"),
-                                            )
-                                            .clicked()
-                                            && !is_fullscreen
-                                        {
-                                            settings.current_settings.window_size_mode =
-                                                WindowSizeMode::FullScreen;
-                                            window_size_changed = true;
-                                        }
-                                    });
-                                // });
-                            });
-                            ui.end_row();
-
-                            if let WindowSizeMode::Custom { width, height } =
-                                &mut settings.current_settings.window_size_mode
+                            if ui
+                                .button(regular::ARROW_COUNTER_CLOCKWISE)
+                                .on_hover_text(i18n.tr("settings_windowsize_reset_hover"))
+                                .clicked()
                             {
-                                ui.label(
+                                settings.current_settings.window_size_mode =
+                                    WindowSizeMode::default();
+                                window_size_changed = true;
+                            }
+                        },
+                    );
+
+                    if let WindowSizeMode::Custom { width, height } =
+                        &mut settings.current_settings.window_size_mode
+                    {
+                        setting_row(
+                            ui,
+                            |ui| {
+                                setting_label(
+                                    ui,
                                     RichText::new(i18n.tr("settings_windowsize_width"))
                                         .color(palette.text_normal),
+                                    None,
                                 );
-                                right_aligned_cell(ui, |ui| {
-                                    window_size_changed |= ui
-                                        .add_sized(
-                                            [SETTINGS_VALUE_WIDTH, ui.spacing().interact_size.y],
-                                            egui::DragValue::new(width)
-                                                .range(800.0..=4000.0)
-                                                .speed(1.0),
-                                        )
-                                        .changed();
-                                });
-                                ui.end_row();
+                            },
+                            |ui| {
+                                window_size_changed |= ui
+                                    .add_sized(
+                                        [SETTINGS_VALUE_WIDTH, ui.spacing().interact_size.y],
+                                        egui::DragValue::new(width)
+                                            .range(800.0..=4000.0)
+                                            .speed(1.0),
+                                    )
+                                    .changed();
+                            },
+                        );
 
-                                ui.label(
+                        setting_row(
+                            ui,
+                            |ui| {
+                                setting_label(
+                                    ui,
                                     RichText::new(i18n.tr("settings_windowsize_height"))
                                         .color(palette.text_normal),
+                                    None,
                                 );
-                                right_aligned_cell(ui, |ui| {
-                                    window_size_changed |= ui
-                                        .add_sized(
-                                            [SETTINGS_VALUE_WIDTH, ui.spacing().interact_size.y],
-                                            egui::DragValue::new(height)
-                                                .range(600.0..=3000.0)
-                                                .speed(1.0),
-                                        )
-                                        .changed();
-                                });
-                                ui.end_row();
-                            }
-                        });
-
-                    if window_size_changed {
-                        action = Some(SettingsAction::ApplySettings);
-
-                        let target_size = match &settings.current_settings.window_size_mode {
-                            WindowSizeMode::FullScreen => ctx.input(|i| i.viewport().monitor_size),
-                            WindowSizeMode::Custom { width, height } => {
-                                Some(egui::vec2(*width, *height))
-                            }
-                        };
-                        if let Some(size) = target_size {
-                            ctx.send_viewport_cmd(egui::ViewportCommand::InnerSize(size));
-                        }
+                            },
+                            |ui| {
+                                window_size_changed |= ui
+                                    .add_sized(
+                                        [SETTINGS_VALUE_WIDTH, ui.spacing().interact_size.y],
+                                        egui::DragValue::new(height)
+                                            .range(600.0..=3000.0)
+                                            .speed(1.0),
+                                    )
+                                    .changed();
+                            },
+                        );
                     }
+
+if window_size_changed {
+    action = Some(SettingsAction::ApplySettings);
+}
+
                     ui.add_space(8.0);
                     // Favorites Reset
                     ui.horizontal(|ui| {
@@ -664,22 +696,18 @@ pub fn draw_settings_window(
             }
             ui.separator();
             // Footer
-            egui::Grid::new("settings_footer")
-                .num_columns(2)
-                .min_row_height(ui.spacing().interact_size.y)
-                .spacing([12.0, 0.0])
-                .show(ui, |ui| {
-                    ui.label(i18n.tr("settings_changes_auto_saved"));
-                    right_aligned_cell(ui, |ui| {
-                        if ui
-                            .button(format!("{} {}", regular::X, i18n.tr("close")))
-                            .clicked()
-                        {
-                            should_close = true;
-                        }
-                    });
-                    ui.end_row();
+            ui.horizontal(|ui| {
+                ui.label(i18n.tr("settings_changes_auto_saved"));
+
+                ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                    if ui
+                        .button(format!("{} {}", regular::X, i18n.tr("close")))
+                        .clicked()
+                    {
+                        should_close = true;
+                    }
                 });
+            });
         });
     // Update the open state based on should_close
     if should_close {

--- a/src/gui/windows/settings.rs
+++ b/src/gui/windows/settings.rs
@@ -1,9 +1,10 @@
 use crate::core::{
     fs::{DateStyle, MY_PC_PATH},
     indexer::WindowSizeMode,
+    utils::widgets::draw_checkbox,
 };
 use crate::gui::i18n::I18n;
-use crate::gui::theme::{ThemePalette, apply_checkbox_colors};
+use crate::gui::theme::ThemePalette;
 use crate::gui::utils::SortColumn;
 use crate::gui::windows::enums::SettingsAction;
 use crate::gui::windows::structs::{AppSettings, SettingsWindow};
@@ -11,6 +12,9 @@ use eframe::egui;
 use egui::RichText;
 use egui_phosphor::regular;
 use std::path::PathBuf;
+
+const SETTINGS_COMBO_WIDTH: f32 = 180.0;
+const SETTINGS_VALUE_WIDTH: f32 = 92.0;
 
 impl Default for AppSettings {
     fn default() -> Self {
@@ -64,6 +68,51 @@ fn info_icon(ui: &mut egui::Ui, hover_text: &str, palette: &ThemePalette) -> egu
     }
 
     resp
+}
+
+fn right_aligned_cell<R>(
+    ui: &mut egui::Ui,
+    add_contents: impl FnOnce(&mut egui::Ui) -> R,
+) -> egui::InnerResponse<R> {
+    let row_height = ui.spacing().interact_size.y;
+    let size = egui::vec2(ui.available_width(), row_height);
+    ui.allocate_ui_with_layout(
+        size,
+        egui::Layout::right_to_left(egui::Align::Center),
+        add_contents,
+    )
+}
+
+fn setting_checkbox(
+    ui: &mut egui::Ui,
+    palette: &ThemePalette,
+    checked: &mut bool,
+    label: RichText,
+    id: impl std::hash::Hash,
+) -> bool {
+    let mut changed = false;
+
+    ui.horizontal(|ui| {
+        let checkbox_resp = ui
+            .allocate_ui_with_layout(
+                egui::vec2(16.0, ui.spacing().interact_size.y),
+                egui::Layout::centered_and_justified(egui::Direction::LeftToRight),
+                |ui| draw_checkbox(ui, palette, checked, id),
+            )
+            .inner;
+
+        if checkbox_resp.clicked() {
+            changed = true;
+        }
+
+        let label_resp = ui.add(egui::Label::new(label).sense(egui::Sense::click()));
+        if label_resp.clicked() {
+            *checked = !*checked;
+            changed = true;
+        }
+    });
+
+    changed
 }
 
 pub fn draw_settings_window(
@@ -126,6 +175,7 @@ pub fn draw_settings_window(
                 ),
             ]
             .into();
+            style.override_text_valign = Some(egui::Align::Center);
             ui.set_style(style);
 
             // SCROLLABLE CONTENT
@@ -145,125 +195,127 @@ pub fn draw_settings_window(
                         }
                     });
 
-                    ui.horizontal(|ui| {
-                        ui.label(RichText::new(i18n.tr("language")).color(palette.text_normal));
+                    egui::Grid::new("settings_language_row")
+                        .num_columns(2)
+                        .min_col_width(120.0)
+                        .spacing([12.0, 8.0])
+                        .show(ui, |ui| {
+                            ui.label(RichText::new(i18n.tr("language")).color(palette.text_normal));
 
-                        let mut selected_locale = settings.current_settings.language.clone();
+                            right_aligned_cell(ui, |ui| {
+                                let mut selected_locale =
+                                    settings.current_settings.language.clone();
 
-                        egui::ComboBox::from_id_salt("language_selector")
-                            .selected_text(match selected_locale.as_str() {
-                                "ja-JP" => i18n.tr("japanese"),
-                                "id-ID" => i18n.tr("indonesian"),
-                                "zh-CN" => i18n.tr("chinese_simple"),
-                                "zh-TW" => i18n.tr("chinese_traditional"),
-                                "zh-HK" => i18n.tr("chinese_traditional_hk"),
-                                _ => i18n.tr("english"),
-                            })
-                            .show_ui(ui, |ui| {
-                                if ui
-                                    .selectable_label(
-                                        selected_locale == "en-US",
-                                        i18n.tr("english"),
-                                    )
-                                    .clicked()
-                                {
-                                    selected_locale = "en-US".to_string();
-                                }
+                                egui::ComboBox::from_id_salt("language_selector")
+                                    .width(SETTINGS_COMBO_WIDTH)
+                                    .selected_text(match selected_locale.as_str() {
+                                        "ja-JP" => i18n.tr("japanese"),
+                                        "id-ID" => i18n.tr("indonesian"),
+                                        "zh-CN" => i18n.tr("chinese_simple"),
+                                        "zh-TW" => i18n.tr("chinese_traditional"),
+                                        "zh-HK" => i18n.tr("chinese_traditional_hk"),
+                                        _ => i18n.tr("english"),
+                                    })
+                                    .show_ui(ui, |ui| {
+                                        if ui
+                                            .selectable_label(
+                                                selected_locale == "en-US",
+                                                i18n.tr("english"),
+                                            )
+                                            .clicked()
+                                        {
+                                            selected_locale = "en-US".to_string();
+                                        }
 
-                                if ui
-                                    .selectable_label(
-                                        selected_locale == "ja-JP",
-                                        i18n.tr("japanese"),
-                                    )
-                                    .clicked()
-                                {
-                                    selected_locale = "ja-JP".to_string();
-                                }
+                                        if ui
+                                            .selectable_label(
+                                                selected_locale == "ja-JP",
+                                                i18n.tr("japanese"),
+                                            )
+                                            .clicked()
+                                        {
+                                            selected_locale = "ja-JP".to_string();
+                                        }
 
-                                if ui
-                                    .selectable_label(
-                                        selected_locale == "id-ID",
-                                        i18n.tr("indonesian"),
-                                    )
-                                    .clicked()
-                                {
-                                    selected_locale = "id-ID".to_string();
-                                }
+                                        if ui
+                                            .selectable_label(
+                                                selected_locale == "id-ID",
+                                                i18n.tr("indonesian"),
+                                            )
+                                            .clicked()
+                                        {
+                                            selected_locale = "id-ID".to_string();
+                                        }
 
-                                if ui
-                                    .selectable_label(
-                                        selected_locale == "zh-CN",
-                                        i18n.tr("chinese_simple"),
-                                    )
-                                    .clicked()
-                                {
-                                    selected_locale = "zh-CN".to_string();
-                                }
+                                        if ui
+                                            .selectable_label(
+                                                selected_locale == "zh-CN",
+                                                i18n.tr("chinese_simple"),
+                                            )
+                                            .clicked()
+                                        {
+                                            selected_locale = "zh-CN".to_string();
+                                        }
 
-                                if ui
-                                    .selectable_label(
-                                        selected_locale == "zh-TW",
-                                        i18n.tr("chinese_traditional"),
-                                    )
-                                    .clicked()
-                                {
-                                    selected_locale = "zh-TW".to_string();
-                                }
+                                        if ui
+                                            .selectable_label(
+                                                selected_locale == "zh-TW",
+                                                i18n.tr("chinese_traditional"),
+                                            )
+                                            .clicked()
+                                        {
+                                            selected_locale = "zh-TW".to_string();
+                                        }
 
-                                if ui
-                                    .selectable_label(
-                                        selected_locale == "zh-HK",
-                                        i18n.tr("chinese_traditional_hk"),
-                                    )
-                                    .clicked()
-                                {
-                                    selected_locale = "zh-HK".to_string();
+                                        if ui
+                                            .selectable_label(
+                                                selected_locale == "zh-HK",
+                                                i18n.tr("chinese_traditional_hk"),
+                                            )
+                                            .clicked()
+                                        {
+                                            selected_locale = "zh-HK".to_string();
+                                        }
+                                    });
+
+                                if selected_locale != settings.current_settings.language {
+                                    i18n.set_locale(&selected_locale);
+                                    settings.current_settings.language = selected_locale;
+                                    action = Some(SettingsAction::ApplySettings);
                                 }
                             });
-
-                        // Check if language changed and update both i18n and settings
-                        if selected_locale != settings.current_settings.language {
-                            i18n.set_locale(&selected_locale);
-                            settings.current_settings.language = selected_locale;
-                            action = Some(SettingsAction::ApplySettings);
-                        }
-                    });
+                            ui.end_row();
+                        });
 
                     // Folder Scanning
                     ui.horizontal(|ui| {
-                        ui.scope(|ui| {
-                            apply_checkbox_colors(ui, palette, false);
-                            if ui
-                                .checkbox(
-                                    &mut settings.current_settings.folder_scanning_enabled,
-                                    RichText::new(&i18n.tr("settings_folderscanning"))
-                                        .color(palette.text_normal),
-                                )
-                                .changed()
-                            {
-                                // Auto-save when setting changes
-                                action = Some(SettingsAction::ApplySettings);
-                            }
-                        });
+                        if setting_checkbox(
+                            ui,
+                            palette,
+                            &mut settings.current_settings.folder_scanning_enabled,
+                            RichText::new(&i18n.tr("settings_folderscanning"))
+                                .color(palette.text_normal),
+                            "settings_folderscanning",
+                        ) {
+                            // Auto-save when setting changes
+                            action = Some(SettingsAction::ApplySettings);
+                        }
                         info_icon(ui, &i18n.tr("tooltip_settings_folderscanning"), palette);
                     });
                     ui.add_space(8.0);
                     // Hidden Files/Folders
                     ui.horizontal(|ui| {
-                        ui.scope(|ui| {
-                            apply_checkbox_colors(ui, palette, false);
-                            if ui
-                                .checkbox(
-                                    &mut settings.current_settings.show_hidden_files_folders,
-                                    RichText::new(&i18n.tr("settings_show_hidden_files_folders"))
-                                        .color(palette.text_normal),
-                                )
-                                .changed()
-                            {
-                                // Auto-save when setting changes
-                                action = Some(SettingsAction::ApplySettings);
-                            }
-                        });
+                        if setting_checkbox(
+                            ui,
+                            palette,
+                            &mut settings.current_settings.show_hidden_files_folders,
+                            RichText::new(&i18n.tr("settings_show_hidden_files_folders"))
+                                .color(palette.text_normal),
+                            "settings_show_hidden_files_folders",
+                        ) {
+                            // Auto-save when setting changes
+                            action = Some(SettingsAction::ApplySettings);
+                        }
                         info_icon(
                             ui,
                             &i18n.tr("tooltip_settings_show_hidden_files_folders"),
@@ -273,20 +325,31 @@ pub fn draw_settings_window(
                     ui.add_space(8.0);
                     // Show/Hide Item Viewer File Icons
                     ui.horizontal(|ui| {
-                        ui.scope(|ui| {
-                            apply_checkbox_colors(ui, palette, false);
-                            if ui
-                                .checkbox(
-                                    &mut settings.current_settings.show_item_viewer_icons,
-                                    RichText::new(&i18n.tr("settings_show_item_viewer_file_icons"))
-                                        .color(palette.text_normal),
-                                )
-                                .changed()
-                            {
-                                // Auto-save when setting changes
-                                action = Some(SettingsAction::ApplySettings);
-                            }
-                        });
+                        if setting_checkbox(
+                            ui,
+                            palette,
+                            &mut settings.current_settings.show_item_viewer_icons,
+                            RichText::new(&i18n.tr("settings_show_item_viewer_file_icons"))
+                                .color(palette.text_normal),
+                            "settings_show_item_viewer_file_icons",
+                        ) {
+                            // Auto-save when setting changes
+                            action = Some(SettingsAction::ApplySettings);
+                        }
+                    });
+                    ui.add_space(8.0);
+                    ui.horizontal(|ui| {
+                        if setting_checkbox(
+                            ui,
+                            palette,
+                            &mut settings.current_settings.windows_context_menu_enabled,
+                            RichText::new(&i18n.tr("settings_contextmenu_enable"))
+                                .color(palette.text_normal),
+                            "settings_contextmenu_enable",
+                        ) {
+                            action = Some(SettingsAction::ApplySettings);
+                        }
+                        info_icon(ui, &i18n.tr("tooltip_settings_contextmenu"), palette);
                     });
                     ui.add_space(8.0);
                     // Starting Path
@@ -321,7 +384,8 @@ pub fn draw_settings_window(
                                     .unwrap_or_default(),
                             );
 
-                        ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                        // ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                        right_aligned_cell(ui, |ui| {
                             if ui
                                 .button(regular::ARROW_COUNTER_CLOCKWISE)
                                 .on_hover_text(i18n.tr("settings_startpath_reset_hover"))
@@ -346,150 +410,178 @@ pub fn draw_settings_window(
                     });
                     ui.add_space(8.0);
                     // Date Style Section
-                    ui.horizontal(|ui| {
-                        ui.label(
-                            RichText::new(i18n.tr("settings_datestyle")).color(palette.text_normal),
-                        );
-
-                        let mut selected_style = settings.current_settings.date_style;
-
-                        egui::ComboBox::from_id_salt("date_style_selector")
-                            .selected_text(match selected_style {
-                                DateStyle::Iso => i18n.tr("settings_datestyle_iso_label"),
-                                DateStyle::UsShort => i18n.tr("settings_datestyle_us_short_label"),
-                                DateStyle::Long => i18n.tr("settings_datestyle_long_label"),
-                            })
-                            .show_ui(ui, |ui| {
-                                ui.selectable_value(
-                                    &mut selected_style,
-                                    DateStyle::Iso,
-                                    i18n.tr("settings_datestyle_iso"),
+                    egui::Grid::new("settings_datestyle_row")
+                        .num_columns(2)
+                        .min_col_width(120.0)
+                        .spacing([12.0, 8.0])
+                        .show(ui, |ui| {
+                            ui.with_layout(egui::Layout::left_to_right(egui::Align::LEFT), |ui| {
+                                ui.label(
+                                    RichText::new(i18n.tr("settings_datestyle"))
+                                        .color(palette.text_normal),
                                 );
-                                ui.selectable_value(
-                                    &mut selected_style,
-                                    DateStyle::UsShort,
-                                    i18n.tr("settings_datestyle_us_short"),
-                                );
-                                ui.selectable_value(
-                                    &mut selected_style,
-                                    DateStyle::Long,
-                                    i18n.tr("settings_datestyle_long"),
-                                );
+                                info_icon(ui, &i18n.tr("tooltip_settings_datestyle"), palette);
                             });
+                            right_aligned_cell(ui, |ui| {
+                                let mut selected_style = settings.current_settings.date_style;
 
-                        if selected_style != settings.current_settings.date_style {
-                            settings.current_settings.date_style = selected_style;
-                            action = Some(SettingsAction::ApplySettings);
-                        }
+                                egui::ComboBox::from_id_salt("date_style_selector")
+                                    .width(SETTINGS_COMBO_WIDTH)
+                                    .selected_text(match selected_style {
+                                        DateStyle::Iso => i18n.tr("settings_datestyle_iso_label"),
+                                        DateStyle::UsShort => {
+                                            i18n.tr("settings_datestyle_us_short_label")
+                                        }
+                                        DateStyle::Long => i18n.tr("settings_datestyle_long_label"),
+                                    })
+                                    .show_ui(ui, |ui| {
+                                        ui.selectable_value(
+                                            &mut selected_style,
+                                            DateStyle::Iso,
+                                            i18n.tr("settings_datestyle_iso"),
+                                        );
+                                        ui.selectable_value(
+                                            &mut selected_style,
+                                            DateStyle::UsShort,
+                                            i18n.tr("settings_datestyle_us_short"),
+                                        );
+                                        ui.selectable_value(
+                                            &mut selected_style,
+                                            DateStyle::Long,
+                                            i18n.tr("settings_datestyle_long"),
+                                        );
+                                    });
 
-                        info_icon(ui, &i18n.tr("tooltip_settings_datestyle"), palette);
-                    });
+                                if selected_style != settings.current_settings.date_style {
+                                    settings.current_settings.date_style = selected_style;
+                                    action = Some(SettingsAction::ApplySettings);
+                                }
+                            });
+                            ui.end_row();
+                        });
                     ui.add_space(8.0);
                     // Time Format Section
                     ui.horizontal(|ui| {
-                        ui.scope(|ui| {
-                            apply_checkbox_colors(ui, palette, false);
-                            if ui
-                                .checkbox(
-                                    &mut settings.current_settings.time_format_24h,
-                                    RichText::new(i18n.tr("settings_timeformat_24h"))
-                                        .color(palette.text_normal),
-                                )
-                                .changed()
-                            {
-                                action = Some(SettingsAction::ApplySettings);
-                            }
-                        });
+                        if setting_checkbox(
+                            ui,
+                            palette,
+                            &mut settings.current_settings.time_format_24h,
+                            RichText::new(i18n.tr("settings_timeformat_24h"))
+                                .color(palette.text_normal),
+                            "settings_timeformat_24h",
+                        ) {
+                            action = Some(SettingsAction::ApplySettings);
+                        }
                         info_icon(ui, &i18n.tr("tooltip_settings_timeformat"), palette);
                     });
                     ui.add_space(8.0);
                     // Window Size Section
                     let mut window_size_changed = false;
-                    ui.horizontal(|ui| {
-                        ui.label(
-                            RichText::new(i18n.tr("settings_windowsize"))
-                                .color(palette.text_normal),
-                        );
-                        info_icon(ui, &i18n.tr("tooltip_settings_windowsize"), palette);
-                    });
-                    ui.horizontal(|ui| {
-                        let is_fullscreen = matches!(
-                            settings.current_settings.window_size_mode,
-                            WindowSizeMode::FullScreen
-                        );
+                    egui::Grid::new("settings_windowsize_row")
+                        .num_columns(2)
+                        .min_col_width(120.0)
+                        .spacing([12.0, 8.0])
+                        .show(ui, |ui| {
+                            ui.label(
+                                RichText::new(i18n.tr("settings_windowsize"))
+                                    .color(palette.text_normal),
+                            );
+                            right_aligned_cell(ui, |ui| {
+                                // ui.with_layout(egui::Layout::right_to_left(egui::Align::RIGHT), |ui| {
+                                let is_fullscreen = matches!(
+                                    settings.current_settings.window_size_mode,
+                                    WindowSizeMode::FullScreen
+                                );
 
-                        egui::ComboBox::from_id_salt("window_size_mode_selector")
-                            .selected_text(if is_fullscreen {
-                                i18n.tr("settings_windowsize_fullscreen")
-                            } else {
-                                i18n.tr("settings_windowsize_custom")
-                            })
-                            .show_ui(ui, |ui| {
                                 if ui
-                                    .selectable_label(
-                                        !is_fullscreen,
-                                        i18n.tr("settings_windowsize_custom"),
-                                    )
+                                    .button(regular::ARROW_COUNTER_CLOCKWISE)
+                                    .on_hover_text(i18n.tr("settings_windowsize_reset_hover"))
                                     .clicked()
-                                    && is_fullscreen
                                 {
                                     settings.current_settings.window_size_mode =
-                                        WindowSizeMode::Custom {
-                                            width: 1200.0,
-                                            height: 800.0,
-                                        };
+                                        WindowSizeMode::default();
                                     window_size_changed = true;
                                 }
 
-                                if ui
-                                    .selectable_label(
-                                        is_fullscreen,
-                                        i18n.tr("settings_windowsize_fullscreen"),
-                                    )
-                                    .clicked()
-                                    && !is_fullscreen
-                                {
-                                    settings.current_settings.window_size_mode =
-                                        WindowSizeMode::FullScreen;
-                                    window_size_changed = true;
-                                }
+                                // ui.add_space(6.0);
+
+                                egui::ComboBox::from_id_salt("window_size_mode_selector")
+                                    .width(SETTINGS_COMBO_WIDTH)
+                                    .selected_text(if is_fullscreen {
+                                        i18n.tr("settings_windowsize_fullscreen")
+                                    } else {
+                                        i18n.tr("settings_windowsize_custom")
+                                    })
+                                    .show_ui(ui, |ui| {
+                                        if ui
+                                            .selectable_label(
+                                                !is_fullscreen,
+                                                i18n.tr("settings_windowsize_custom"),
+                                            )
+                                            .clicked()
+                                            && is_fullscreen
+                                        {
+                                            settings.current_settings.window_size_mode =
+                                                WindowSizeMode::Custom {
+                                                    width: 1200.0,
+                                                    height: 800.0,
+                                                };
+                                            window_size_changed = true;
+                                        }
+
+                                        if ui
+                                            .selectable_label(
+                                                is_fullscreen,
+                                                i18n.tr("settings_windowsize_fullscreen"),
+                                            )
+                                            .clicked()
+                                            && !is_fullscreen
+                                        {
+                                            settings.current_settings.window_size_mode =
+                                                WindowSizeMode::FullScreen;
+                                            window_size_changed = true;
+                                        }
+                                    });
+                                // });
                             });
+                            ui.end_row();
 
-                        if ui
-                            .button(regular::ARROW_COUNTER_CLOCKWISE)
-                            .on_hover_text(i18n.tr("settings_windowsize_reset_hover"))
-                            .clicked()
-                        {
-                            settings.current_settings.window_size_mode = WindowSizeMode::default();
-                            window_size_changed = true;
-                        }
-                    });
+                            if let WindowSizeMode::Custom { width, height } =
+                                &mut settings.current_settings.window_size_mode
+                            {
+                                ui.label(
+                                    RichText::new(i18n.tr("settings_windowsize_width"))
+                                        .color(palette.text_normal),
+                                );
+                                right_aligned_cell(ui, |ui| {
+                                    window_size_changed |= ui
+                                        .add_sized(
+                                            [SETTINGS_VALUE_WIDTH, ui.spacing().interact_size.y],
+                                            egui::DragValue::new(width)
+                                                .range(800.0..=4000.0)
+                                                .speed(1.0),
+                                        )
+                                        .changed();
+                                });
+                                ui.end_row();
 
-                    if let WindowSizeMode::Custom { width, height } =
-                        &mut settings.current_settings.window_size_mode
-                    {
-                        ui.horizontal(|ui| {
-                            ui.label(
-                                RichText::new(i18n.tr("settings_windowsize_width"))
-                                    .color(palette.text_normal),
-                            );
-                            window_size_changed |= ui
-                                .add(egui::DragValue::new(width).range(800.0..=4000.0).speed(1.0))
-                                .changed();
-
-                            ui.label(
-                                RichText::new(i18n.tr("settings_windowsize_height"))
-                                    .color(palette.text_normal),
-                            );
-                            window_size_changed |= ui
-                                .add(
-                                    egui::DragValue::new(height)
-                                        .range(600.0..=3000.0)
-                                        .speed(1.0),
-                                )
-                                .changed();
+                                ui.label(
+                                    RichText::new(i18n.tr("settings_windowsize_height"))
+                                        .color(palette.text_normal),
+                                );
+                                right_aligned_cell(ui, |ui| {
+                                    window_size_changed |= ui
+                                        .add_sized(
+                                            [SETTINGS_VALUE_WIDTH, ui.spacing().interact_size.y],
+                                            egui::DragValue::new(height)
+                                                .range(600.0..=3000.0)
+                                                .speed(1.0),
+                                        )
+                                        .changed();
+                                });
+                                ui.end_row();
+                            }
                         });
-                    }
 
                     if window_size_changed {
                         action = Some(SettingsAction::ApplySettings);
@@ -504,26 +596,6 @@ pub fn draw_settings_window(
                             ctx.send_viewport_cmd(egui::ViewportCommand::InnerSize(size));
                         }
                     }
-                    ui.add_space(8.0);
-                    // Context Menu Section
-                    ui.heading(i18n.tr("settings_contextmenu"));
-                    ui.add_space(8.0);
-                    ui.horizontal(|ui| {
-                        ui.scope(|ui| {
-                            apply_checkbox_colors(ui, palette, false);
-                            if ui
-                                .checkbox(
-                                    &mut settings.current_settings.windows_context_menu_enabled,
-                                    RichText::new(&i18n.tr("settings_contextmenu_enable"))
-                                        .color(palette.text_normal),
-                                )
-                                .changed()
-                            {
-                                action = Some(SettingsAction::ApplySettings);
-                            }
-                        });
-                        info_icon(ui, &i18n.tr("tooltip_settings_contextmenu"), palette);
-                    });
                     ui.add_space(8.0);
                     // Favorites Reset
                     ui.horizontal(|ui| {
@@ -592,17 +664,22 @@ pub fn draw_settings_window(
             }
             ui.separator();
             // Footer
-            ui.horizontal(|ui| {
-                ui.label(i18n.tr("settings_changes_auto_saved"));
-                ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-                    if ui
-                        .button(format!("{} {}", regular::X, i18n.tr("close")))
-                        .clicked()
-                    {
-                        should_close = true;
-                    }
+            egui::Grid::new("settings_footer")
+                .num_columns(2)
+                .min_row_height(ui.spacing().interact_size.y)
+                .spacing([12.0, 0.0])
+                .show(ui, |ui| {
+                    ui.label(i18n.tr("settings_changes_auto_saved"));
+                    right_aligned_cell(ui, |ui| {
+                        if ui
+                            .button(format!("{} {}", regular::X, i18n.tr("close")))
+                            .clicked()
+                        {
+                            should_close = true;
+                        }
+                    });
+                    ui.end_row();
                 });
-            });
         });
     // Update the open state based on should_close
     if should_close {

--- a/src/gui/windows/settings.rs
+++ b/src/gui/windows/settings.rs
@@ -624,9 +624,9 @@ pub fn draw_settings_window(
                         );
                     }
 
-if window_size_changed {
-    action = Some(SettingsAction::ApplySettings);
-}
+                    if window_size_changed {
+                        action = Some(SettingsAction::ApplySettings);
+                    }
 
                     ui.add_space(8.0);
                     // Favorites Reset

--- a/src/gui/windows/windowsoverrides.rs
+++ b/src/gui/windows/windowsoverrides.rs
@@ -79,14 +79,6 @@ fn save_manual_window_size(hwnd: HWND) {
             ..Default::default()
         };
 
-        if GetWindowPlacement(hwnd, &mut placement).is_ok() {
-            if placement.showCmd == SW_SHOWMAXIMIZED.0 as u32
-                || placement.showCmd == SW_SHOWMINIMIZED.0 as u32
-            {
-                return;
-            }
-        }
-
         let mut rect = RECT::default();
         if GetClientRect(hwnd, &mut rect).is_err() {
             return;
@@ -424,5 +416,53 @@ pub fn get_hwnd_from_frame(frame: &eframe::Frame) -> Option<HWND> {
             }
         }
         _ => None,
+    }
+}
+
+fn resize_and_center_window(hwnd: HWND, width: i32, height: i32) {
+    unsafe {
+        let monitor = MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST);
+
+        if monitor.is_invalid() {
+            return;
+        }
+
+        let mut monitor_info = MONITORINFO {
+            cbSize: std::mem::size_of::<MONITORINFO>() as u32,
+            ..Default::default()
+        };
+
+        if !GetMonitorInfoW(monitor, &mut monitor_info).as_bool() {
+            return;
+        }
+
+        let work = monitor_info.rcWork;
+
+        let x = work.left + ((work.right - work.left) - width) / 2;
+        let y = work.top + ((work.bottom - work.top) - height) / 2;
+
+        let _ = ShowWindow(hwnd, SW_RESTORE);
+
+        let _ = SetWindowPos(
+            hwnd,
+            None,
+            x,
+            y,
+            width,
+            height,
+            SWP_NOZORDER | SWP_NOACTIVATE,
+        );
+    }
+}
+
+pub fn set_window_mode(hwnd: HWND, mode: &WindowSizeMode) {
+    match mode {
+        WindowSizeMode::FullScreen => unsafe {
+            let _ = ShowWindow(hwnd, SW_MAXIMIZE);
+        },
+
+        WindowSizeMode::Custom { width, height } => {
+            resize_and_center_window(hwnd, width.round() as i32, height.round() as i32);
+        }
     }
 }


### PR DESCRIPTION
## 🔄 What's Changed

- Settings UI has been updated to look cleaner and more aligned
- The Windows submenu now appears on the right-hand side in traditional format
- Replaced the usage of egui checkboxs with our EdenExplorer checkbox implementation
- All egui dropdowns are now styled and respect the palette

## What's Fixed

- Sidebar context menu now uses the new EdenExplorer context menu styling
- Label and dropdown vertical centering alignment
- Window Size changes to full screen caused issues


## Screenshots
<img width="500" height="428" alt="image" src="https://github.com/user-attachments/assets/5c5352a7-7ec9-402d-a1dc-05c02d897f9a" />
<img width="413" height="497" alt="image" src="https://github.com/user-attachments/assets/6bd502c1-3131-44dc-9256-bd9ac61ac30f" />
