### PR TITLE
feat: add more keyboard and mouse shortcuts and terminal button

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "EdenExplorer"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "bincode",
  "chrono",

--- a/README.md
+++ b/README.md
@@ -272,6 +272,7 @@
 - [x] Support changing the application font based on the system-installed fonts
 - [x] Collapsible sidebar
 - [x] Split-pane view in the Explorer
+- [x] Explorer view displays objects that have tags applied to them based on the tag color 
 
 ### 🚀 Upcoming Beta Features
 - [ ] New Explorer view that displays pictures in medium/large format
@@ -292,6 +293,26 @@
    <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=mtucciarone/EdenExplorer&type=date&legend=top-left&sealed_token=Vc9gAQ1EyNnsDshDmlm_VHBAb2pSnvtzPSk4Ip2omG5jagl9CGXy2C8L95S9d_GkLvTh49MUH8vx6A9y7hEGpgJ4x0tv0ZgDqqVAqJs9nxm3Ys_3F1PHK1jpm4v1UHK5yrZ4AJjo99PRtk7JQZV_08P0z5gCxq5EiNnz-YWNQRqeY4nGJyDwhqH5mCqT" />
  </picture>
 </a>
+
+## Keyboard Shortcuts
+F1 - Toggle fullscreen
+Ctrl+Shift+C - Copy selected path
+Ctrl+W - Close current Tab
+Ctrl+T - New Tab
+Ctrl+Tab - Next Tab
+Ctrl+Shift+Tab - Previous Tab
+Ctrl+Shift+N - Create new folder in current directory
+Ctrl+R (F5) - Refresh current directory
+Alt+D - select the address bar / current directory path
+F2 - rename current selected file (if any is selected inside the explorer)
+Alt-Enter - open current properties of current selected file  (if any is selected inside the explorer)
+Home/End - scroll to the top or bottom of the current explorer directory and select the first/last object
+Alt + Left Arrow - goes back to the previous folder
+Alt + Right Arrow - goes forward
+Alt + Up Arrow - moves up one folder level
+Backspace - also navigates back
+Back/Forward mouse buttons (Mouse Button 4 and Mouse Button 5)
+Enter - If a file is selected, runs the default program
 
 ## License
 This project is FOSS, released under the MIT License.

--- a/locales/en-US/main.ftl
+++ b/locales/en-US/main.ftl
@@ -14,6 +14,7 @@ tooltip_newfolder = Create new folder
 tooltip_newfile = Create new file
 tooltip_favorites_add = Add current directory to favorites
 tooltip_favorites_remove = Remove current directory from favorites
+tooltip_open_terminal = Open terminal in current directory
 tooltip_nav_up = Navigate to parent directory
 tooltip_nav_back = Navigate to previous directory
 tooltip_nav_forward = Navigate to next directory

--- a/locales/id-ID/main.ftl
+++ b/locales/id-ID/main.ftl
@@ -14,6 +14,7 @@ tooltip_newfolder = Buat folder baru
 tooltip_newfile = Buat file baru
 tooltip_favorites_add = Tambahkan direktori saat ini ke favorit
 tooltip_favorites_remove = Hapus direktori saat ini dari favorit
+tooltip_open_terminal = Buka terminal di direktori saat ini
 tooltip_nav_up = Navigasi ke direktori induk
 tooltip_nav_back = Kembali ke direktori sebelumnya
 tooltip_nav_forward = Maju ke direktori berikutnya

--- a/locales/ja-JP/main.ftl
+++ b/locales/ja-JP/main.ftl
@@ -14,6 +14,7 @@ tooltip_newfolder = 新しいフォルダーを作成
 tooltip_newfile = 新しいファイルを作成
 tooltip_favorites_add = 現在のディレクトリをお気に入りに追加
 tooltip_favorites_remove = 現在のディレクトリをお気に入りから削除
+tooltip_open_terminal = 現在のディレクトリでターミナルを開く
 tooltip_nav_up = 親ディレクトリへ移動
 tooltip_nav_back = 前のディレクトリへ戻る
 tooltip_nav_forward = 次のディレクトリへ進む

--- a/locales/zh-CN/main.ftl
+++ b/locales/zh-CN/main.ftl
@@ -14,6 +14,7 @@ tooltip_newfolder = 创建新文件夹
 tooltip_newfile = 创建新文件
 tooltip_favorites_add = 将当前目录添加到收藏夹
 tooltip_favorites_remove = 从收藏夹中移除当前目录
+tooltip_open_terminal = 在当前目录中打开终端
 tooltip_nav_up = 导航到上级目录
 tooltip_nav_back = 返回上一个目录
 tooltip_nav_forward = 前往下一个目录

--- a/locales/zh-HK/main.ftl
+++ b/locales/zh-HK/main.ftl
@@ -14,6 +14,7 @@ tooltip_newfolder = 建立新資料夾
 tooltip_newfile = 建立新檔案
 tooltip_favorites_add = 將目前目錄加入我的最愛
 tooltip_favorites_remove = 從我的最愛移除目前目錄
+tooltip_open_terminal = 在目前目錄中開啟終端機
 tooltip_nav_up = 前往上層目錄
 tooltip_nav_back = 返回上一個目錄
 tooltip_nav_forward = 前往下一個目錄

--- a/locales/zh-TW/main.ftl
+++ b/locales/zh-TW/main.ftl
@@ -14,6 +14,7 @@ tooltip_newfolder = 建立新資料夾
 tooltip_newfile = 建立新檔案
 tooltip_favorites_add = 將目前目錄加入我的最愛
 tooltip_favorites_remove = 從我的最愛移除目前目錄
+tooltip_open_terminal = 在目前目錄中開啟終端機
 tooltip_nav_up = 前往上層目錄
 tooltip_nav_back = 返回上一個目錄
 tooltip_nav_forward = 前往下一個目錄

--- a/src/gui/windows/containers/itemviewer.rs
+++ b/src/gui/windows/containers/itemviewer.rs
@@ -171,9 +171,12 @@ pub fn draw_item_viewer(
 
     if !visible_items_empty {
         let modifiers = ui.ctx().input(|i| i.modifiers);
-        let arrow_nav = ui
-            .ctx()
-            .input(|i| i.key_pressed(egui::Key::ArrowDown) || i.key_pressed(egui::Key::ArrowUp));
+        let arrow_nav = ui.ctx().input(|i| {
+            i.key_pressed(egui::Key::ArrowDown)
+                || i.key_pressed(egui::Key::ArrowUp)
+                || i.key_pressed(egui::Key::Home)
+                || i.key_pressed(egui::Key::End)
+        });
         let current_width = ui.available_width();
         let available_height = ui.available_height();
 
@@ -320,6 +323,7 @@ pub fn draw_item_viewer(
                     let is_non_ntfs_drive =
                         layout.is_drive_view && is_raw_physical_drive_path(&file.path);
                     let is_selected = explorer_state.selected_paths.contains(&file.path);
+                    let tag_color = tags_state.tag_color_for_path(&file.path);
                     row.set_selected(is_selected);
                     let is_cut = is_cut_mode && clipboard_set.contains(&file.path);
 
@@ -411,6 +415,19 @@ pub fn draw_item_viewer(
                     }
 
                     let row_resp = row.response();
+
+                    if let Some(tag_color) = tag_color {
+                        let tag_rect = egui::Rect::from_min_size(
+                            row_resp.rect.min,
+                            egui::vec2(row_resp.rect.width(), layout.row_height),
+                        )
+                        .shrink2(egui::vec2(0.0, 1.0));
+                        let painter = row_resp.ctx.layer_painter(egui::LayerId::new(
+                            egui::Order::Background,
+                            egui::Id::new(("tag_row_bg", active_tab_id, &file.path)),
+                        ));
+                        painter.rect_filled(tag_rect, egui::CornerRadius::same(palette.medium_radius), tag_color.linear_multiply(0.18));
+                    }
 
                     if drag_hover_active {
                         if let Some(target) = hovered_target_ref {

--- a/src/gui/windows/containers/itemviewer_helper.rs
+++ b/src/gui/windows/containers/itemviewer_helper.rs
@@ -12,7 +12,9 @@ use crate::gui::utils::{
     SortColumn, clear_clipboard_files, drive_usage_bar, format_size, get_file_type_name,
     truncate_item_text,
 };
-use crate::gui::windows::containers::enums::{ItemViewerAction, ItemViewerContextAction};
+use crate::gui::windows::containers::enums::{
+    ItemViewerAction, ItemViewerContextAction, ItemViewerNavAction,
+};
 use crate::gui::windows::containers::itemviewer::draw_item_viewer;
 use crate::gui::windows::containers::structs::{
     DragState, ExplorerState, FilterState, ItemViewerFolderSizeState, ItemViewerLayout,
@@ -795,6 +797,17 @@ pub fn handle_global_actions(
         drag_state.start_pos = None;
     }
 
+    let mut set_nav_action = |nav: ItemViewerNavAction| {
+        if let Some(existing) = tabbar_action.as_mut() {
+            existing.nav = Some(nav);
+        } else {
+            *tabbar_action = Some(ItemViewerNavBarAction {
+                nav: Some(nav),
+                ..Default::default()
+            });
+        }
+    };
+
     if filter_state.active {
         let cancel = ui.input(|i| i.key_pressed(egui::Key::Escape));
 
@@ -871,10 +884,24 @@ pub fn handle_global_actions(
         }
     });
     ui.input(|i| {
-        if i.key_pressed(egui::Key::Backspace) {
-            action = Some(ItemViewerAction::BackNavigation);
+        let alt = i.modifiers.alt;
+
+        if i.pointer.button_pressed(egui::PointerButton::Extra1)
+            || (alt && i.key_pressed(egui::Key::ArrowLeft))
+            || i.key_pressed(egui::Key::Backspace)
+        {
+            set_nav_action(ItemViewerNavAction::Back);
         }
-        if i.key_pressed(egui::Key::Enter) {
+        if i.pointer.button_pressed(egui::PointerButton::Extra2)
+            || (alt && i.key_pressed(egui::Key::ArrowRight))
+        {
+            set_nav_action(ItemViewerNavAction::Forward);
+        }
+        if alt && i.key_pressed(egui::Key::ArrowUp) {
+            set_nav_action(ItemViewerNavAction::Up);
+        }
+
+        if !alt && i.key_pressed(egui::Key::Enter) {
             let selected_paths: Vec<PathBuf> = explorer_state
                 .selected_paths
                 .iter()
@@ -933,7 +960,7 @@ pub fn handle_global_actions(
     let mut start_filter = String::new();
 
     ui.input(|i| {
-        if i.modifiers.command || i.modifiers.ctrl {
+        if i.modifiers.command || i.modifiers.ctrl || i.modifiers.alt {
             return;
         }
         for event in &i.events {
@@ -1178,7 +1205,16 @@ pub fn handle_keyboard_navigation(
         }
     };
 
+    let first_selectable = || (0..filtered_indices.len()).find(|&i| is_selectable(i));
+    let last_selectable = || {
+        (0..filtered_indices.len())
+            .rev()
+            .find(|&i| is_selectable(i))
+    };
+
     let mut action: Option<ItemViewerAction> = None;
+    let home_pressed = ctx.input(|i| i.key_pressed(egui::Key::Home));
+    let end_pressed = ctx.input(|i| i.key_pressed(egui::Key::End));
 
     let current_index = explorer_state
         .selected_paths
@@ -1193,8 +1229,28 @@ pub fn handle_keyboard_navigation(
     let current_idx = match current_index {
         Some(idx) => idx,
         None => {
+            if home_pressed {
+                let first_idx = first_selectable()?;
+                let first = files[filtered_indices[first_idx]].path.clone();
+
+                explorer_state.selection_anchor = Some(first_idx);
+                explorer_state.selection_focus = Some(first_idx);
+
+                return Some(ItemViewerAction::ReplaceSelection(first));
+            }
+
+            if end_pressed {
+                let last_idx = last_selectable()?;
+                let last = files[filtered_indices[last_idx]].path.clone();
+
+                explorer_state.selection_anchor = Some(last_idx);
+                explorer_state.selection_focus = Some(last_idx);
+
+                return Some(ItemViewerAction::ReplaceSelection(last));
+            }
+
             if ctx.input(|i| i.key_pressed(egui::Key::ArrowDown)) {
-                let first_idx = (0..filtered_indices.len()).find(|&i| is_selectable(i))?;
+                let first_idx = first_selectable()?;
                 let first = files[filtered_indices[first_idx]].path.clone();
 
                 explorer_state.selection_anchor = Some(first_idx);
@@ -1204,9 +1260,7 @@ pub fn handle_keyboard_navigation(
             }
 
             if ctx.input(|i| i.key_pressed(egui::Key::ArrowUp)) {
-                let last_idx = (0..filtered_indices.len())
-                    .rev()
-                    .find(|&i| is_selectable(i))?;
+                let last_idx = last_selectable()?;
                 let last = files[filtered_indices[last_idx]].path.clone();
 
                 explorer_state.selection_anchor = Some(last_idx);
@@ -1249,6 +1303,18 @@ pub fn handle_keyboard_navigation(
             }
         }
 
+        if home_pressed {
+            if let Some(first) = first_selectable() {
+                new_focus = first;
+            }
+        }
+
+        if end_pressed {
+            if let Some(last) = last_selectable() {
+                new_focus = last;
+            }
+        }
+
         explorer_state.selection_anchor = Some(anchor);
         explorer_state.selection_focus = Some(new_focus);
 
@@ -1283,6 +1349,14 @@ pub fn handle_keyboard_navigation(
             if let Some(prev) = next_selectable(current_idx, -1) {
                 new_idx = prev;
             }
+        }
+
+        if home_pressed && let Some(first) = first_selectable() {
+            new_idx = first;
+        }
+
+        if end_pressed && let Some(last) = last_selectable() {
+            new_idx = last;
         }
 
         if new_idx != current_idx {

--- a/src/gui/windows/containers/itemviewer_navbar.rs
+++ b/src/gui/windows/containers/itemviewer_navbar.rs
@@ -11,10 +11,12 @@ use crate::gui::windows::containers::structs::{
     Breadcrumb, ItemViewerNavBarAction, RenderedBreadcrumb, TabView,
 };
 use eframe::egui;
+use egui::text::{CCursor, CCursorRange};
 use egui::{FontFamily, FontId};
 use egui_extras::Size;
 use egui_phosphor::{fill, regular};
 use std::path::{Path, PathBuf};
+use std::process::Command;
 
 pub fn draw_itemviewer_navigation_bar(
     ui: &mut egui::Ui,
@@ -49,6 +51,7 @@ pub fn draw_itemviewer_navigation_bar(
             i18n,
             palette,
             is_favorited,
+            &tab.nav.current,
             tab.nav.is_root(),
             can_go_back,
             can_go_forward,
@@ -62,6 +65,18 @@ pub fn draw_itemviewer_navigation_bar(
 
         if tab.breadcrumb_path_editing {
             let text_edit_id = ui.id().with(("breadcrumbs_path_edit", tab_id));
+
+            if tab.breadcrumb_select_all_on_focus {
+                let mut state =
+                    egui::widgets::text_edit::TextEditState::load(ui.ctx(), text_edit_id)
+                        .unwrap_or_default();
+                let cursor_end = CCursor::new(tab.breadcrumb_path_buffer.chars().count());
+                state
+                    .cursor
+                    .set_char_range(Some(CCursorRange::two(CCursor::new(0), cursor_end)));
+                state.store(ui.ctx(), text_edit_id);
+            }
+
             let mut offset_x = 0.0;
             if tab.breadcrumb_path_error {
                 let t = (ui.input(|i| i.time) - tab.breadcrumb_path_error_animation_time) as f32;
@@ -118,6 +133,10 @@ pub fn draw_itemviewer_navigation_bar(
             if !tab.breadcrumb_just_started_editing || tab.breadcrumb_path_error {
                 resp.request_focus();
                 tab.breadcrumb_just_started_editing = true;
+            }
+
+            if resp.has_focus() {
+                tab.breadcrumb_select_all_on_focus = false;
             }
 
             action.is_breadcrumb_path_edit_active = resp.has_focus();
@@ -307,6 +326,7 @@ fn draw_navigation_bar_buttons(
     i18n: &I18n,
     palette: &ThemePalette,
     is_favorited: bool,
+    current_dir: &Path,
     is_root: bool,
     can_go_back: bool,
     can_go_forward: bool,
@@ -448,7 +468,47 @@ fn draw_navigation_bar_buttons(
         }
     }
 
+    ui.add_space(4.0);
+
+    if clickable_icon(ui, regular::TERMINAL, palette.primary)
+        .on_hover_text(
+            egui::RichText::new(i18n.tr("tooltip_open_terminal"))
+                .size(palette.tooltip_text_size)
+                .color(palette.tooltip_text_color),
+        )
+        .on_hover_cursor(egui::CursorIcon::PointingHand)
+        .clicked()
+    {
+        open_default_terminal(current_dir);
+    }
+
     action
+}
+
+fn open_default_terminal(current_dir: &Path) {
+    let start_dir = if current_dir.to_string_lossy() == MY_PC_PATH || !current_dir.exists() {
+        dirs::home_dir().unwrap_or_else(|| current_dir.to_path_buf())
+    } else {
+        current_dir.to_path_buf()
+    };
+
+    let launched = Command::new("wt.exe")
+        .arg("-d")
+        .arg(&start_dir)
+        .spawn()
+        .is_ok()
+        || Command::new("powershell.exe")
+            .current_dir(&start_dir)
+            .spawn()
+            .is_ok()
+        || Command::new("cmd.exe")
+            .current_dir(&start_dir)
+            .spawn()
+            .is_ok();
+
+    if !launched {
+        eprintln!("Failed to open terminal");
+    }
 }
 
 fn measure_breadcrumb_width(ui: &egui::Ui, font_id: &egui::FontId, text: &str) -> f32 {

--- a/src/gui/windows/containers/structs.rs
+++ b/src/gui/windows/containers/structs.rs
@@ -62,6 +62,7 @@ pub struct TabView {
     pub breadcrumb_path_editing: bool,
     pub breadcrumb_path_buffer: String,
     pub breadcrumb_just_started_editing: bool,
+    pub breadcrumb_select_all_on_focus: bool,
     pub breadcrumb_path_error: bool,
     pub breadcrumb_path_error_animation_time: f64,
     pub sort_column: crate::gui::utils::SortColumn,
@@ -90,6 +91,7 @@ impl TabView {
             breadcrumb_path_editing: false,
             breadcrumb_path_buffer: String::new(),
             breadcrumb_just_started_editing: false,
+            breadcrumb_select_all_on_focus: false,
             breadcrumb_path_error: false,
             breadcrumb_path_error_animation_time: 0.0,
             sort_column: default_sort_column,
@@ -384,6 +386,13 @@ impl TagsState {
         self.groups
             .iter()
             .any(|group| group.items.iter().any(|item| item == path))
+    }
+
+    pub fn tag_color_for_path(&self, path: &Path) -> Option<egui::Color32> {
+        self.groups
+            .iter()
+            .find(|group| group.items.iter().any(|item| item == path))
+            .map(|group| group.color)
     }
 
     pub fn add_paths_to_group(&mut self, group_id: u64, paths: &[PathBuf]) -> bool {

--- a/src/gui/windows/containers/tabs.rs
+++ b/src/gui/windows/containers/tabs.rs
@@ -2,7 +2,9 @@ use crate::gui::i18n::I18n;
 use crate::gui::theme::ThemePalette;
 use crate::gui::utils::{clickable_icon, truncate_item_text};
 use crate::gui::windows::containers::structs::{TabInfo, TabsAction};
-use crate::gui::windows::windowsoverrides::handle_draw_windows_buttons;
+use crate::gui::windows::windowsoverrides::{
+    handle_draw_windows_buttons, toggle_window_fullscreen,
+};
 use eframe::egui;
 use egui::{FontFamily, FontId};
 use egui_phosphor::{fill, regular};
@@ -122,6 +124,11 @@ pub fn draw_tabs(
                         );
                         if drag_rect.width() > 4.0 {
                             let resp = ui.allocate_rect(drag_rect, egui::Sense::click_and_drag());
+                            if resp.double_clicked() {
+                                if let Some(hwnd) = hwnd {
+                                    toggle_window_fullscreen(hwnd);
+                                }
+                            }
                             if resp.drag_started() || resp.dragged() {
                                 ui.ctx().send_viewport_cmd(egui::ViewportCommand::StartDrag);
                             }

--- a/src/gui/windows/containers/topbar.rs
+++ b/src/gui/windows/containers/topbar.rs
@@ -1,9 +1,11 @@
 use crate::gui::i18n::I18n;
 use crate::gui::utils::{clickable_active_icon, clickable_icon};
 use crate::gui::windows::containers::structs::TopbarAction;
+use crate::gui::windows::windowsoverrides::toggle_window_fullscreen;
 use eframe::egui;
 use egui::Pos2;
 use egui_phosphor::regular;
+use windows::Win32::Foundation::HWND;
 
 pub fn draw_topbar(
     ui: &mut egui::Ui,
@@ -11,6 +13,7 @@ pub fn draw_topbar(
     is_dark: bool,
     is_file_explorer: bool,
     sidebar_collapsed: bool,
+    hwnd: Option<HWND>,
     palette: &crate::gui::theme::ThemePalette,
 ) -> TopbarAction {
     let mut action = TopbarAction::default();
@@ -25,10 +28,11 @@ pub fn draw_topbar(
                 is_dark,
                 is_file_explorer,
                 sidebar_collapsed,
+                hwnd,
                 palette,
                 &mut action,
             );
-            draw_drag_region(ui);
+            draw_drag_region(ui, hwnd);
         });
     } else {
         // Expanded: original horizontal topbar row.
@@ -43,12 +47,13 @@ pub fn draw_topbar(
                     is_dark,
                     is_file_explorer,
                     sidebar_collapsed,
+                    hwnd,
                     palette,
                     &mut action,
                 );
             });
 
-            draw_drag_region(ui);
+            draw_drag_region(ui, hwnd);
         });
     }
 
@@ -122,6 +127,7 @@ fn draw_mode_icons(
     is_dark: bool,
     is_file_explorer: bool,
     sidebar_collapsed: bool,
+    _hwnd: Option<HWND>,
     palette: &crate::gui::theme::ThemePalette,
     action: &mut TopbarAction,
 ) {
@@ -206,11 +212,16 @@ fn draw_mode_icons(
     }
 }
 
-fn draw_drag_region(ui: &mut egui::Ui) {
+fn draw_drag_region(ui: &mut egui::Ui, hwnd: Option<HWND>) {
     // Remaining empty space: lets the user drag the window from the topbar.
     let drag_rect = ui.available_rect_before_wrap();
     if drag_rect.width() > 0.0 && drag_rect.height() > 0.0 {
         let resp = ui.allocate_rect(drag_rect, egui::Sense::click_and_drag());
+        if resp.double_clicked() {
+            if let Some(hwnd) = hwnd {
+                toggle_window_fullscreen(hwnd);
+            }
+        }
         if resp.drag_started() || resp.dragged() {
             ui.ctx().send_viewport_cmd(egui::ViewportCommand::StartDrag);
         }

--- a/src/gui/windows/mainwindow.rs
+++ b/src/gui/windows/mainwindow.rs
@@ -464,6 +464,7 @@ impl eframe::App for MainWindow {
                                         self.theme == ThemeMode::Dark,
                                         self.display_file_explorer,
                                         self.sidebar_collapsed,
+                                        self.hwnd,
                                         &palette,
                                     ));
                                 });
@@ -1067,6 +1068,7 @@ impl eframe::App for MainWindow {
         );
         self.handle_draw_settings_window(ctx, &palette);
         self.handle_draw_about_window(ctx, &palette);
+        self.handle_global_shortcuts(ctx);
 
         if tags_changed {
             self.persist_tags();

--- a/src/gui/windows/mainwindow_imp.rs
+++ b/src/gui/windows/mainwindow_imp.rs
@@ -26,6 +26,7 @@ use crate::gui::windows::enums::{SettingsAction, ThemeCustomizerAction};
 use crate::gui::windows::settings::draw_settings_window;
 use crate::gui::windows::structs::{Navigation, ThemeCustomizer};
 use crate::gui::windows::windowsoverrides::mark_clipboard_dirty;
+use crate::gui::windows::windowsoverrides::toggle_window_fullscreen;
 use crossbeam_channel::Receiver;
 use crossbeam_channel::{Sender, unbounded};
 use eframe::egui;
@@ -1299,6 +1300,202 @@ impl MainWindow {
             if action.toggle_sidebar {
                 self.sidebar_collapsed = !self.sidebar_collapsed;
             }
+        }
+    }
+
+    fn global_shortcuts_disabled(&self, ctx: &egui::Context) -> bool {
+        let topbar_menu_open = ctx.memory(|mem| {
+            mem.data
+                .get_temp::<bool>(egui::Id::new("topbar_hamburger_menu"))
+                .unwrap_or(false)
+        });
+
+        let active_tab = self.active_tab();
+        self.theme_customizer.open
+            || self.settings_window.open
+            || self.about_window.open
+            || self.tags_state.picker.is_some()
+            || self.tags_state.delete_confirmation.is_some()
+            || self
+                .rename_state
+                .as_ref()
+                .map(|state| state.validation_error_show)
+                .unwrap_or(false)
+            || self.sidebar_state.non_ntfs_popup_path.is_some()
+            || active_tab
+                .primary_view
+                .explorer_state
+                .non_ntfs_popup_path
+                .is_some()
+            || active_tab
+                .split_view
+                .as_ref()
+                .map(|view| view.explorer_state.non_ntfs_popup_path.is_some())
+                .unwrap_or(false)
+            || topbar_menu_open
+            || !self.display_file_explorer
+    }
+
+    fn enter_address_bar_edit_mode(&mut self) {
+        let current_path = self.current_nav().current.clone();
+        let side = self.focused_split;
+        let view = self.active_tab_mut().view_mut(side);
+
+        view.breadcrumb_path_editing = true;
+        view.breadcrumb_path_buffer = current_path.to_string_lossy().to_string();
+        view.breadcrumb_just_started_editing = false;
+        view.breadcrumb_select_all_on_focus = true;
+        view.breadcrumb_path_error = false;
+        view.breadcrumb_path_error_animation_time = 0.0;
+    }
+
+    fn selected_path_for_rename(&self) -> Option<PathBuf> {
+        let view = self.active_tab().view(self.focused_split);
+
+        if let Some(focus_idx) = view.explorer_state.selection_focus
+            && focus_idx < view.item_viewer_filter_state.cached_indices.len()
+        {
+            let file_idx = view.item_viewer_filter_state.cached_indices[focus_idx];
+            let focused_path = view.files.get(file_idx)?.path.clone();
+            if view.explorer_state.selected_paths.contains(&focused_path) {
+                return Some(focused_path);
+            }
+        }
+
+        let mut selected_paths: Vec<PathBuf> =
+            view.explorer_state.selected_paths.iter().cloned().collect();
+        selected_paths.sort();
+        selected_paths.into_iter().next()
+    }
+
+    fn selected_paths_for_properties(&self) -> Option<Vec<PathBuf>> {
+        let view = self.active_tab().view(self.focused_split);
+        if view.explorer_state.selected_paths.is_empty() {
+            return None;
+        }
+
+        let mut paths: Vec<PathBuf> = view.explorer_state.selected_paths.iter().cloned().collect();
+        paths.sort();
+        paths.dedup();
+        Some(paths)
+    }
+
+    pub fn handle_global_shortcuts(&mut self, ctx: &egui::Context) {
+        if self.global_shortcuts_disabled(ctx) {
+            return;
+        }
+
+        let shortcuts = ctx.input(|input| {
+            let ctrl = input.modifiers.ctrl;
+            let alt = input.modifiers.alt;
+            let shift = input.modifiers.shift;
+
+            (
+                ctrl && shift && input.key_pressed(egui::Key::Tab),
+                ctrl && input.key_pressed(egui::Key::Tab),
+                ctrl && input.key_pressed(egui::Key::T),
+                ctrl && input.key_pressed(egui::Key::W),
+                ctrl && shift && input.key_pressed(egui::Key::N),
+                ctrl && input.key_pressed(egui::Key::R),
+                input.key_pressed(egui::Key::F5),
+                input.key_pressed(egui::Key::F1),
+                alt && input.key_pressed(egui::Key::D),
+                input.key_pressed(egui::Key::F2),
+                alt && input.key_pressed(egui::Key::Enter),
+            )
+        });
+
+        if shortcuts.0 {
+            self.activate_tab_relative(-1);
+            return;
+        }
+
+        if shortcuts.1 {
+            self.activate_tab_relative(1);
+            return;
+        }
+
+        if shortcuts.2 {
+            let action = TabsAction {
+                open_new: true,
+                ..Default::default()
+            };
+            self.handle_tabs_action(Some(action), None);
+            return;
+        }
+
+        if shortcuts.3 {
+            let action = TabsAction {
+                close: Some(self.active_tab().id),
+                ..Default::default()
+            };
+            self.handle_tabs_action(Some(action), None);
+            return;
+        }
+
+        if shortcuts.4 {
+            self.create_new_folder();
+            return;
+        }
+
+        if shortcuts.5 || shortcuts.6 {
+            self.load_path();
+            return;
+        }
+
+        if shortcuts.7 {
+            self.toggle_fullscreen();
+        }
+
+        if shortcuts.8 {
+            self.enter_address_bar_edit_mode();
+            return;
+        }
+
+        if shortcuts.9 {
+            if self.rename_state.is_none()
+                && !self
+                    .active_tab()
+                    .view(self.focused_split)
+                    .breadcrumb_path_editing
+                && let Some(path) = self.selected_path_for_rename()
+            {
+                let action = ItemViewerAction::StartEdit(path);
+                handle_pending_actions(Some(action), self);
+            }
+            return;
+        }
+
+        if shortcuts.10 {
+            if !self
+                .active_tab()
+                .view(self.focused_split)
+                .breadcrumb_path_editing
+                && let Some(paths) = self.selected_paths_for_properties()
+            {
+                self.open_properties_multi(&paths);
+            }
+        }
+    }
+
+    fn activate_tab_relative(&mut self, delta: isize) {
+        if self.tabs.is_empty() {
+            return;
+        }
+
+        let len = self.tabs.len() as isize;
+        let next = (self.active_tab as isize + delta).rem_euclid(len) as usize;
+        let id = self.tabs[next].id;
+        let action = TabsAction {
+            activate: Some(id),
+            ..Default::default()
+        };
+        self.handle_tabs_action(Some(action), None);
+    }
+
+    fn toggle_fullscreen(&mut self) {
+        if let Some(hwnd) = self.hwnd {
+            toggle_window_fullscreen(hwnd);
         }
     }
 

--- a/src/gui/windows/windowsoverrides.rs
+++ b/src/gui/windows/windowsoverrides.rs
@@ -370,20 +370,7 @@ pub fn handle_draw_windows_buttons(ui: &mut egui::Ui, hwnd: Option<HWND>, palett
             .on_hover_cursor(egui::CursorIcon::PointingHand)
             .clicked()
         {
-            unsafe {
-                let mut placement = WINDOWPLACEMENT {
-                    length: std::mem::size_of::<WINDOWPLACEMENT>() as u32,
-                    ..Default::default()
-                };
-
-                if GetWindowPlacement(hwnd, &mut placement).is_ok() {
-                    if placement.showCmd == SW_SHOWMAXIMIZED.0 as u32 {
-                        let _ = ShowWindow(hwnd, SW_RESTORE);
-                    } else {
-                        let _ = ShowWindow(hwnd, SW_MAXIMIZE);
-                    }
-                }
-            }
+            toggle_window_fullscreen(hwnd);
         }
 
         if clickable_icon(ui, regular::MINUS, palette.primary)
@@ -397,6 +384,23 @@ pub fn handle_draw_windows_buttons(ui: &mut egui::Ui, hwnd: Option<HWND>, palett
         {
             unsafe {
                 let _ = ShowWindow(hwnd, SW_MINIMIZE);
+            }
+        }
+    }
+}
+
+pub fn toggle_window_fullscreen(hwnd: HWND) {
+    unsafe {
+        let mut placement = WINDOWPLACEMENT {
+            length: std::mem::size_of::<WINDOWPLACEMENT>() as u32,
+            ..Default::default()
+        };
+
+        if GetWindowPlacement(hwnd, &mut placement).is_ok() {
+            if placement.showCmd == SW_SHOWMAXIMIZED.0 as u32 {
+                let _ = ShowWindow(hwnd, SW_RESTORE);
+            } else {
+                let _ = ShowWindow(hwnd, SW_MAXIMIZE);
             }
         }
     }


### PR DESCRIPTION
## 🆕 What's New

- New global keyboard and mouse shortcuts, referenced now in the README.md
- New terminal button that opens your default terminal (powershell/cmd)
- Added Recycle Bin to My Places (but currently launches native Windows explorer)
- Tagged objects are now highlighted in their Tag color inside the Explorer view
- Top bar can be double-clicked to maximize the window

## 🔗 Related Issues

https://github.com/mtucciarone/EdenExplorer/issues/38
https://github.com/mtucciarone/EdenExplorer/issues/61
https://github.com/mtucciarone/EdenExplorer/issues/58
https://github.com/mtucciarone/EdenExplorer/issues/63
https://github.com/mtucciarone/EdenExplorer/issues/59