### PR TITLE
feat: open arg given path in new tab or new window

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "EdenExplorer"
-version = "0.22.0"
+version = "0.22.1"
 dependencies = [
  "bincode",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ windows = { version = "0.62.2", features = [
     "Win32_NetworkManagement_NetManagement",
     "Win32_UI_Input_KeyboardAndMouse",
     "Win32_Graphics_DirectWrite",
+    "Win32_Globalization",
 ] }
 windows-core = "0.62.2"
 crossbeam-channel = "0.5.15"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ windows = { version = "0.62.2", features = [
     "Win32_Storage_FileSystem",
     "Win32_Security",
     "Win32_System_IO",
+    "Win32_System_Threading",
     "Win32_System_Ioctl",
     "Win32_System_DataExchange",
     "Win32_System_Memory",

--- a/locales/en-US/main.ftl
+++ b/locales/en-US/main.ftl
@@ -160,3 +160,16 @@ tag_delete_group = Delete Tag Group
 tag_delete_confirm = Are you sure you want to delete this tag group?
 theme_font = Font
 theme_mono_font = Monospace Font
+launch-unknown-option = 
+    Unknown option: 
+    {$option}
+launch-invalid-directory = 
+    Not an existing directory: 
+    {$path}
+launch-mutex-create = 
+    Could not create the instance mutex: 
+    {$error}
+launch-window-not-ready = 
+    The running EdenExplorer window was not ready.
+launch-window-rejected = 
+    The running EdenExplorer window did not accept the request.

--- a/locales/id-ID/main.ftl
+++ b/locales/id-ID/main.ftl
@@ -157,3 +157,16 @@ tag_delete_group = Hapus Grup Tag
 tag_delete_confirm = Apakah Anda yakin ingin menghapus grup tag ini?
 theme_font = Font
 theme_mono_font = Font Monospace
+launch-unknown-option = 
+    Opsi tidak dikenal: 
+    {$option}
+launch-invalid-directory = 
+    Bukan direktori yang ada: 
+    {$path}
+launch-mutex-create = 
+    Tidak dapat membuat mutex instance: 
+    {$error}
+launch-window-not-ready = 
+    Jendela EdenExplorer yang sedang berjalan tidak siap.
+launch-window-rejected = 
+    Jendela EdenExplorer yang sedang berjalan tidak menerima permintaan.

--- a/locales/ja-JP/main.ftl
+++ b/locales/ja-JP/main.ftl
@@ -157,3 +157,16 @@ tag_delete_group = タググループを削除
 tag_delete_confirm = このタググループを削除してもよろしいですか？
 theme_font = フォント
 theme_mono_font = モノスペースフォント
+launch-unknown-option = 
+    不明なオプション: 
+    {$option}
+launch-invalid-directory = 
+    既存のディレクトリではありません: 
+    {$path}
+launch-mutex-create = 
+    インスタンスミューテックスを作成できませんでした: 
+    {$error}
+launch-window-not-ready = 
+    実行中のEdenExplorerウィンドウが準備できていません。
+launch-window-rejected = 
+    実行中のEdenExplorerウィンドウがリクエストを拒否しました。

--- a/locales/zh-CN/main.ftl
+++ b/locales/zh-CN/main.ftl
@@ -157,3 +157,16 @@ tag_delete_group = 删除标签组
 tag_delete_confirm = 您确定要删除此标签组吗？
 theme_font = 字体
 theme_mono_font = 等宽字体
+launch-unknown-option = 
+    未知选项: 
+    {$option}
+launch-invalid-directory = 
+    不是现有目录: 
+    {$path}
+launch-mutex-create = 
+    无法创建实例互斥锁: 
+    {$error}
+launch-window-not-ready = 
+    运行中的 EdenExplorer 窗口未准备好。
+launch-window-rejected = 
+    运行中的 EdenExplorer 窗口拒绝了请求。

--- a/locales/zh-HK/main.ftl
+++ b/locales/zh-HK/main.ftl
@@ -157,3 +157,16 @@ tag_delete_group = 刪除標籤群組
 tag_delete_confirm = 您確定要刪除此標籤群組嗎？
 theme_font = 字體
 theme_mono_font = 等寬字體
+launch-unknown-option = 
+    未知選項: 
+    {$option}
+launch-invalid-directory = 
+    不是現有目錄: 
+    {$path}
+launch-mutex-create = 
+    無法建立實例互斥鎖: 
+    {$error}
+launch-window-not-ready = 
+    運行中的 EdenExplorer 窗口未準備好。
+launch-window-rejected = 
+    運行中的 EdenExplorer 窗口拒絕了請求。

--- a/locales/zh-TW/main.ftl
+++ b/locales/zh-TW/main.ftl
@@ -157,3 +157,16 @@ tag_delete_group = 刪除標籤群組
 tag_delete_confirm = 您確定要刪除此標籤群組嗎？
 theme_font = 字體
 theme_mono_font = 等寬字體
+launch-unknown-option = 
+    未知選項: 
+    {$option}
+launch-invalid-directory = 
+    不是現有目錄: 
+    {$path}
+launch-mutex-create = 
+    無法建立實例互斥鎖: 
+    {$error}
+launch-window-not-ready = 
+    運行中的 EdenExplorer 窗口未準備好。
+launch-window-rejected = 
+    運行中的 EdenExplorer 窗口拒絕了請求。

--- a/src/core/launch.rs
+++ b/src/core/launch.rs
@@ -1,4 +1,39 @@
+use fluent_bundle::{FluentArgs, FluentBundle, FluentResource};
+use rust_embed::RustEmbed;
+use std::borrow::Cow;
+use std::ffi::c_void;
+use std::mem::size_of;
+use std::os::windows::ffi::OsStrExt;
 use std::path::PathBuf;
+use std::str::FromStr;
+use std::sync::Mutex;
+use std::thread;
+use std::time::Duration;
+use unic_langid::LanguageIdentifier;
+use windows::Win32::Foundation::CloseHandle;
+use windows::Win32::Foundation::ERROR_ALREADY_EXISTS;
+use windows::Win32::Foundation::HANDLE;
+use windows::Win32::Foundation::{GetLastError, HWND, LPARAM, WPARAM};
+use windows::Win32::Globalization::GetUserDefaultLocaleName;
+use windows::Win32::System::DataExchange::COPYDATASTRUCT;
+use windows::Win32::System::Threading::{CreateMutexW, ReleaseMutex};
+use windows::Win32::UI::WindowsAndMessaging::{
+    FindWindowW, SW_RESTORE, SendMessageW, SetForegroundWindow, ShowWindow, WM_COPYDATA,
+};
+use windows::core::PCWSTR;
+
+#[derive(RustEmbed)]
+#[folder = "locales/"]
+struct LaunchLocalizations;
+
+const INSTANCE_MUTEX: &str = "Local\\EdenExplorer.SingleInstance.v1";
+const WINDOW_TITLE: &str = "EdenExplorer";
+const COPYDATA_ID: usize = 0x4544_454e;
+static FORWARDED_PATHS: Mutex<Vec<PathBuf>> = Mutex::new(Vec::new());
+
+pub struct InstanceGuard {
+    handle: HANDLE,
+}
 
 #[derive(Debug, Default)]
 pub struct LaunchOptions {
@@ -6,7 +41,143 @@ pub struct LaunchOptions {
     pub new_window: bool,
 }
 
-pub fn parse_args<I, S>(args: I) -> Result<LaunchOptions, String>
+#[derive(Debug)]
+pub enum LaunchError {
+    UnknownOption(String),
+    InvalidDirectory(PathBuf),
+    MutexCreate(String),
+    WindowNotReady,
+    WindowRejected,
+}
+
+impl LaunchError {
+    pub fn message(&self) -> String {
+        let i18n = LaunchI18n::new();
+
+        match self {
+            Self::UnknownOption(option) => {
+                let mut args = FluentArgs::new();
+                args.set("option", option.as_str());
+                i18n.tr_args("launch-unknown-option", &args)
+            }
+
+            Self::InvalidDirectory(path) => {
+                let mut args = FluentArgs::new();
+                args.set("path", path.display().to_string());
+                i18n.tr_args("launch-invalid-directory", &args)
+            }
+
+            Self::MutexCreate(error) => {
+                let mut args = FluentArgs::new();
+                args.set("error", error.as_str());
+                i18n.tr_args("launch-mutex-create", &args)
+            }
+
+            Self::WindowNotReady => i18n.tr("launch-window-not-ready"),
+
+            Self::WindowRejected => i18n.tr("launch-window-rejected"),
+        }
+    }
+}
+
+struct LaunchI18n {
+    bundle: FluentBundle<FluentResource>,
+}
+
+impl LaunchI18n {
+    fn new() -> Self {
+        let locale = system_locale();
+
+        let langid = LanguageIdentifier::from_str(&locale)
+            .unwrap_or_else(|_| LanguageIdentifier::from_str("en-US").unwrap());
+
+        let mut bundle = FluentBundle::new(vec![langid]);
+        bundle.set_use_isolating(false);
+
+        // Always load English first.
+        load_locale(&mut bundle, "en-US");
+
+        // Overlay the user's language.
+        if locale != "en-US" {
+            load_locale(&mut bundle, &locale);
+        }
+
+        Self { bundle }
+    }
+
+    fn tr(&self, key: &str) -> String {
+        let message = match self.bundle.get_message(key) {
+            Some(message) => message,
+            None => return key.to_string(),
+        };
+
+        let pattern = match message.value() {
+            Some(pattern) => pattern,
+            None => return key.to_string(),
+        };
+
+        let mut errors = Vec::new();
+
+        self.bundle
+            .format_pattern(pattern, None, &mut errors)
+            .to_string()
+    }
+
+    fn tr_args(&self, key: &str, args: &FluentArgs) -> String {
+        let message = match self.bundle.get_message(key) {
+            Some(message) => message,
+            None => return key.to_string(),
+        };
+
+        let pattern = match message.value() {
+            Some(pattern) => pattern,
+            None => return key.to_string(),
+        };
+
+        let mut errors = Vec::new();
+
+        self.bundle
+            .format_pattern(pattern, Some(args), &mut errors)
+            .to_string()
+    }
+}
+
+impl Drop for InstanceGuard {
+    fn drop(&mut self) {
+        unsafe {
+            let _ = ReleaseMutex(self.handle);
+            let _ = CloseHandle(self.handle);
+        }
+    }
+}
+
+#[cfg(windows)]
+pub fn system_locale() -> String {
+    let mut buf = [0u16; 85];
+    let len = unsafe { GetUserDefaultLocaleName(&mut buf) };
+
+    if len <= 1 {
+        return "en-US".to_string();
+    }
+
+    let locale = String::from_utf16_lossy(&buf[..(len as usize - 1)]);
+
+    // Prefer exact match.
+    if LaunchLocalizations::get(&format!("{}/main.ftl", locale)).is_some() {
+        return locale;
+    }
+
+    // Fall back to language only.
+    if let Some((language, _)) = locale.split_once('-') {
+        if LaunchLocalizations::get(&format!("{}/main.ftl", language)).is_some() {
+            return language.to_string();
+        }
+    }
+
+    "en-US".to_string()
+}
+
+pub fn parse_args<I, S>(args: I) -> Result<LaunchOptions, LaunchError>
 where
     I: IntoIterator<Item = S>,
     S: Into<String>,
@@ -21,7 +192,7 @@ where
         } else if !after_double_dash && arg == "--new-window" {
             options.new_window = true;
         } else if !after_double_dash && arg.starts_with('-') {
-            return Err(format!("Unknown option: {arg}"));
+            return Err(LaunchError::UnknownOption(arg));
         } else if !arg.is_empty() {
             options.paths.push(PathBuf::from(arg));
         }
@@ -30,15 +201,151 @@ where
     Ok(options)
 }
 
-pub fn existing_directories(options: &LaunchOptions) -> Result<Vec<PathBuf>, String> {
+pub fn existing_directories(options: &LaunchOptions) -> Result<Vec<PathBuf>, LaunchError> {
     let mut paths = Vec::with_capacity(options.paths.len());
     for path in &options.paths {
         if !path.is_dir() {
-            return Err(format!("Not an existing directory: {}", path.display()));
+            return Err(LaunchError::InvalidDirectory(path.clone()));
         }
         paths.push(path.clone());
     }
     Ok(paths)
+}
+
+pub fn acquire_or_forward(paths: &[PathBuf]) -> Result<Option<InstanceGuard>, LaunchError> {
+    let name = wide(INSTANCE_MUTEX);
+    let handle = unsafe { CreateMutexW(None, true, PCWSTR(name.as_ptr())) }
+        .map_err(|e| LaunchError::MutexCreate(e.to_string()))?;
+
+    if unsafe { GetLastError() } == ERROR_ALREADY_EXISTS {
+        let result = forward_paths(paths);
+        unsafe {
+            let _ = CloseHandle(handle);
+        }
+        result.map(|_| None)
+    } else {
+        Ok(Some(InstanceGuard { handle }))
+    }
+}
+
+pub fn receive_copydata(lparam: LPARAM) -> bool {
+    let data = unsafe { (lparam.0 as *const COPYDATASTRUCT).as_ref() };
+    let Some(data) = data else { return false };
+    if data.dwData != COPYDATA_ID || data.cbData == 0 || data.lpData.is_null() {
+        return false;
+    }
+
+    let units = data.cbData as usize / size_of::<u16>();
+    let words = unsafe { std::slice::from_raw_parts(data.lpData as *const u16, units) };
+    let paths = words
+        .split(|unit| *unit == 0)
+        .take_while(|part| !part.is_empty())
+        .map(String::from_utf16_lossy)
+        .map(PathBuf::from)
+        .filter(|path| path.is_dir())
+        .collect::<Vec<_>>();
+    if let Ok(mut pending) = FORWARDED_PATHS.lock() {
+        pending.extend(paths);
+    }
+    true
+}
+
+pub fn take_forwarded_paths() -> Vec<PathBuf> {
+    FORWARDED_PATHS
+        .lock()
+        .map(|mut paths| std::mem::take(&mut *paths))
+        .unwrap_or_default()
+}
+
+fn wide(value: &str) -> Vec<u16> {
+    std::ffi::OsStr::new(value)
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect()
+}
+
+fn load_locale(bundle: &mut FluentBundle<FluentResource>, locale: &str) {
+    let path = format!("{}/main.ftl", locale);
+
+    let file = match LaunchLocalizations::get(&path) {
+        Some(file) => file,
+        None => return,
+    };
+
+    let source = match file.data {
+        Cow::Borrowed(bytes) => match std::str::from_utf8(bytes) {
+            Ok(text) => text.to_owned(),
+            Err(_) => return,
+        },
+        Cow::Owned(bytes) => match String::from_utf8(bytes) {
+            Ok(text) => text,
+            Err(_) => return,
+        },
+    };
+
+    let resource = match FluentResource::try_new(source) {
+        Ok(resource) => resource,
+        Err(_) => return,
+    };
+
+    let _ = bundle.add_resource(resource);
+}
+
+fn forward_paths(paths: &[PathBuf]) -> Result<(), LaunchError> {
+    let mut payload: Vec<u16> = Vec::new();
+    for path in paths {
+        payload.extend(path.as_os_str().encode_wide());
+        payload.push(0);
+    }
+    payload.push(0);
+
+    let title = wide(WINDOW_TITLE);
+    let mut hwnd = HWND::default();
+    for _ in 0..30 {
+        hwnd = unsafe { FindWindowW(None, PCWSTR(title.as_ptr())) }.unwrap_or_default();
+        if !hwnd.is_invalid() {
+            break;
+        }
+        thread::sleep(Duration::from_millis(100));
+    }
+    if hwnd.is_invalid() {
+        return Err(LaunchError::WindowNotReady);
+    }
+
+    let data = COPYDATASTRUCT {
+        dwData: COPYDATA_ID,
+        cbData: (payload.len() * size_of::<u16>()) as u32,
+        lpData: payload.as_ptr() as *mut c_void,
+    };
+    let mut delivered = false;
+    for _ in 0..20 {
+        let result = unsafe {
+            SendMessageW(
+                hwnd,
+                WM_COPYDATA,
+                Some(WPARAM(0)),
+                Some(LPARAM(&data as *const COPYDATASTRUCT as isize)),
+            )
+        };
+        if result.0 != 0 {
+            delivered = true;
+            break;
+        }
+        thread::sleep(Duration::from_millis(100));
+    }
+    if !delivered {
+        return Err(LaunchError::WindowRejected);
+    }
+    unsafe {
+        let _ = ShowWindow(hwnd, SW_RESTORE);
+        let _ = SetForegroundWindow(hwnd);
+    }
+    Ok(())
+}
+
+#[cfg(not(windows))]
+pub fn take_forwarded_paths() -> Vec<PathBuf> {
+    Vec::new()
 }
 
 #[cfg(test)]
@@ -71,158 +378,20 @@ mod tests {
     #[test]
     fn rejects_unknown_options() {
         let error = parse_args(["EdenExplorer.exe", "--unknown"]).unwrap_err();
-        assert!(error.contains("--unknown"));
-    }
-}
-
-mod windows_instance {
-    use super::*;
-    use std::ffi::c_void;
-    use std::mem::size_of;
-    use std::os::windows::ffi::OsStrExt;
-    use std::sync::Mutex;
-    use std::thread;
-    use std::time::Duration;
-    use windows::Win32::Foundation::CloseHandle;
-    use windows::Win32::Foundation::ERROR_ALREADY_EXISTS;
-    use windows::Win32::Foundation::HANDLE;
-    use windows::Win32::Foundation::{GetLastError, HWND, LPARAM, WPARAM};
-    use windows::Win32::System::DataExchange::COPYDATASTRUCT;
-    use windows::Win32::System::Threading::{CreateMutexW, ReleaseMutex};
-    use windows::Win32::UI::WindowsAndMessaging::{
-        FindWindowW, SW_RESTORE, SendMessageW, SetForegroundWindow, ShowWindow, WM_COPYDATA,
-    };
-    use windows::core::PCWSTR;
-
-    const INSTANCE_MUTEX: &str = "Local\\EdenExplorer.SingleInstance.v1";
-    const WINDOW_TITLE: &str = "EdenExplorer";
-    const COPYDATA_ID: usize = 0x4544_454e;
-
-    static FORWARDED_PATHS: Mutex<Vec<PathBuf>> = Mutex::new(Vec::new());
-
-    fn wide(value: &str) -> Vec<u16> {
-        std::ffi::OsStr::new(value)
-            .encode_wide()
-            .chain(std::iter::once(0))
-            .collect()
-    }
-
-    pub struct InstanceGuard {
-        handle: HANDLE,
-    }
-
-    impl Drop for InstanceGuard {
-        fn drop(&mut self) {
-            unsafe {
-                let _ = ReleaseMutex(self.handle);
-                let _ = CloseHandle(self.handle);
+        match error {
+            LaunchError::UnknownOption(option) => {
+                assert_eq!(option, "--unknown");
             }
+            _ => panic!("unexpected error"),
         }
     }
 
-    pub fn acquire_or_forward(paths: &[PathBuf]) -> Result<Option<InstanceGuard>, String> {
-        let name = wide(INSTANCE_MUTEX);
-        let handle = unsafe { CreateMutexW(None, true, PCWSTR(name.as_ptr())) }
-            .map_err(|e| format!("Could not create the instance mutex: {e}"))?;
+    #[test]
+    fn startup_i18n_loads() {
+        let i18n = LaunchI18n::new();
 
-        if unsafe { GetLastError() } == ERROR_ALREADY_EXISTS {
-            let result = forward_paths(paths);
-            unsafe {
-                let _ = CloseHandle(handle);
-            }
-            result.map(|_| None)
-        } else {
-            Ok(Some(InstanceGuard { handle }))
-        }
+        let value = i18n.tr("launch-window-not-ready");
+
+        assert_ne!(value, "");
     }
-
-    fn forward_paths(paths: &[PathBuf]) -> Result<(), String> {
-        let mut payload: Vec<u16> = Vec::new();
-        for path in paths {
-            payload.extend(path.as_os_str().encode_wide());
-            payload.push(0);
-        }
-        payload.push(0);
-
-        let title = wide(WINDOW_TITLE);
-        let mut hwnd = HWND::default();
-        for _ in 0..30 {
-            hwnd = unsafe { FindWindowW(None, PCWSTR(title.as_ptr())) }.unwrap_or_default();
-            if !hwnd.is_invalid() {
-                break;
-            }
-            thread::sleep(Duration::from_millis(100));
-        }
-        if hwnd.is_invalid() {
-            return Err("The running EdenExplorer window was not ready.".to_string());
-        }
-
-        let data = COPYDATASTRUCT {
-            dwData: COPYDATA_ID,
-            cbData: (payload.len() * size_of::<u16>()) as u32,
-            lpData: payload.as_ptr() as *mut c_void,
-        };
-        let mut delivered = false;
-        for _ in 0..20 {
-            let result = unsafe {
-                SendMessageW(
-                    hwnd,
-                    WM_COPYDATA,
-                    Some(WPARAM(0)),
-                    Some(LPARAM(&data as *const COPYDATASTRUCT as isize)),
-                )
-            };
-            if result.0 != 0 {
-                delivered = true;
-                break;
-            }
-            thread::sleep(Duration::from_millis(100));
-        }
-        if !delivered {
-            return Err("The running EdenExplorer window did not accept the request.".to_string());
-        }
-        unsafe {
-            let _ = ShowWindow(hwnd, SW_RESTORE);
-            let _ = SetForegroundWindow(hwnd);
-        }
-        Ok(())
-    }
-
-    pub fn receive_copydata(lparam: LPARAM) -> bool {
-        let data = unsafe { (lparam.0 as *const COPYDATASTRUCT).as_ref() };
-        let Some(data) = data else { return false };
-        if data.dwData != COPYDATA_ID || data.cbData == 0 || data.lpData.is_null() {
-            return false;
-        }
-
-        let units = data.cbData as usize / size_of::<u16>();
-        let words = unsafe { std::slice::from_raw_parts(data.lpData as *const u16, units) };
-        let paths = words
-            .split(|unit| *unit == 0)
-            .take_while(|part| !part.is_empty())
-            .map(String::from_utf16_lossy)
-            .map(PathBuf::from)
-            .filter(|path| path.is_dir())
-            .collect::<Vec<_>>();
-        if let Ok(mut pending) = FORWARDED_PATHS.lock() {
-            pending.extend(paths);
-        }
-        true
-    }
-
-    pub fn take_forwarded_paths() -> Vec<PathBuf> {
-        FORWARDED_PATHS
-            .lock()
-            .map(|mut paths| std::mem::take(&mut *paths))
-            .unwrap_or_default()
-    }
-}
-
-pub use windows_instance::{
-    InstanceGuard, acquire_or_forward, receive_copydata, take_forwarded_paths,
-};
-
-#[cfg(not(windows))]
-pub fn take_forwarded_paths() -> Vec<PathBuf> {
-    Vec::new()
 }

--- a/src/core/launch.rs
+++ b/src/core/launch.rs
@@ -1,0 +1,228 @@
+use std::path::PathBuf;
+
+#[derive(Debug, Default)]
+pub struct LaunchOptions {
+    pub paths: Vec<PathBuf>,
+    pub new_window: bool,
+}
+
+pub fn parse_args<I, S>(args: I) -> Result<LaunchOptions, String>
+where
+    I: IntoIterator<Item = S>,
+    S: Into<String>,
+{
+    let mut options = LaunchOptions::default();
+    let mut after_double_dash = false;
+
+    for raw in args.into_iter().skip(1) {
+        let arg = raw.into();
+        if !after_double_dash && arg == "--" {
+            after_double_dash = true;
+        } else if !after_double_dash && arg == "--new-window" {
+            options.new_window = true;
+        } else if !after_double_dash && arg.starts_with('-') {
+            return Err(format!("Unknown option: {arg}"));
+        } else if !arg.is_empty() {
+            options.paths.push(PathBuf::from(arg));
+        }
+    }
+
+    Ok(options)
+}
+
+pub fn existing_directories(options: &LaunchOptions) -> Result<Vec<PathBuf>, String> {
+    let mut paths = Vec::with_capacity(options.paths.len());
+    for path in &options.paths {
+        if !path.is_dir() {
+            return Err(format!("Not an existing directory: {}", path.display()));
+        }
+        paths.push(path.clone());
+    }
+    Ok(paths)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_multiple_paths_and_new_window() {
+        let options = parse_args([
+            "EdenExplorer.exe",
+            "--new-window",
+            "C:\\Projects",
+            "D:\\Archive",
+        ])
+        .unwrap();
+
+        assert!(options.new_window);
+        assert_eq!(
+            options.paths,
+            vec![PathBuf::from("C:\\Projects"), PathBuf::from("D:\\Archive")]
+        );
+    }
+
+    #[test]
+    fn allows_dash_prefixed_paths_after_double_dash() {
+        let options = parse_args(["EdenExplorer.exe", "--", "-folder"]).unwrap();
+        assert_eq!(options.paths, vec![PathBuf::from("-folder")]);
+    }
+
+    #[test]
+    fn rejects_unknown_options() {
+        let error = parse_args(["EdenExplorer.exe", "--unknown"]).unwrap_err();
+        assert!(error.contains("--unknown"));
+    }
+}
+
+mod windows_instance {
+    use super::*;
+    use std::ffi::c_void;
+    use std::mem::size_of;
+    use std::os::windows::ffi::OsStrExt;
+    use std::sync::Mutex;
+    use std::thread;
+    use std::time::Duration;
+    use windows::Win32::Foundation::CloseHandle;
+    use windows::Win32::Foundation::ERROR_ALREADY_EXISTS;
+    use windows::Win32::Foundation::HANDLE;
+    use windows::Win32::Foundation::{GetLastError, HWND, LPARAM, WPARAM};
+    use windows::Win32::System::DataExchange::COPYDATASTRUCT;
+    use windows::Win32::System::Threading::{CreateMutexW, ReleaseMutex};
+    use windows::Win32::UI::WindowsAndMessaging::{
+        FindWindowW, SW_RESTORE, SendMessageW, SetForegroundWindow, ShowWindow, WM_COPYDATA,
+    };
+    use windows::core::PCWSTR;
+
+    const INSTANCE_MUTEX: &str = "Local\\EdenExplorer.SingleInstance.v1";
+    const WINDOW_TITLE: &str = "EdenExplorer";
+    const COPYDATA_ID: usize = 0x4544_454e;
+
+    static FORWARDED_PATHS: Mutex<Vec<PathBuf>> = Mutex::new(Vec::new());
+
+    fn wide(value: &str) -> Vec<u16> {
+        std::ffi::OsStr::new(value)
+            .encode_wide()
+            .chain(std::iter::once(0))
+            .collect()
+    }
+
+    pub struct InstanceGuard {
+        handle: HANDLE,
+    }
+
+    impl Drop for InstanceGuard {
+        fn drop(&mut self) {
+            unsafe {
+                let _ = ReleaseMutex(self.handle);
+                let _ = CloseHandle(self.handle);
+            }
+        }
+    }
+
+    pub fn acquire_or_forward(paths: &[PathBuf]) -> Result<Option<InstanceGuard>, String> {
+        let name = wide(INSTANCE_MUTEX);
+        let handle = unsafe { CreateMutexW(None, true, PCWSTR(name.as_ptr())) }
+            .map_err(|e| format!("Could not create the instance mutex: {e}"))?;
+
+        if unsafe { GetLastError() } == ERROR_ALREADY_EXISTS {
+            let result = forward_paths(paths);
+            unsafe {
+                let _ = CloseHandle(handle);
+            }
+            result.map(|_| None)
+        } else {
+            Ok(Some(InstanceGuard { handle }))
+        }
+    }
+
+    fn forward_paths(paths: &[PathBuf]) -> Result<(), String> {
+        let mut payload: Vec<u16> = Vec::new();
+        for path in paths {
+            payload.extend(path.as_os_str().encode_wide());
+            payload.push(0);
+        }
+        payload.push(0);
+
+        let title = wide(WINDOW_TITLE);
+        let mut hwnd = HWND::default();
+        for _ in 0..30 {
+            hwnd = unsafe { FindWindowW(None, PCWSTR(title.as_ptr())) }.unwrap_or_default();
+            if !hwnd.is_invalid() {
+                break;
+            }
+            thread::sleep(Duration::from_millis(100));
+        }
+        if hwnd.is_invalid() {
+            return Err("The running EdenExplorer window was not ready.".to_string());
+        }
+
+        let data = COPYDATASTRUCT {
+            dwData: COPYDATA_ID,
+            cbData: (payload.len() * size_of::<u16>()) as u32,
+            lpData: payload.as_ptr() as *mut c_void,
+        };
+        let mut delivered = false;
+        for _ in 0..20 {
+            let result = unsafe {
+                SendMessageW(
+                    hwnd,
+                    WM_COPYDATA,
+                    Some(WPARAM(0)),
+                    Some(LPARAM(&data as *const COPYDATASTRUCT as isize)),
+                )
+            };
+            if result.0 != 0 {
+                delivered = true;
+                break;
+            }
+            thread::sleep(Duration::from_millis(100));
+        }
+        if !delivered {
+            return Err("The running EdenExplorer window did not accept the request.".to_string());
+        }
+        unsafe {
+            let _ = ShowWindow(hwnd, SW_RESTORE);
+            let _ = SetForegroundWindow(hwnd);
+        }
+        Ok(())
+    }
+
+    pub fn receive_copydata(lparam: LPARAM) -> bool {
+        let data = unsafe { (lparam.0 as *const COPYDATASTRUCT).as_ref() };
+        let Some(data) = data else { return false };
+        if data.dwData != COPYDATA_ID || data.cbData == 0 || data.lpData.is_null() {
+            return false;
+        }
+
+        let units = data.cbData as usize / size_of::<u16>();
+        let words = unsafe { std::slice::from_raw_parts(data.lpData as *const u16, units) };
+        let paths = words
+            .split(|unit| *unit == 0)
+            .take_while(|part| !part.is_empty())
+            .map(String::from_utf16_lossy)
+            .map(PathBuf::from)
+            .filter(|path| path.is_dir())
+            .collect::<Vec<_>>();
+        if let Ok(mut pending) = FORWARDED_PATHS.lock() {
+            pending.extend(paths);
+        }
+        true
+    }
+
+    pub fn take_forwarded_paths() -> Vec<PathBuf> {
+        FORWARDED_PATHS
+            .lock()
+            .map(|mut paths| std::mem::take(&mut *paths))
+            .unwrap_or_default()
+    }
+}
+
+pub use windows_instance::{
+    InstanceGuard, acquire_or_forward, receive_copydata, take_forwarded_paths,
+};
+
+#[cfg(not(windows))]
+pub fn take_forwarded_paths() -> Vec<PathBuf> {
+    Vec::new()
+}

--- a/src/core/launch.rs
+++ b/src/core/launch.rs
@@ -14,7 +14,7 @@ use windows::Win32::Foundation::CloseHandle;
 use windows::Win32::Foundation::ERROR_ALREADY_EXISTS;
 use windows::Win32::Foundation::HANDLE;
 use windows::Win32::Foundation::{GetLastError, HWND, LPARAM, WPARAM};
-use windows::Win32::Globalization::GetUserDefaultLocaleName;
+use windows::Win32::Globalization::GetUserDefaultUILanguage;
 use windows::Win32::System::DataExchange::COPYDATASTRUCT;
 use windows::Win32::System::Threading::{CreateMutexW, ReleaseMutex};
 use windows::Win32::UI::WindowsAndMessaging::{
@@ -30,6 +30,30 @@ const INSTANCE_MUTEX: &str = "Local\\EdenExplorer.SingleInstance.v1";
 const WINDOW_TITLE: &str = "EdenExplorer";
 const COPYDATA_ID: usize = 0x4544_454e;
 static FORWARDED_PATHS: Mutex<Vec<PathBuf>> = Mutex::new(Vec::new());
+const LANGUAGE_MAP: &[(u16, &str)] = &[
+    // English
+    (0x0409, "en-US"),
+    (0x0809, "en-US"),
+    (0x0C09, "en-US"),
+    (0x1009, "en-US"),
+    (0x1409, "en-US"),
+    (0x1809, "en-US"),
+    (0x1C09, "en-US"),
+    (0x2009, "en-US"),
+    (0x2409, "en-US"),
+    (0x2809, "en-US"),
+    (0x2C09, "en-US"),
+    (0x3009, "en-US"),
+    (0x3409, "en-US"),
+    // Indonesian
+    (0x0421, "id-ID"),
+    // Japanese
+    (0x0411, "ja-JP"),
+    // Chinese
+    (0x0404, "zh-TW"),
+    (0x0804, "zh-CN"),
+    (0x0C04, "zh-HK"),
+];
 
 pub struct InstanceGuard {
     handle: HANDLE,
@@ -81,64 +105,56 @@ impl LaunchError {
 }
 
 struct LaunchI18n {
-    bundle: FluentBundle<FluentResource>,
+    primary: FluentBundle<FluentResource>,
+    fallback: FluentBundle<FluentResource>,
 }
 
 impl LaunchI18n {
     fn new() -> Self {
         let locale = system_locale();
+        println!("Windows locale: {}", locale);
 
         let langid = LanguageIdentifier::from_str(&locale)
             .unwrap_or_else(|_| LanguageIdentifier::from_str("en-US").unwrap());
 
-        let mut bundle = FluentBundle::new(vec![langid]);
-        bundle.set_use_isolating(false);
+        let mut primary = FluentBundle::new(vec![langid]);
+        primary.set_use_isolating(false);
+        load_locale(&mut primary, &locale);
 
-        // Always load English first.
-        load_locale(&mut bundle, "en-US");
+        let mut fallback = FluentBundle::new(vec![LanguageIdentifier::from_str("en-US").unwrap()]);
+        fallback.set_use_isolating(false);
+        load_locale(&mut fallback, "en-US");
 
-        // Overlay the user's language.
-        if locale != "en-US" {
-            load_locale(&mut bundle, &locale);
-        }
+        Self { primary, fallback }
+    }
 
-        Self { bundle }
+    fn format_bundle(
+        bundle: &FluentBundle<FluentResource>,
+        key: &str,
+        args: Option<&FluentArgs>,
+    ) -> Option<String> {
+        let message = bundle.get_message(key)?;
+        let pattern = message.value()?;
+
+        let mut errors = Vec::new();
+
+        Some(
+            bundle
+                .format_pattern(pattern, args, &mut errors)
+                .to_string(),
+        )
     }
 
     fn tr(&self, key: &str) -> String {
-        let message = match self.bundle.get_message(key) {
-            Some(message) => message,
-            None => return key.to_string(),
-        };
-
-        let pattern = match message.value() {
-            Some(pattern) => pattern,
-            None => return key.to_string(),
-        };
-
-        let mut errors = Vec::new();
-
-        self.bundle
-            .format_pattern(pattern, None, &mut errors)
-            .to_string()
+        Self::format_bundle(&self.primary, key, None)
+            .or_else(|| Self::format_bundle(&self.fallback, key, None))
+            .unwrap_or_else(|| key.to_string())
     }
 
     fn tr_args(&self, key: &str, args: &FluentArgs) -> String {
-        let message = match self.bundle.get_message(key) {
-            Some(message) => message,
-            None => return key.to_string(),
-        };
-
-        let pattern = match message.value() {
-            Some(pattern) => pattern,
-            None => return key.to_string(),
-        };
-
-        let mut errors = Vec::new();
-
-        self.bundle
-            .format_pattern(pattern, Some(args), &mut errors)
-            .to_string()
+        Self::format_bundle(&self.primary, key, Some(args))
+            .or_else(|| Self::format_bundle(&self.fallback, key, Some(args)))
+            .unwrap_or_else(|| key.to_string())
     }
 }
 
@@ -153,28 +169,13 @@ impl Drop for InstanceGuard {
 
 #[cfg(windows)]
 pub fn system_locale() -> String {
-    let mut buf = [0u16; 85];
-    let len = unsafe { GetUserDefaultLocaleName(&mut buf) };
+    let langid = unsafe { GetUserDefaultUILanguage() };
 
-    if len <= 1 {
-        return "en-US".to_string();
-    }
-
-    let locale = String::from_utf16_lossy(&buf[..(len as usize - 1)]);
-
-    // Prefer exact match.
-    if LaunchLocalizations::get(&format!("{}/main.ftl", locale)).is_some() {
-        return locale;
-    }
-
-    // Fall back to language only.
-    if let Some((language, _)) = locale.split_once('-') {
-        if LaunchLocalizations::get(&format!("{}/main.ftl", language)).is_some() {
-            return language.to_string();
-        }
-    }
-
-    "en-US".to_string()
+    LANGUAGE_MAP
+        .iter()
+        .find(|(id, _)| *id == langid)
+        .map(|(_, locale)| (*locale).to_string())
+        .unwrap_or_else(|| "en-US".to_string())
 }
 
 pub fn parse_args<I, S>(args: I) -> Result<LaunchOptions, LaunchError>
@@ -266,29 +267,42 @@ fn wide(value: &str) -> Vec<u16> {
 
 fn load_locale(bundle: &mut FluentBundle<FluentResource>, locale: &str) {
     let path = format!("{}/main.ftl", locale);
-
     let file = match LaunchLocalizations::get(&path) {
         Some(file) => file,
-        None => return,
+        None => {
+            println!("Missing locale file: {}", path);
+            return;
+        }
     };
 
     let source = match file.data {
         Cow::Borrowed(bytes) => match std::str::from_utf8(bytes) {
             Ok(text) => text.to_owned(),
-            Err(_) => return,
+            Err(e) => {
+                println!("UTF-8 error: {:?}", e);
+                return;
+            }
         },
         Cow::Owned(bytes) => match String::from_utf8(bytes) {
             Ok(text) => text,
-            Err(_) => return,
+            Err(e) => {
+                println!("UTF-8 error: {:?}", e);
+                return;
+            }
         },
     };
 
     let resource = match FluentResource::try_new(source) {
         Ok(resource) => resource,
-        Err(_) => return,
+        Err((_, errors)) => {
+            println!("Fluent parse errors: {:?}", errors);
+            return;
+        }
     };
 
-    let _ = bundle.add_resource(resource);
+    if let Err(errors) = bundle.add_resource(resource) {
+        println!("add_resource errors: {:?}", errors);
+    }
 }
 
 fn forward_paths(paths: &[PathBuf]) -> Result<(), LaunchError> {

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,5 +1,6 @@
 pub mod drives;
 pub mod fs;
 pub mod indexer;
+pub mod launch;
 pub mod portable;
 pub mod utils;

--- a/src/gui/i18n.rs
+++ b/src/gui/i18n.rs
@@ -19,6 +19,10 @@ impl I18n {
 
         Self::load_locale(&mut bundles, default_locale);
 
+        if default_locale != "en-US" {
+            Self::load_locale(&mut bundles, default_locale);
+        }
+
         Self {
             current_locale: default_locale.to_string(),
             bundles,

--- a/src/gui/windows/mainwindow.rs
+++ b/src/gui/windows/mainwindow.rs
@@ -272,10 +272,6 @@ impl Default for MainWindow {
 }
 
 impl MainWindow {
-    pub fn new() -> Self {
-        Self::new_with_paths(Vec::new())
-    }
-
     pub fn new_with_paths(paths: Vec<PathBuf>) -> Self {
         let mut app = Self::default();
         if !paths.is_empty() {

--- a/src/gui/windows/mainwindow.rs
+++ b/src/gui/windows/mainwindow.rs
@@ -2,6 +2,7 @@ use crate::core::indexer::WindowSizeMode;
 use crate::core::indexer::{
     load_app_settings, load_favorites, load_tags, load_theme_settings, save_app_settings,
 };
+use crate::core::launch::take_forwarded_paths;
 use crate::core::utils::tabs::update_tab_infos_cache;
 use crate::gui::dragdrop::{DragDropBackend, DropTargets};
 use crate::gui::i18n::I18n;
@@ -272,7 +273,14 @@ impl Default for MainWindow {
 
 impl MainWindow {
     pub fn new() -> Self {
-        let app = Self::default();
+        Self::new_with_paths(Vec::new())
+    }
+
+    pub fn new_with_paths(paths: Vec<PathBuf>) -> Self {
+        let mut app = Self::default();
+        if !paths.is_empty() {
+            app.open_startup_paths(&paths);
+        }
         app
     }
 
@@ -291,6 +299,15 @@ impl MainWindow {
 
 impl eframe::App for MainWindow {
     fn update(&mut self, ctx: &egui::Context, frame: &mut eframe::Frame) {
+        {
+            let forwarded_paths = take_forwarded_paths();
+            for path in &forwarded_paths {
+                self.open_new_tab(path.clone());
+            }
+            if !forwarded_paths.is_empty() {
+                self.load_path();
+            }
+        }
         let palette = get_palette(self.theme);
 
         if self.hwnd.is_none() {

--- a/src/gui/windows/mainwindow_imp.rs
+++ b/src/gui/windows/mainwindow_imp.rs
@@ -152,6 +152,39 @@ impl MainWindow {
         self.mark_tab_infos_dirty();
     }
 
+    pub fn open_startup_paths(&mut self, paths: &[PathBuf]) {
+        let Some(first_path) = paths.first() else {
+            return;
+        };
+
+        let pinned_count = self.settings_window.current_settings.pinned_tabs.len();
+        if pinned_count == 0 {
+            self.tabs[0].primary_view.nav = Navigation::new(first_path.clone());
+            self.active_tab = 0;
+            self.focused_split = SplitSide::Primary;
+            self.load_path();
+        } else {
+            self.open_new_tab(first_path.clone());
+            self.load_path();
+        }
+
+        for path in paths.iter().skip(1) {
+            self.open_new_tab(path.clone());
+        }
+
+        if pinned_count > 0 {
+            self.active_tab = pinned_count;
+            self.focused_split = SplitSide::Primary;
+            self.pending_tab_scroll_id = self.tabs.get(self.active_tab).map(|tab| tab.id);
+            self.load_path();
+        } else {
+            self.active_tab = 0;
+            self.focused_split = SplitSide::Primary;
+            self.pending_tab_scroll_id = self.tabs.first().map(|tab| tab.id);
+        }
+        self.mark_tab_infos_dirty();
+    }
+
     pub fn default_favorites(&self) -> Vec<FavoriteItem> {
         let mut favorites = Vec::new();
         if let Some(home) = dirs::home_dir() {

--- a/src/gui/windows/windowsoverrides.rs
+++ b/src/gui/windows/windowsoverrides.rs
@@ -1,5 +1,6 @@
 use crate::core::drives::mark_drive_cache_dirty;
 use crate::core::indexer::{WindowSizeMode, load_app_settings, save_app_settings};
+use crate::core::launch::receive_copydata;
 use crate::gui::theme::ThemePalette;
 use crate::gui::utils::clickable_icon;
 use eframe::egui;
@@ -235,6 +236,14 @@ unsafe extern "system" fn custom_wndproc(
     lparam: LPARAM,
 ) -> LRESULT {
     match msg {
+        WM_COPYDATA => {
+            if receive_copydata(lparam) {
+                request_repaint();
+                LRESULT(1)
+            } else {
+                LRESULT(0)
+            }
+        }
         WM_CLIPBOARDUPDATE => {
             mark_clipboard_dirty();
             LRESULT(0)

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ mod core;
 mod gui;
 
 use crate::core::indexer::{WindowSizeMode, load_windows_size_mode_on_start};
+use crate::core::launch::{existing_directories, parse_args};
 use crate::core::utils::fonts::apply_custom_font_definitions;
 use crate::gui::windows::windowsoverrides::set_egui_ctx;
 use eframe::{NativeOptions, egui};
@@ -10,6 +11,34 @@ use windows::Win32::System::Com::{COINIT_APARTMENTTHREADED, CoInitializeEx};
 use windows::Win32::UI::WindowsAndMessaging::{GetSystemMetrics, SM_CXSCREEN, SM_CYSCREEN};
 
 fn main() -> eframe::Result<()> {
+    let launch_options = match parse_args(std::env::args()) {
+        Ok(options) => options,
+        Err(error) => {
+            show_launch_error(&error);
+            return Ok(());
+        }
+    };
+    let launch_paths = match existing_directories(&launch_options) {
+        Ok(paths) => paths,
+        Err(error) => {
+            show_launch_error(&error);
+            return Ok(());
+        }
+    };
+
+    let _instance_guard = if launch_options.new_window {
+        None
+    } else {
+        match crate::core::launch::acquire_or_forward(&launch_paths) {
+            Ok(Some(guard)) => Some(guard),
+            Ok(None) => return Ok(()),
+            Err(error) => {
+                show_launch_error(&error);
+                return Ok(());
+            }
+        }
+    };
+
     unsafe {
         let _ = CoInitializeEx(None, COINIT_APARTMENTTHREADED);
     }
@@ -52,9 +81,38 @@ fn main() -> eframe::Result<()> {
             cc.egui_ctx.set_fonts(fonts);
             set_egui_ctx(&cc.egui_ctx);
 
-            Ok(Box::new(gui::MainWindow::new()))
+            Ok(Box::new(gui::MainWindow::new_with_paths(
+                launch_paths.clone(),
+            )))
         }),
     )
+}
+
+fn show_launch_error(message: &str) {
+    {
+        use std::os::windows::ffi::OsStrExt;
+        use windows::Win32::UI::WindowsAndMessaging::{MB_ICONERROR, MB_OK, MessageBoxW};
+        use windows::core::PCWSTR;
+        let text: Vec<u16> = std::ffi::OsStr::new(message)
+            .encode_wide()
+            .chain(std::iter::once(0))
+            .collect();
+        let title: Vec<u16> = std::ffi::OsStr::new("EdenExplorer")
+            .encode_wide()
+            .chain(std::iter::once(0))
+            .collect();
+
+        unsafe {
+            let _ = MessageBoxW(
+                None,
+                PCWSTR(text.as_ptr()),
+                PCWSTR(title.as_ptr()),
+                MB_OK | MB_ICONERROR,
+            );
+        }
+    }
+    #[cfg(not(windows))]
+    eprintln!("{message}");
 }
 
 static ICON_BYTES: &[u8] = include_bytes!("assets/icon.ico");

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,12 +3,16 @@ mod core;
 mod gui;
 
 use crate::core::indexer::{WindowSizeMode, load_windows_size_mode_on_start};
-use crate::core::launch::{existing_directories, parse_args};
+use crate::core::launch::{LaunchError, acquire_or_forward, existing_directories, parse_args};
 use crate::core::utils::fonts::apply_custom_font_definitions;
 use crate::gui::windows::windowsoverrides::set_egui_ctx;
 use eframe::{NativeOptions, egui};
+use std::os::windows::ffi::OsStrExt;
 use windows::Win32::System::Com::{COINIT_APARTMENTTHREADED, CoInitializeEx};
-use windows::Win32::UI::WindowsAndMessaging::{GetSystemMetrics, SM_CXSCREEN, SM_CYSCREEN};
+use windows::Win32::UI::WindowsAndMessaging::{
+    GetSystemMetrics, MB_ICONERROR, MB_OK, MessageBoxW, SM_CXSCREEN, SM_CYSCREEN,
+};
+use windows::core::PCWSTR;
 
 fn main() -> eframe::Result<()> {
     let launch_options = match parse_args(std::env::args()) {
@@ -29,7 +33,7 @@ fn main() -> eframe::Result<()> {
     let _instance_guard = if launch_options.new_window {
         None
     } else {
-        match crate::core::launch::acquire_or_forward(&launch_paths) {
+        match acquire_or_forward(&launch_paths) {
             Ok(Some(guard)) => Some(guard),
             Ok(None) => return Ok(()),
             Err(error) => {
@@ -88,15 +92,16 @@ fn main() -> eframe::Result<()> {
     )
 }
 
-fn show_launch_error(message: &str) {
+fn show_launch_error(error: &LaunchError) {
+    let message = error.message();
+
+    #[cfg(windows)]
     {
-        use std::os::windows::ffi::OsStrExt;
-        use windows::Win32::UI::WindowsAndMessaging::{MB_ICONERROR, MB_OK, MessageBoxW};
-        use windows::core::PCWSTR;
-        let text: Vec<u16> = std::ffi::OsStr::new(message)
+        let text: Vec<u16> = std::ffi::OsStr::new(&message)
             .encode_wide()
             .chain(std::iter::once(0))
             .collect();
+
         let title: Vec<u16> = std::ffi::OsStr::new("EdenExplorer")
             .encode_wide()
             .chain(std::iter::once(0))
@@ -111,6 +116,7 @@ fn show_launch_error(message: &str) {
             );
         }
     }
+
     #[cfg(not(windows))]
     eprintln!("{message}");
 }


### PR DESCRIPTION
---

Defaults to opening in new tab in the existing open window (if any). use `--new-window` to open in a new window, instead. multiple paths may be supplied.

Useful for scripts, open folders from other apps, context menu integrations (e.g. Custom Context Menu), or to open folder in EdenExplorer from launchers (like Command Palette, Raycast, etc.). and more.

The following are all valid:

```
EdenExplorer.exe
EdenExplorer.exe "C:\Windows"
EdenExplorer.exe "C:\Windows" "C:\"
EdenExplorer.exe --new-window "C:\Windows" "C:\"
```

If no path is given, it will honor the configured startup directory in settings.

## 🆕 What's New

* Added single-instance enforcement for EdenExplorer on Windows.
* Added `--new-window` support for launching additional windows.
* Added support for opening multiple directories from the command line.
* Added inter-process communication to forward directory-opening requests to the existing instance.

## 🔄 What's Changed

* Startup paths are now validated and opened in separate tabs. User can provide more than one path.
* Improved handling of pinned tabs and initial navigation state.
* Added user-friendly error dialogs for invalid command-line arguments and missing directories.
* Updated Windows crate features and registered the new launch module.

## 🐛 What's Fixed

* Prevented multiple EdenExplorer instances from running by default.
* Improved forwarding and opening of directories launched from another process.
* Added robust handling for unknown options and non-existent paths.

## 🔗 Related Issues

* none