### PR TITLE
feat: massive ui overhaul and egui upgrades

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "EdenExplorer"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "bincode",
  "chrono",
@@ -31,8 +31,8 @@ dependencies = [
  "serde_json",
  "sys-locale",
  "unic-langid",
- "windows 0.62.2",
- "windows-core 0.62.2",
+ "windows",
+ "windows-core",
  "winres",
 ]
 
@@ -54,47 +54,68 @@ checksum = "366ffbaa4442f4684d91e2cd7c5ea7c4ed8add41959a31447066e279e432b618"
 
 [[package]]
 name = "accesskit"
-version = "0.21.1"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf203f9d3bd8f29f98833d1fbef628df18f759248a547e7e01cfbf63cda36a99"
+checksum = "d3b7f7f85a7e5f68090000ed7622545829afd484d210358702ae4cb97dd0c320"
 dependencies = [
  "enumn",
  "serde",
+ "uuid",
 ]
 
 [[package]]
 name = "accesskit_atspi_common"
-version = "0.14.2"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "890d241cf51fc784f0ac5ac34dfc847421f8d39da6c7c91a0fcc987db62a8267"
+checksum = "1e8c61bee90b42a772d39d06a740207dc71a4e780004ace1db8d99fb1baaa954"
 dependencies = [
  "accesskit",
- "accesskit_consumer",
+ "accesskit_consumer 0.36.0",
  "atspi-common",
+ "phf 0.13.1",
  "serde",
- "thiserror 1.0.69",
  "zvariant",
 ]
 
 [[package]]
 name = "accesskit_consumer"
-version = "0.31.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db81010a6895d8707f9072e6ce98070579b43b717193d2614014abd5cb17dd43"
+checksum = "53cf47daed85312e763fbf85ceca136e0d7abc68e0a7e12abe11f48172bc3b10"
 dependencies = [
  "accesskit",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
+]
+
+[[package]]
+name = "accesskit_consumer"
+version = "0.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25e0d7e25d06f4dc21d1774d67146e9e80d6789216cbd4d1e88185b0095dba60"
+dependencies = [
+ "accesskit",
+ "hashbrown 0.16.1",
+]
+
+[[package]]
+name = "accesskit_consumer"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d10a236f96f87d70732e44520046785431ef01d5bcd6b041317bfadd2f88245"
+dependencies = [
+ "accesskit",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
 name = "accesskit_macos"
-version = "0.22.2"
+version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0089e5c0ac0ca281e13ea374773898d9354cc28d15af9f0f7394d44a495b575"
+checksum = "ce02dc63b43f0c9296af9ac946312a2dc8814427d7a64d2d600971dac55b6076"
 dependencies = [
  "accesskit",
- "accesskit_consumer",
- "hashbrown 0.15.5",
+ "accesskit_consumer 0.38.0",
+ "hashbrown 0.16.1",
  "objc2 0.5.2",
  "objc2-app-kit 0.2.2",
  "objc2-foundation 0.2.2",
@@ -102,9 +123,9 @@ dependencies = [
 
 [[package]]
 name = "accesskit_unix"
-version = "0.17.2"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301e55b39cfc15d9c48943ce5f572204a551646700d0e8efa424585f94fec528"
+checksum = "b016ca8db0ea0ea2ceff29a9d6240391492d960716aa471967c00e8cc8cb197c"
 dependencies = [
  "accesskit",
  "accesskit_atspi_common",
@@ -120,23 +141,23 @@ dependencies = [
 
 [[package]]
 name = "accesskit_windows"
-version = "0.29.2"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2d63dd5041e49c363d83f5419a896ecb074d309c414036f616dc0b04faca971"
+checksum = "eff7009f1a532e917d66970a1e80c965140c6cfbbabbdde3d64e5431e6c78e21"
 dependencies = [
  "accesskit",
- "accesskit_consumer",
- "hashbrown 0.15.5",
+ "accesskit_consumer 0.35.0",
+ "hashbrown 0.16.1",
  "static_assertions",
- "windows 0.61.3",
- "windows-core 0.61.2",
+ "windows",
+ "windows-core",
 ]
 
 [[package]]
 name = "accesskit_winit"
-version = "0.29.2"
+version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8cfabe59d0eaca7412bfb1f70198dd31e3b0496fee7e15b066f9c36a1a140a0"
+checksum = "1fe9a94394896352cc4660ca2288bd4ef883d83238853c038b44070c8f134313"
 dependencies = [
  "accesskit",
  "accesskit_macos",
@@ -197,7 +218,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef6978589202a00cd7e118380c448a08b6ed394c3a8df3a430d0898e3a42d046"
 dependencies = [
  "android-properties",
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
  "cc",
  "cesu8",
  "jni 0.21.1",
@@ -453,20 +474,19 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "atspi"
-version = "0.25.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c83247582e7508838caf5f316c00791eee0e15c0bf743e6880585b867e16815c"
+checksum = "c77886257be21c9cd89a4ae7e64860c6f0eefca799bb79127913052bd0eefb3d"
 dependencies = [
  "atspi-common",
- "atspi-connection",
  "atspi-proxies",
 ]
 
 [[package]]
 name = "atspi-common"
-version = "0.9.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33dfc05e7cdf90988a197803bf24f5788f94f7c94a69efa95683e8ffe76cfdfb"
+checksum = "20c5617155740c98003016429ad13fe43ce7a77b007479350a9f8bf95a29f63d"
 dependencies = [
  "enumflags2",
  "serde",
@@ -479,22 +499,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "atspi-connection"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4193d51303d8332304056ae0004714256b46b6635a5c556109b319c0d3784938"
-dependencies = [
- "atspi-common",
- "atspi-proxies",
- "futures-lite",
- "zbus",
-]
-
-[[package]]
 name = "atspi-proxies"
-version = "0.9.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2eebcb9e7e76f26d0bcfd6f0295e1cd1e6f33bedbc5698a971db8dc43d7751c"
+checksum = "2230e48787ed3eb4088996eab66a32ca20c0b67bbd4fd6cdfe79f04f1f04c9fc"
 dependencies = [
  "atspi-common",
  "serde",
@@ -561,18 +569,18 @@ dependencies = [
 
 [[package]]
 name = "bit-set"
-version = "0.8.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+checksum = "34ddef2995421ab6a5c779542c81ee77c115206f4ad9d5a8e05f4ff49716a3dd"
 dependencies = [
  "bit-vec",
 ]
 
 [[package]]
 name = "bit-vec"
-version = "0.8.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
 
 [[package]]
 name = "bit_field"
@@ -588,9 +596,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "bitstream-io"
@@ -600,12 +608,6 @@ checksum = "60d4bd9d1db2c6bdf285e223a7fa369d5ce98ec767dec949c6ca62863ce61757"
 dependencies = [
  "core2",
 ]
-
-[[package]]
-name = "block"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
 
 [[package]]
 name = "block-buffer"
@@ -703,7 +705,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b99da2f8558ca23c71f4fd15dc57c906239752dd27ff3c00a1d56b685b7cbfec"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
  "log",
  "polling",
  "rustix 0.38.44",
@@ -717,7 +719,7 @@ version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dbf9978365bac10f54d1d4b04f7ce4427e51f71d61f2fe15e3fed5166474df7"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
  "polling",
  "rustix 1.1.4",
  "slab",
@@ -797,7 +799,7 @@ dependencies = [
  "js-sys",
  "num-traits",
  "wasm-bindgen",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -820,13 +822,22 @@ dependencies = [
 
 [[package]]
 name = "codespan-reporting"
-version = "0.12.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe6d2e5af09e8c8ad56c969f2157a3d4238cebc7c55f0a517728c38f7b200f81"
+checksum = "af491d569909a7e4dee0ad7db7f5341fef5c614d5b8ec8cf765732aba3cff681"
 dependencies = [
  "serde",
  "termcolor",
  "unicode-width",
+]
+
+[[package]]
+name = "color"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ec7c5eb7a16992b1904d76c517d170ab353b0e0b3d5a0c81a8a0cd1037893cf"
+dependencies = [
+ "bytemuck",
 ]
 
 [[package]]
@@ -888,7 +899,7 @@ checksum = "c07782be35f9e1140080c6b96f0d44b739e2278479f64e02fdab4e32dfd8b081"
 dependencies = [
  "bitflags 1.3.2",
  "core-foundation 0.9.4",
- "core-graphics-types 0.1.3",
+ "core-graphics-types",
  "foreign-types",
  "libc",
 ]
@@ -901,17 +912,6 @@ checksum = "45390e6114f68f718cc7a830514a96f903cccd70d02a8f6d9f643ac4ba45afaf"
 dependencies = [
  "bitflags 1.3.2",
  "core-foundation 0.9.4",
- "libc",
-]
-
-[[package]]
-name = "core-graphics-types"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
-dependencies = [
- "bitflags 2.11.0",
- "core-foundation 0.10.1",
  "libc",
 ]
 
@@ -1047,7 +1047,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
  "block2 0.6.2",
  "libc",
  "objc2 0.6.4",
@@ -1096,9 +1096,9 @@ checksum = "d8b14ccef22fc6f5a8f4d7d768562a182c04ce9a3b3157b91390b52ddfdf1a76"
 
 [[package]]
 name = "ecolor"
-version = "0.33.3"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71ddb8ac7643d1dba1bb02110e804406dd459a838efcb14011ced10556711a8e"
+checksum = "6758be723a3f298bbfda4db75748bc2ba0abafe096b6383c7c32da264764fbc3"
 dependencies = [
  "bytemuck",
  "emath",
@@ -1107,9 +1107,9 @@ dependencies = [
 
 [[package]]
 name = "eframe"
-version = "0.33.3"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "457481173e6db5ca9fa2be93a58df8f4c7be639587aeb4853b526c6cf87db4e6"
+checksum = "8dc8234e2f681b2afd2b2e8c332fa614de2fddbdcb28d0acf5c420449682ea90"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -1118,17 +1118,17 @@ dependencies = [
  "egui-wgpu",
  "egui-winit",
  "egui_glow",
- "glow",
  "glutin",
  "glutin-winit",
  "image",
  "js-sys",
  "log",
- "objc2 0.5.2",
- "objc2-app-kit 0.2.2",
- "objc2-foundation 0.2.2",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
+ "objc2-foundation 0.3.2",
  "parking_lot",
  "percent-encoding",
+ "pollster",
  "profiling",
  "raw-window-handle",
  "static_assertions",
@@ -1136,21 +1136,23 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "web-time",
+ "wgpu",
  "windows-sys 0.61.2",
  "winit",
 ]
 
 [[package]]
 name = "egui"
-version = "0.33.3"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a9b567d356674e9a5121ed3fedfb0a7c31e059fe71f6972b691bcd0bfc284e3"
+checksum = "2796c98d50b79631281d516343a6f6e93c0666462ca36e2c93b39f25d7793325"
 dependencies = [
  "accesskit",
  "ahash",
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
  "emath",
  "epaint",
+ "itertools",
  "log",
  "nohash-hasher",
  "profiling",
@@ -1161,18 +1163,18 @@ dependencies = [
 
 [[package]]
 name = "egui-phosphor"
-version = "0.11.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3b2838620355debaeb7fa3cc331a1d8ab77e6387d40e65686fa468c229dbf63"
+checksum = "249826f9529c1757d71dbbb3a22ec101b21110ab663c45fb771c2b86121379e4"
 dependencies = [
  "egui",
 ]
 
 [[package]]
 name = "egui-wgpu"
-version = "0.33.3"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e4d209971c84b2352a06174abdba701af1e552ce56b144d96f2bd50a3c91236"
+checksum = "d2e6cfac0725563555fa4f91e9f799b9d7c6c5dd831fca6abc8234afc64b7a34"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -1190,18 +1192,18 @@ dependencies = [
 
 [[package]]
 name = "egui-winit"
-version = "0.33.3"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec6687e5bb551702f4ad10ac428bab12acf9d53047ebb1082d4a0ed8c6251a29"
+checksum = "9ea6bf3608db949588b95b8b341ee358d0c3f95cf4dc3f53d8d76717edee87db"
 dependencies = [
  "accesskit_winit",
  "arboard",
  "bytemuck",
  "egui",
  "log",
- "objc2 0.5.2",
- "objc2-foundation 0.2.2",
- "objc2-ui-kit",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
+ "objc2-ui-kit 0.3.2",
  "profiling",
  "raw-window-handle",
  "smithay-clipboard",
@@ -1212,13 +1214,14 @@ dependencies = [
 
 [[package]]
 name = "egui_extras"
-version = "0.33.3"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d01d34e845f01c62e3fded726961092e70417d66570c499b9817ab24674ca4ed"
+checksum = "e2bd33be7338367bf21f54d62e069d58a5fb3ae033fa8bc6df7a77b9ef4cf957"
 dependencies = [
  "ahash",
  "egui",
  "enum-map",
+ "itertools",
  "log",
  "mime_guess2",
  "profiling",
@@ -1226,9 +1229,9 @@ dependencies = [
 
 [[package]]
 name = "egui_glow"
-version = "0.33.3"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6420863ea1d90e750f75075231a260030ad8a9f30a7cef82cdc966492dc4c4eb"
+checksum = "52274b9bfb8d8e252cd0f00c9f6214f360d75a0962baa77a2d62ddb002fe99d4"
 dependencies = [
  "bytemuck",
  "egui",
@@ -1236,8 +1239,6 @@ dependencies = [
  "log",
  "memoffset",
  "profiling",
- "wasm-bindgen",
- "web-sys",
  "winit",
 ]
 
@@ -1249,9 +1250,9 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "emath"
-version = "0.33.3"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "491bdf728bf25ddd9ad60d4cf1c48588fa82c013a2440b91aa7fc43e34a07c32"
+checksum = "cd4ec073c9898516584d8c6cfdcee95b530b3d941cd5031ef4050aa36812308b"
 dependencies = [
  "bytemuck",
  "serde",
@@ -1329,28 +1330,35 @@ dependencies = [
 
 [[package]]
 name = "epaint"
-version = "0.33.3"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "009d0dd3c2163823a0abdb899451ecbc78798dec545ee91b43aff1fa790bab62"
+checksum = "4e60a8888b51da911df23918fd7301359b1d43a406a0ff3b8863af093dd7fc6c"
 dependencies = [
- "ab_glyph",
  "ahash",
  "bytemuck",
  "ecolor",
  "emath",
  "epaint_default_fonts",
+ "font-types",
+ "harfrust",
  "log",
  "nohash-hasher",
  "parking_lot",
  "profiling",
+ "self_cell 1.3.0",
  "serde",
+ "skrifa",
+ "smallvec",
+ "unicode-general-category",
+ "unicode-segmentation",
+ "vello_cpu",
 ]
 
 [[package]]
 name = "epaint_default_fonts"
-version = "0.33.3"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c4fbe202b6578d3d56428fa185cdf114a05e49da05f477b3c7f0fbb221f1862"
+checksum = "13ee4e1f553a3584c301f3a56ff1a775f1384781396cea301c8d952e9b93f560"
 
 [[package]]
 name = "equator"
@@ -1393,6 +1401,15 @@ name = "error-code"
 version = "3.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
+
+[[package]]
+name = "euclid"
+version = "0.22.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "event-listener"
@@ -1466,6 +1483,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fearless_simd"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97b65636e5b9ef369943878ac74335ba1c55c1cb6adbf1e2c293c624248d693"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1536,6 +1559,16 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "font-types"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b38ad915f6dadd993ced50848a8291a543bd41ca62bc10740d5e64e2ab4cfd7"
+dependencies = [
+ "bytemuck",
+ "serde",
+]
 
 [[package]]
 name = "foreign-types"
@@ -1645,7 +1678,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
 dependencies = [
  "rustix 1.1.4",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -1706,10 +1739,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "glow"
-version = "0.16.0"
+name = "glifo"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5e5ea60d70410161c8bf5da3fdfeaa1c72ed2c15f8bbb9d19fe3a4fad085f08"
+checksum = "d99fc21d493812643aae86d53b7bbd02f376434a90317e8a790bc209fdd6605e"
+dependencies = [
+ "bytemuck",
+ "foldhash 0.2.0",
+ "hashbrown 0.17.1",
+ "log",
+ "peniko",
+ "skrifa",
+ "smallvec",
+ "vello_common",
+]
+
+[[package]]
+name = "glow"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29038e1c483364cc6bb3cf78feee1816002e127c331a1eec55a4d202b9e1adb5"
 dependencies = [
  "js-sys",
  "slotmap",
@@ -1723,7 +1772,7 @@ version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12124de845cacfebedff80e877bb37b5b75c34c5a4c89e47e1cdd67fb6041325"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
  "cfg_aliases",
  "cgl",
  "dispatch2",
@@ -1784,34 +1833,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "gpu-alloc"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbcd2dba93594b227a1f57ee09b8b9da8892c34d55aa332e034a228d0fe6a171"
-dependencies = [
- "bitflags 2.11.0",
- "gpu-alloc-types",
-]
-
-[[package]]
-name = "gpu-alloc-types"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98ff03b468aa837d70984d55f5d3f846f6ec31fe34bbb97c4f85219caeee1ca4"
-dependencies = [
- "bitflags 2.11.0",
-]
-
-[[package]]
 name = "gpu-allocator"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c151a2a5ef800297b4e79efa4f4bec035c5f51d5ae587287c9b952bdf734cacd"
+checksum = "51255ea7cfaadb6c5f1528d43e92a82acb2b96c43365989a28b2d44ee38f8795"
 dependencies = [
+ "ash",
+ "hashbrown 0.16.1",
  "log",
  "presser",
- "thiserror 1.0.69",
- "windows 0.58.0",
+ "thiserror 2.0.18",
+ "windows",
 ]
 
 [[package]]
@@ -1820,7 +1852,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b89c83349105e3732062a895becfc71a8f921bb71ecbbdd8ff99263e3b53a0ca"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
  "gpu-descriptor-types",
  "hashbrown 0.15.5",
 ]
@@ -1831,7 +1863,16 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdf242682df893b86f33a73828fb09ca4b2d3bb6cc95249707fc684d27484b91"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
+]
+
+[[package]]
+name = "guillotiere"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b17e70c989c36bad147b27a58d148c0741c51448aa5653436547323e524d0ab"
+dependencies = [
+ "euclid",
 ]
 
 [[package]]
@@ -1844,6 +1885,18 @@ dependencies = [
  "crunchy",
  "num-traits",
  "zerocopy",
+]
+
+[[package]]
+name = "harfrust"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0431e8e389aa0f1e72bb9d1c2db8957a1a7a3580e8ed97db819c14837aac9b3e"
+dependencies = [
+ "bitflags 2.13.1",
+ "bytemuck",
+ "read-fonts",
+ "smallvec",
 ]
 
 [[package]]
@@ -1870,14 +1923,16 @@ version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.2.0",
 ]
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -1934,7 +1989,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -2181,7 +2236,7 @@ dependencies = [
  "simd_cesu8",
  "thiserror 2.0.18",
  "walkdir",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -2234,11 +2289,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.91"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
 dependencies = [
- "once_cell",
+ "cfg-if",
+ "futures-util",
  "wasm-bindgen",
 ]
 
@@ -2258,6 +2314,18 @@ name = "khronos_api"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
+
+[[package]]
+name = "kurbo"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b60dfc32f652b926df6192e55525b16d186c69d47876c3ead4da5cc9f8450e2"
+dependencies = [
+ "arrayvec",
+ "euclid",
+ "polycool",
+ "smallvec",
+]
 
 [[package]]
 name = "lazy_static"
@@ -2300,7 +2368,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
 dependencies = [
  "cfg-if",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -2315,11 +2383,17 @@ version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
  "libc",
  "plain",
  "redox_syscall 0.7.3",
 ]
+
+[[package]]
+name = "linebender_resource_handle"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4a5ff6bcca6c4867b1c4fd4ef63e4db7436ef363e0ad7531d1558856bae64f4"
 
 [[package]]
 name = "linux-raw-sys"
@@ -2356,9 +2430,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "loop9"
@@ -2375,16 +2449,7 @@ version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e0b564323a0fb6d54b864f625ae139de9612e27edb944dda37c109f05aac531"
 dependencies = [
- "hashbrown 0.17.0",
-]
-
-[[package]]
-name = "malloc_buf"
-version = "0.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
-dependencies = [
- "libc",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -2422,21 +2487,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "metal"
-version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00c15a6f673ff72ddcc22394663290f870fb224c1bfce55734a75c414150e605"
-dependencies = [
- "bitflags 2.11.0",
- "block",
- "core-graphics-types 0.2.0",
- "foreign-types",
- "log",
- "objc",
- "paste",
-]
-
-[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2449,8 +2499,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1706dc14a2e140dec0a7a07109d9a3d5890b81e85bd6c60b906b249a77adf0ca"
 dependencies = [
  "mime",
- "phf",
- "phf_shared",
+ "phf 0.11.3",
+ "phf_shared 0.11.3",
  "unicase",
 ]
 
@@ -2476,13 +2526,13 @@ dependencies = [
 
 [[package]]
 name = "naga"
-version = "27.0.3"
+version = "29.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "066cf25f0e8b11ee0df221219010f213ad429855f57c494f995590c861a9a7d8"
+checksum = "b2bf919621e7975acb27d881bae2fb993e0d45c8e0446e85e6272971e00dc8df"
 dependencies = [
  "arrayvec",
  "bit-set",
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
  "cfg-if",
  "cfg_aliases",
  "codespan-reporting",
@@ -2506,7 +2556,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
  "jni-sys 0.3.0",
  "log",
  "ndk-sys",
@@ -2650,15 +2700,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "objc"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
-dependencies = [
- "malloc_buf",
-]
-
-[[package]]
 name = "objc-sys"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2689,14 +2730,14 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4e89ad9e3d7d297152b17d39ed92cd50ca8063a89a9fa569046d41568891eff"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
  "block2 0.5.1",
  "libc",
  "objc2 0.5.2",
  "objc2-core-data",
  "objc2-core-image",
  "objc2-foundation 0.2.2",
- "objc2-quartz-core",
+ "objc2-quartz-core 0.2.2",
 ]
 
 [[package]]
@@ -2705,7 +2746,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
  "block2 0.6.2",
  "objc2 0.6.4",
  "objc2-core-foundation",
@@ -2719,7 +2760,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74dd3b56391c7a0596a295029734d3c1c5e7e510a4cb30245f8221ccea96b009"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-core-location",
@@ -2743,7 +2784,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "617fbf49e071c178c0b24c080767db52958f716d9eabdf0890523aeae54773ef"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
@@ -2755,7 +2796,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
  "dispatch2",
  "objc2 0.6.4",
 ]
@@ -2766,7 +2807,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
  "dispatch2",
  "objc2 0.6.4",
  "objc2-core-foundation",
@@ -2782,7 +2823,7 @@ dependencies = [
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
- "objc2-metal",
+ "objc2-metal 0.2.2",
 ]
 
 [[package]]
@@ -2809,7 +2850,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
  "block2 0.5.1",
  "dispatch",
  "libc",
@@ -2822,7 +2863,8 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
+ "block2 0.6.2",
  "objc2 0.6.4",
  "objc2-core-foundation",
 ]
@@ -2833,7 +2875,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
  "objc2 0.6.4",
  "objc2-core-foundation",
 ]
@@ -2856,10 +2898,22 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd0cba1276f6023976a406a14ffa85e1fdd19df6b0f737b063b95f6c8c7aadd6"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-metal"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0125f776a10d00af4152d74616409f0d4a2053a6f57fa5b7d6aa2854ac04794"
+dependencies = [
+ "bitflags 2.13.1",
+ "block2 0.6.2",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -2868,11 +2922,24 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e42bee7bff906b14b167da2bac5efe6b6a07e6f7c0a21a7308d40c960242dc7a"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
- "objc2-metal",
+ "objc2-metal 0.2.2",
+]
+
+[[package]]
+name = "objc2-quartz-core"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
+dependencies = [
+ "bitflags 2.13.1",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+ "objc2-metal 0.3.2",
 ]
 
 [[package]]
@@ -2891,7 +2958,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8bb46798b20cd6b91cbd113524c490f1686f4c4e8f49502431415f3512e2b6f"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-cloud-kit",
@@ -2900,10 +2967,22 @@ dependencies = [
  "objc2-core-location",
  "objc2-foundation 0.2.2",
  "objc2-link-presentation",
- "objc2-quartz-core",
+ "objc2-quartz-core 0.2.2",
  "objc2-symbols",
  "objc2-uniform-type-identifiers",
  "objc2-user-notifications",
+]
+
+[[package]]
+name = "objc2-ui-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
+dependencies = [
+ "bitflags 2.13.1",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -2923,7 +3002,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76cfcbf642358e8689af64cee815d139339f3ed8ad05103ed5eaf73db8d84cb3"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-core-location",
@@ -3006,7 +3085,7 @@ dependencies = [
  "libc",
  "redox_syscall 0.5.18",
  "smallvec",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -3022,6 +3101,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
 
 [[package]]
+name = "peniko"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "839c8299360d2e998bdb106dc0a6cd71dcc5f4df51df1b620361bf50e283cca6"
+dependencies = [
+ "bytemuck",
+ "color",
+ "kurbo",
+ "linebender_resource_handle",
+ "smallvec",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3033,8 +3125,19 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
- "phf_macros",
- "phf_shared",
+ "phf_macros 0.11.3",
+ "phf_shared 0.11.3",
+]
+
+[[package]]
+name = "phf"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+dependencies = [
+ "phf_macros 0.13.1",
+ "phf_shared 0.13.1",
+ "serde",
 ]
 
 [[package]]
@@ -3043,8 +3146,18 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
- "phf_shared",
+ "phf_shared 0.11.3",
  "rand 0.8.5",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
+dependencies = [
+ "fastrand",
+ "phf_shared 0.13.1",
 ]
 
 [[package]]
@@ -3053,12 +3166,25 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
 dependencies = [
- "phf_generator",
- "phf_shared",
+ "phf_generator 0.11.3",
+ "phf_shared 0.11.3",
  "proc-macro2",
  "quote",
  "syn",
  "unicase",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
+dependencies = [
+ "phf_generator 0.13.1",
+ "phf_shared 0.13.1",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -3069,6 +3195,15 @@ checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
 dependencies = [
  "siphasher",
  "unicase",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
+dependencies = [
+ "siphasher",
 ]
 
 [[package]]
@@ -3126,7 +3261,7 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -3152,6 +3287,15 @@ name = "pollster"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3"
+
+[[package]]
+name = "polycool"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50596ddc09eb5ad5f75cacd40209568e66df71baf86e1499a0e99c4cff12a5a6"
+dependencies = [
+ "arrayvec",
+]
 
 [[package]]
 name = "portable-atomic"
@@ -3420,6 +3564,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
 
 [[package]]
+name = "raw-window-metal"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40d213455a5f1dc59214213c7330e074ddf8114c9a42411eb890c767357ce135"
+dependencies = [
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+ "objc2-quartz-core 0.3.2",
+]
+
+[[package]]
 name = "rayon"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3440,6 +3596,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "read-fonts"
+version = "0.39.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4ed38b89c2c77ff968c524145ad65fb010f38af5c7a224b53b81d47ac2daa81"
+dependencies = [
+ "bytemuck",
+ "font-types",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3454,7 +3620,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -3463,7 +3629,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -3577,7 +3743,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -3590,7 +3756,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
@@ -3643,14 +3809,14 @@ version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e14e4d63b804dc0c7ec4a1e52bcb63f02c7ac94476755aa579edac21e01f915d"
 dependencies = [
- "self_cell 1.2.2",
+ "self_cell 1.3.0",
 ]
 
 [[package]]
 name = "self_cell"
-version = "1.2.2"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b12e76d157a900eb52e81bc6e9f3069344290341720e9178cde2407113ac8d89"
+checksum = "2ab42ca02749e120097e328d91d415325bdf43b1c72c4c8badf37375fe40a813"
 
 [[package]]
 name = "semver"
@@ -3777,6 +3943,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
+name = "skrifa"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c34617370ae968efb7161bb2beb517d9084659aae19e24b89e3db25b46e4564"
+dependencies = [
+ "bytemuck",
+ "read-fonts",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3796,6 +3972,9 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "smithay-client-toolkit"
@@ -3803,7 +3982,7 @@ version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3457dea1f0eb631b4034d61d4d8c32074caa6cd1ab2d59f2327bd8461e2c0016"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
  "calloop 0.13.0",
  "calloop-wayland-source 0.3.0",
  "cursor-icon",
@@ -3828,7 +4007,7 @@ version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0512da38f5e2b31201a93524adb8d3136276fa4fe4aafab4e1f727a82b534cc0"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
  "calloop 0.14.4",
  "calloop-wayland-source 0.4.1",
  "cursor-icon",
@@ -3880,11 +4059,11 @@ dependencies = [
 
 [[package]]
 name = "spirv"
-version = "0.3.0+sdk-1.3.268.0"
+version = "0.4.0+sdk-1.4.341.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eda41003dc44290527a59b13432d4a0379379fa074b70174882adfbdfd917844"
+checksum = "d9571ea910ebd84c86af4b3ed27f9dbdc6ad06f17c5f96146b2b671e2976744f"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -4176,6 +4355,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
+name = "unicode-general-category"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b993bddc193ae5bd0d623b49ec06ac3e9312875fdae725a975c51db1cc1677f"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4183,9 +4368,9 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.12.0"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-width"
@@ -4240,6 +4425,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "vello_common"
+version = "0.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d672facaa2d697285a786cd9d44d614cd2ce54cdc022504bf339f8fff3b750"
+dependencies = [
+ "bytemuck",
+ "fearless_simd",
+ "guillotiere",
+ "hashbrown 0.17.1",
+ "log",
+ "peniko",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "vello_cpu"
+version = "0.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "588691169aed86b5c8fb487266afee01323234e6fd0a3f2aaec0eaa8e4007f23"
+dependencies = [
+ "bytemuck",
+ "glifo",
+ "hashbrown 0.17.1",
+ "vello_common",
+]
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4281,9 +4494,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.114"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4294,23 +4507,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.64"
+version = "0.4.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
+checksum = "6b7777d5cc23d0e91404e53ce2d5e8ec7acae3026b16233dba62cd3246457950"
 dependencies = [
- "cfg-if",
- "futures-util",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.114"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4318,9 +4527,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.114"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -4331,9 +4540,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.114"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
 dependencies = [
  "unicode-ident",
 ]
@@ -4366,7 +4575,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -4392,7 +4601,7 @@ version = "0.31.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab51d9f7c071abeee76007e2b742499e535148035bb835f97aaed1338cf516c3"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
  "rustix 1.1.4",
  "wayland-backend",
  "wayland-scanner",
@@ -4404,7 +4613,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "625c5029dbd43d25e6aa9615e88b829a5cad13b2819c4ae129fdbb7c31ab4c7e"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
  "cursor-icon",
  "wayland-backend",
 ]
@@ -4426,7 +4635,7 @@ version = "0.32.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b23b5df31ceff1328f06ac607591d5ba360cf58f90c8fad4ac8d3a55a3c4aec7"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
  "wayland-backend",
  "wayland-client",
  "wayland-scanner",
@@ -4438,7 +4647,7 @@ version = "20250721.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40a1f863128dcaaec790d7b4b396cc9b9a7a079e878e18c47e6c2d2c5a8dcbb1"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
  "wayland-backend",
  "wayland-client",
  "wayland-protocols",
@@ -4451,7 +4660,7 @@ version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "429b99200febaf95d4f4e46deff6fe4382bcff3280ee16a41cf887b3c3364984"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
  "wayland-backend",
  "wayland-client",
  "wayland-protocols",
@@ -4464,7 +4673,7 @@ version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d392fc283a87774afc9beefcd6f931582bb97fe0e6ced0b306a62cb1d026527c"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
  "wayland-backend",
  "wayland-client",
  "wayland-protocols",
@@ -4477,7 +4686,7 @@ version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78248e4cc0eff8163370ba5c158630dcae1f3497a586b826eca2ef5f348d6235"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
  "wayland-backend",
  "wayland-client",
  "wayland-protocols",
@@ -4509,9 +4718,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.91"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+checksum = "c435338968042f4f59a557f690a253676d47ce13ceb55d70100e7facf6620a30"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4551,12 +4760,13 @@ checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
 name = "wgpu"
-version = "27.0.1"
+version = "29.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfe68bac7cde125de7a731c3400723cadaaf1703795ad3f4805f187459cd7a77"
+checksum = "76e8840e1ba2881d4cbb18d2147627a56af426ff064c0401eb0c8410c6325d07"
 dependencies = [
  "arrayvec",
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
+ "bytemuck",
  "cfg-if",
  "cfg_aliases",
  "document-features",
@@ -4580,14 +4790,14 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core"
-version = "27.0.3"
+version = "29.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27a75de515543b1897b26119f93731b385a19aea165a1ec5f0e3acecc229cae7"
+checksum = "2f519832254e56965a9940c4af57dcb75f702b6f6fa4a0b172f685395843a4d7"
 dependencies = [
  "arrayvec",
  "bit-set",
  "bit-vec",
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
  "bytemuck",
  "cfg_aliases",
  "document-features",
@@ -4605,57 +4815,66 @@ dependencies = [
  "thiserror 2.0.18",
  "wgpu-core-deps-apple",
  "wgpu-core-deps-emscripten",
+ "wgpu-core-deps-wasm",
  "wgpu-core-deps-windows-linux-android",
  "wgpu-hal",
+ "wgpu-naga-bridge",
  "wgpu-types",
 ]
 
 [[package]]
 name = "wgpu-core-deps-apple"
-version = "27.0.0"
+version = "29.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0772ae958e9be0c729561d5e3fd9a19679bcdfb945b8b1a1969d9bfe8056d233"
+checksum = "f5e39e26c4c0e07589e67d18546cf79ff45383659fc72fca4dd293358a0347f3"
 dependencies = [
  "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-core-deps-emscripten"
-version = "27.0.0"
+version = "29.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b06ac3444a95b0813ecfd81ddb2774b66220b264b3e2031152a4a29fda4da6b5"
+checksum = "01e09be551dc939498bdd5f6b2c66e55ab275dad25825267a08605a80fc9f0af"
+dependencies = [
+ "wgpu-hal",
+]
+
+[[package]]
+name = "wgpu-core-deps-wasm"
+version = "29.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af1fb1798be2a912497d4c224f72d39bb0cb34af50e8bcc29865bc339c943059"
 dependencies = [
  "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-core-deps-windows-linux-android"
-version = "27.0.0"
+version = "29.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71197027d61a71748e4120f05a9242b2ad142e3c01f8c1b47707945a879a03c3"
+checksum = "4e592c1bbef6ad047647ae6e666ebd8cee7a32bb4544d9700ec96cbf73230257"
 dependencies = [
  "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-hal"
-version = "27.0.4"
+version = "29.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b21cb61c57ee198bc4aff71aeadff4cbb80b927beb912506af9c780d64313ce"
+checksum = "97ace1c17727311c22a46e4e3faf56ea6de81af99dcc839bdfb54857b94d448d"
 dependencies = [
  "android_system_properties",
  "arrayvec",
  "ash",
  "bit-set",
- "bitflags 2.11.0",
- "block",
+ "bitflags 2.13.1",
+ "block2 0.6.2",
  "bytemuck",
  "cfg-if",
  "cfg_aliases",
- "core-graphics-types 0.2.0",
  "glow",
  "glutin_wgl_sys",
- "gpu-alloc",
  "gpu-allocator",
  "gpu-descriptor",
  "hashbrown 0.16.1",
@@ -4664,10 +4883,13 @@ dependencies = [
  "libc",
  "libloading",
  "log",
- "metal",
  "naga",
  "ndk-sys",
- "objc",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+ "objc2-metal 0.3.2",
+ "objc2-quartz-core 0.3.2",
  "once_cell",
  "ordered-float",
  "parking_lot",
@@ -4676,27 +4898,41 @@ dependencies = [
  "profiling",
  "range-alloc",
  "raw-window-handle",
+ "raw-window-metal",
  "renderdoc-sys",
  "smallvec",
  "thiserror 2.0.18",
  "wasm-bindgen",
+ "wayland-sys",
  "web-sys",
+ "wgpu-naga-bridge",
  "wgpu-types",
- "windows 0.58.0",
- "windows-core 0.58.0",
+ "windows",
+ "windows-core",
+ "windows-result",
+]
+
+[[package]]
+name = "wgpu-naga-bridge"
+version = "29.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95226013f547544b223281cd16a4fb549aa9dcb562adbda0faae4c73ffbbc161"
+dependencies = [
+ "naga",
+ "wgpu-types",
 ]
 
 [[package]]
 name = "wgpu-types"
-version = "27.0.1"
+version = "29.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afdcf84c395990db737f2dd91628706cb31e86d72e53482320d368e52b5da5eb"
+checksum = "84bf84cd9ca8ca45e2b223a3868f1adf9bfc0c66aeac212e76ee7e40fdadf8f5"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
  "bytemuck",
  "js-sys",
  "log",
- "thiserror 2.0.18",
+ "raw-window-handle",
  "web-sys",
 ]
 
@@ -4733,46 +4969,14 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
-dependencies = [
- "windows-core 0.58.0",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows"
-version = "0.61.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
-dependencies = [
- "windows-collections 0.2.0",
- "windows-core 0.61.2",
- "windows-future 0.2.1",
- "windows-link 0.1.3",
- "windows-numerics 0.2.0",
-]
-
-[[package]]
-name = "windows"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
 dependencies = [
- "windows-collections 0.3.2",
- "windows-core 0.62.2",
- "windows-future 0.3.2",
- "windows-numerics 0.3.1",
-]
-
-[[package]]
-name = "windows-collections"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
-dependencies = [
- "windows-core 0.61.2",
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
 ]
 
 [[package]]
@@ -4781,33 +4985,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
 dependencies = [
- "windows-core 0.62.2",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
-dependencies = [
- "windows-implement 0.58.0",
- "windows-interface 0.58.0",
- "windows-result 0.2.0",
- "windows-strings 0.1.0",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.61.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
-dependencies = [
- "windows-implement 0.60.2",
- "windows-interface 0.59.3",
- "windows-link 0.1.3",
- "windows-result 0.3.4",
- "windows-strings 0.4.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -4816,22 +4994,11 @@ version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
- "windows-implement 0.60.2",
- "windows-interface 0.59.3",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
-]
-
-[[package]]
-name = "windows-future"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
-dependencies = [
- "windows-core 0.61.2",
- "windows-link 0.1.3",
- "windows-threading 0.1.0",
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
 ]
 
 [[package]]
@@ -4840,20 +5007,9 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
 dependencies = [
- "windows-core 0.62.2",
- "windows-link 0.2.1",
- "windows-threading 0.2.1",
-]
-
-[[package]]
-name = "windows-implement"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "windows-core",
+ "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
@@ -4861,17 +5017,6 @@ name = "windows-implement"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4891,25 +5036,9 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
-
-[[package]]
-name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
-
-[[package]]
-name = "windows-numerics"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
-dependencies = [
- "windows-core 0.61.2",
- "windows-link 0.1.3",
-]
 
 [[package]]
 name = "windows-numerics"
@@ -4917,26 +5046,8 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
- "windows-core 0.62.2",
- "windows-link 0.2.1",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
-dependencies = [
- "windows-link 0.1.3",
+ "windows-core",
+ "windows-link",
 ]
 
 [[package]]
@@ -4945,26 +5056,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link 0.2.1",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
-dependencies = [
- "windows-result 0.2.0",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
-dependencies = [
- "windows-link 0.1.3",
+ "windows-link",
 ]
 
 [[package]]
@@ -4973,7 +5065,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -5018,7 +5110,7 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -5058,7 +5150,7 @@ version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
  "windows_aarch64_gnullvm 0.53.1",
  "windows_aarch64_msvc 0.53.1",
  "windows_i686_gnu 0.53.1",
@@ -5071,20 +5163,11 @@ dependencies = [
 
 [[package]]
 name = "windows-threading"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
-dependencies = [
- "windows-link 0.1.3",
-]
-
-[[package]]
-name = "windows-threading"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -5234,7 +5317,7 @@ dependencies = [
  "ahash",
  "android-activity",
  "atomic-waker",
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
  "block2 0.5.1",
  "bytemuck",
  "calloop 0.13.0",
@@ -5251,7 +5334,7 @@ dependencies = [
  "objc2 0.5.2",
  "objc2-app-kit 0.2.2",
  "objc2-foundation 0.2.2",
- "objc2-ui-kit",
+ "objc2-ui-kit 0.2.2",
  "orbclient",
  "percent-encoding",
  "pin-project",
@@ -5362,7 +5445,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
  "indexmap",
  "log",
  "serde",
@@ -5442,7 +5525,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d039de8032a9a8856a6be89cea3e5d12fdd82306ab7c94d74e6deab2460651c5"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
  "dlib",
  "log",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,9 @@ LegalCopyright = "Copyright © 2026"
 
 [dependencies]
 image = "0.25.10"
-eframe = "0.33.3"
-egui = { version = "0.33.3", features = ["serde"] }
-egui_extras = "0.33.3"
+eframe = "0.35.0"
+egui = { version = "0.35.0", features = ["serde"] }
+egui_extras = "0.35.0"
 ntapi = "0.4.3"
 windows = { version = "0.62.2", features = [
     "Win32_Foundation",
@@ -57,7 +57,7 @@ bincode = "1.3"
 postcard = { version = "1.1.3", features = ["alloc"] }
 serde = { version = "1.0.228", features = ["derive"], default-features = false }
 rayon = "1.12"
-egui-phosphor = { version = "0.11", features = ["regular", "fill"] }
+egui-phosphor = { version = "0.13.0", features = ["regular", "fill"] }
 serde_json = "1.0.149"
 num_cpus = "1.17"
 lazy_static = "1.5"

--- a/README.md
+++ b/README.md
@@ -285,11 +285,11 @@
 
 ## Star History
 
-<a href="https://www.star-history.com/?repos=mtucciarone%2FEdenExplorer">
+<a href="https://www.star-history.com/?repos=mtucciarone%2Fedenexplorer&type=date&legend=top-left">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=mtucciarone/EdenExplorer&type=date&theme=dark&legend=top-left&sealed_token=Vc9gAQ1EyNnsDshDmlm_VHBAb2pSnvtzPSk4Ip2omG5jagl9CGXy2C8L95S9d_GkLvTh49MUH8vx6A9y7hEGpgJ4x0tv0ZgDqqVAqJs9nxm3Ys_3F1PHK1jpm4v1UHK5yrZ4AJjo99PRtk7JQZV_08P0z5gCxq5EiNnz-YWNQRqeY4nGJyDwhqH5mCqT" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=mtucciarone/EdenExplorer&type=date&legend=top-left&sealed_token=Vc9gAQ1EyNnsDshDmlm_VHBAb2pSnvtzPSk4Ip2omG5jagl9CGXy2C8L95S9d_GkLvTh49MUH8vx6A9y7hEGpgJ4x0tv0ZgDqqVAqJs9nxm3Ys_3F1PHK1jpm4v1UHK5yrZ4AJjo99PRtk7JQZV_08P0z5gCxq5EiNnz-YWNQRqeY4nGJyDwhqH5mCqT" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=mtucciarone/EdenExplorer&type=date&legend=top-left&sealed_token=Vc9gAQ1EyNnsDshDmlm_VHBAb2pSnvtzPSk4Ip2omG5jagl9CGXy2C8L95S9d_GkLvTh49MUH8vx6A9y7hEGpgJ4x0tv0ZgDqqVAqJs9nxm3Ys_3F1PHK1jpm4v1UHK5yrZ4AJjo99PRtk7JQZV_08P0z5gCxq5EiNnz-YWNQRqeY4nGJyDwhqH5mCqT" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=mtucciarone/edenexplorer&type=date&theme=dark&legend=top-left&sealed_token=NI5dBaKp_iac6WVxE46Q87Ri_obOUEGRld3AK0tm-wDI4Q-mCBlbqFcK5p1RpdylDEyaAME4_B-EyS3tCik9fMvdUFV5TfBCYtlmdNn1ivy4QWSSQXMGESzTxp438CEXvm1y49Mu2_r0YodXYa_oTaIMKkwsRKnAdRB1VCGBorGKIbqE63fU68LsK6bN" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=mtucciarone/edenexplorer&type=date&legend=top-left&sealed_token=NI5dBaKp_iac6WVxE46Q87Ri_obOUEGRld3AK0tm-wDI4Q-mCBlbqFcK5p1RpdylDEyaAME4_B-EyS3tCik9fMvdUFV5TfBCYtlmdNn1ivy4QWSSQXMGESzTxp438CEXvm1y49Mu2_r0YodXYa_oTaIMKkwsRKnAdRB1VCGBorGKIbqE63fU68LsK6bN" />
+   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=mtucciarone/edenexplorer&type=date&legend=top-left&sealed_token=NI5dBaKp_iac6WVxE46Q87Ri_obOUEGRld3AK0tm-wDI4Q-mCBlbqFcK5p1RpdylDEyaAME4_B-EyS3tCik9fMvdUFV5TfBCYtlmdNn1ivy4QWSSQXMGESzTxp438CEXvm1y49Mu2_r0YodXYa_oTaIMKkwsRKnAdRB1VCGBorGKIbqE63fU68LsK6bN" />
  </picture>
 </a>
 

--- a/README.md
+++ b/README.md
@@ -274,9 +274,9 @@
 - [x] Explorer view displays objects that have tags applied to them based on the tag color 
 - [x] Added native Recycle Bin support
 - [x] New Explorer view that displays media files in small/medium/large/extra large format
+- [x] Add special icons for Desktop, Downloads, My User Home, Music, Videos, My Documents
 
 ### 🚀 Upcoming Alpha Features
-- [ ] Add special icons for Desktop, Downloads, My User Home, Music, Videos, My Documents
 - [ ] Tab re-ordering via drag'n'drop
 - [ ] Support multi-column sorting (smart grouping)
 - [ ] Add multi-tagging of objects

--- a/locales/en-US/main.ftl
+++ b/locales/en-US/main.ftl
@@ -174,3 +174,7 @@ launch-window-not-ready =
     The running EdenExplorer window was not ready.
 launch-window-rejected = 
     The running EdenExplorer window did not accept the request.
+theme_sidebar_item_spacing_y = Sidebar Item Vertical Spacing
+restore = Restore
+maximize = Maximize
+minimize = Minimize

--- a/locales/id-ID/main.ftl
+++ b/locales/id-ID/main.ftl
@@ -171,3 +171,7 @@ launch-window-not-ready =
     Jendela EdenExplorer yang sedang berjalan tidak siap.
 launch-window-rejected = 
     Jendela EdenExplorer yang sedang berjalan tidak menerima permintaan.
+theme_sidebar_item_spacing_y = Spasi Vertikal Item Sidebar
+restore = Pulihkan
+maximize = Maksimalkan
+minimize = Minimalkan

--- a/locales/ja-JP/main.ftl
+++ b/locales/ja-JP/main.ftl
@@ -171,3 +171,7 @@ launch-window-not-ready =
     実行中のEdenExplorerウィンドウが準備できていません。
 launch-window-rejected = 
     実行中のEdenExplorerウィンドウがリクエストを拒否しました。
+theme_sidebar_item_spacing_y = サイドバー項目の垂直間隔
+restore = 戻す
+maximize = 最大化
+minimize = 最小化

--- a/locales/zh-CN/main.ftl
+++ b/locales/zh-CN/main.ftl
@@ -171,3 +171,7 @@ launch-window-not-ready =
     运行中的 EdenExplorer 窗口未准备好。
 launch-window-rejected = 
     运行中的 EdenExplorer 窗口拒绝了请求。
+theme_sidebar_item_spacing_y = 侧边栏项目垂直间距
+restore = 恢复
+maximize = 最大化
+minimize = 最小化

--- a/locales/zh-HK/main.ftl
+++ b/locales/zh-HK/main.ftl
@@ -171,3 +171,7 @@ launch-window-not-ready =
     運行中的 EdenExplorer 窗口未準備好。
 launch-window-rejected = 
     運行中的 EdenExplorer 窗口拒絕了請求。
+theme_sidebar_item_spacing_y = 側邊欄項目垂直間距
+restore = 復原
+maximize = 最大化
+minimize = 最小化

--- a/locales/zh-TW/main.ftl
+++ b/locales/zh-TW/main.ftl
@@ -171,3 +171,7 @@ launch-window-not-ready =
     運行中的 EdenExplorer 窗口未準備好。
 launch-window-rejected = 
     運行中的 EdenExplorer 窗口拒絕了請求。
+theme_sidebar_item_spacing_y = 側邊欄項目垂直間距
+restore = 復原
+maximize = 最大化
+minimize = 最小化

--- a/src/core/indexer.rs
+++ b/src/core/indexer.rs
@@ -1,5 +1,6 @@
 use crate::core::fs::{DateStyle, MY_PC_PATH};
 use crate::gui::theme::{THEME_VERSION, ThemePalette, get_default_palette};
+use crate::gui::windows::containers::enums::ItemViewerHeaderColumn;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
@@ -51,13 +52,17 @@ struct AppSettingsSnapshot {
     #[serde(default = "default_language")]
     language: String,
     #[serde(default = "default_item_viewer_file_column_order")]
-    item_viewer_file_column_order:
-        Vec<crate::gui::windows::containers::enums::ItemViewerHeaderColumn>,
+    item_viewer_file_column_order: Vec<ItemViewerHeaderColumn>,
     #[serde(default = "default_item_viewer_drive_column_order")]
-    item_viewer_drive_column_order:
-        Vec<crate::gui::windows::containers::enums::ItemViewerHeaderColumn>,
+    item_viewer_drive_column_order: Vec<ItemViewerHeaderColumn>,
     #[serde(default = "default_recycle_bin_column_order")]
-    recycle_bin_column_order: Vec<crate::gui::windows::containers::enums::ItemViewerHeaderColumn>,
+    recycle_bin_column_order: Vec<ItemViewerHeaderColumn>,
+    #[serde(default = "default_item_viewer_file_column_size")]
+    item_viewer_file_column_sizes: Vec<f32>,
+    #[serde(default = "default_item_viewer_drive_column_size")]
+    item_viewer_drive_column_sizes: Vec<f32>,
+    #[serde(default = "default_recycle_bin_column_size")]
+    recycle_bin_column_sizes: Vec<f32>,
 }
 
 // Legacy snapshot struct for deserializing old settings with HalfScreen
@@ -98,6 +103,9 @@ impl From<LegacyAppSettingsSnapshot> for AppSettingsSnapshot {
             item_viewer_file_column_order: default_item_viewer_file_column_order(),
             item_viewer_drive_column_order: default_item_viewer_drive_column_order(),
             recycle_bin_column_order: default_recycle_bin_column_order(),
+            item_viewer_file_column_sizes: default_item_viewer_file_column_size(),
+            item_viewer_drive_column_sizes: default_item_viewer_drive_column_size(),
+            recycle_bin_column_sizes: default_recycle_bin_column_size(),
         }
     }
 }
@@ -184,33 +192,42 @@ fn default_language() -> String {
     "en-US".to_string()
 }
 
-fn default_item_viewer_file_column_order()
--> Vec<crate::gui::windows::containers::enums::ItemViewerHeaderColumn> {
+fn default_item_viewer_file_column_order() -> Vec<ItemViewerHeaderColumn> {
     vec![
-        crate::gui::windows::containers::enums::ItemViewerHeaderColumn::Type,
-        crate::gui::windows::containers::enums::ItemViewerHeaderColumn::Size,
-        crate::gui::windows::containers::enums::ItemViewerHeaderColumn::Modified,
-        crate::gui::windows::containers::enums::ItemViewerHeaderColumn::Created,
+        ItemViewerHeaderColumn::Type,
+        ItemViewerHeaderColumn::Size,
+        ItemViewerHeaderColumn::Modified,
+        ItemViewerHeaderColumn::Created,
     ]
 }
 
-fn default_item_viewer_drive_column_order()
--> Vec<crate::gui::windows::containers::enums::ItemViewerHeaderColumn> {
+fn default_item_viewer_drive_column_order() -> Vec<ItemViewerHeaderColumn> {
     vec![
-        crate::gui::windows::containers::enums::ItemViewerHeaderColumn::Type,
-        crate::gui::windows::containers::enums::ItemViewerHeaderColumn::Size,
-        crate::gui::windows::containers::enums::ItemViewerHeaderColumn::Usage,
+        ItemViewerHeaderColumn::Type,
+        ItemViewerHeaderColumn::Size,
+        ItemViewerHeaderColumn::Usage,
     ]
 }
 
-fn default_recycle_bin_column_order()
--> Vec<crate::gui::windows::containers::enums::ItemViewerHeaderColumn> {
+fn default_recycle_bin_column_order() -> Vec<ItemViewerHeaderColumn> {
     vec![
-        crate::gui::windows::containers::enums::ItemViewerHeaderColumn::Type,
-        crate::gui::windows::containers::enums::ItemViewerHeaderColumn::Size,
-        crate::gui::windows::containers::enums::ItemViewerHeaderColumn::Deleted,
-        crate::gui::windows::containers::enums::ItemViewerHeaderColumn::Created,
+        ItemViewerHeaderColumn::Type,
+        ItemViewerHeaderColumn::Size,
+        ItemViewerHeaderColumn::Deleted,
+        ItemViewerHeaderColumn::Created,
     ]
+}
+
+pub fn default_item_viewer_file_column_size() -> Vec<f32> {
+    vec![180.0, 60.0, 75.0, 100.0, 100.0]
+}
+
+pub fn default_item_viewer_drive_column_size() -> Vec<f32> {
+    vec![180.0, 120.0, 150.0]
+}
+
+pub fn default_recycle_bin_column_size() -> Vec<f32> {
+    vec![180.0, 60.0, 120.0, 100.0, 100.0]
 }
 
 fn default_date_style() -> DateStyle {
@@ -331,9 +348,12 @@ pub fn load_app_settings() -> (
     bool,
     String,
     DateStyle,
-    Vec<crate::gui::windows::containers::enums::ItemViewerHeaderColumn>,
-    Vec<crate::gui::windows::containers::enums::ItemViewerHeaderColumn>,
-    Vec<crate::gui::windows::containers::enums::ItemViewerHeaderColumn>,
+    Vec<ItemViewerHeaderColumn>,
+    Vec<ItemViewerHeaderColumn>,
+    Vec<ItemViewerHeaderColumn>,
+    Vec<f32>,
+    Vec<f32>,
+    Vec<f32>,
 ) {
     let default_path = PathBuf::from(MY_PC_PATH);
 
@@ -369,6 +389,9 @@ pub fn load_app_settings() -> (
         snapshot.item_viewer_file_column_order,
         snapshot.item_viewer_drive_column_order,
         snapshot.recycle_bin_column_order,
+        snapshot.item_viewer_file_column_sizes,
+        snapshot.item_viewer_drive_column_sizes,
+        snapshot.recycle_bin_column_sizes,
     )
 }
 
@@ -388,9 +411,12 @@ fn default_app_settings(
     bool,
     String,
     DateStyle,
-    Vec<crate::gui::windows::containers::enums::ItemViewerHeaderColumn>,
-    Vec<crate::gui::windows::containers::enums::ItemViewerHeaderColumn>,
-    Vec<crate::gui::windows::containers::enums::ItemViewerHeaderColumn>,
+    Vec<ItemViewerHeaderColumn>,
+    Vec<ItemViewerHeaderColumn>,
+    Vec<ItemViewerHeaderColumn>,
+    Vec<f32>,
+    Vec<f32>,
+    Vec<f32>,
 ) {
     (
         true,
@@ -409,6 +435,9 @@ fn default_app_settings(
         default_item_viewer_file_column_order(),
         default_item_viewer_drive_column_order(),
         default_recycle_bin_column_order(),
+        default_item_viewer_file_column_size(),
+        default_item_viewer_drive_column_size(),
+        default_recycle_bin_column_size(),
     )
 }
 
@@ -426,9 +455,12 @@ pub fn save_app_settings(
     sort_ascending: bool,
     language: &str,
     date_style: DateStyle,
-    item_viewer_file_column_order: &[crate::gui::windows::containers::enums::ItemViewerHeaderColumn],
-    item_viewer_drive_column_order: &[crate::gui::windows::containers::enums::ItemViewerHeaderColumn],
-    recycle_bin_column_order: &[crate::gui::windows::containers::enums::ItemViewerHeaderColumn],
+    item_viewer_file_column_order: &[ItemViewerHeaderColumn],
+    item_viewer_drive_column_order: &[ItemViewerHeaderColumn],
+    recycle_bin_column_order: &[ItemViewerHeaderColumn],
+    item_viewer_file_column_sizes: &[f32],
+    item_viewer_drive_column_sizes: &[f32],
+    recycle_bin_column_sizes: &[f32],
 ) {
     let path = match settings_cache_path() {
         Some(path) => path,
@@ -452,6 +484,9 @@ pub fn save_app_settings(
         item_viewer_file_column_order: item_viewer_file_column_order.to_vec(),
         item_viewer_drive_column_order: item_viewer_drive_column_order.to_vec(),
         recycle_bin_column_order: recycle_bin_column_order.to_vec(),
+        item_viewer_file_column_sizes: item_viewer_file_column_sizes.to_vec(),
+        item_viewer_drive_column_sizes: item_viewer_drive_column_sizes.to_vec(),
+        recycle_bin_column_sizes: recycle_bin_column_sizes.to_vec(),
     };
     if let Ok(data) = postcard::to_allocvec(&snapshot) {
         let _ = std::fs::write(path, data);

--- a/src/core/utils/thumbnails.rs
+++ b/src/core/utils/thumbnails.rs
@@ -16,7 +16,7 @@ use windows::Win32::System::Com::{
 };
 use windows::Win32::UI::Shell::{
     ISharedBitmap, IShellItem, IThumbnailCache, LocalThumbnailCache, SHCreateItemFromParsingName,
-    WTS_CACHEFLAGS, WTS_EXTRACT, WTS_FASTEXTRACT, WTS_FLAGS, WTS_INCACHEONLY, WTS_THUMBNAILID,
+    WTS_CACHEFLAGS, WTS_EXTRACT, WTS_FLAGS, WTS_INCACHEONLY, WTS_THUMBNAILID,
 };
 use windows::core::{Error, HRESULT, HSTRING, Result};
 
@@ -199,26 +199,37 @@ fn run_thumbnail_job(job: ThumbnailJob, tx: Sender<ThumbnailResult>) {
 
 fn extract_thumbnail(path: &Path) -> Result<ThumbnailImage> {
     let _com = ComGuard::init()?;
+
     let shell_item: IShellItem = unsafe {
         SHCreateItemFromParsingName(&HSTRING::from(path.to_string_lossy().as_ref()), None)?
     };
+
     let cache: IThumbnailCache =
         unsafe { CoCreateInstance(&LocalThumbnailCache, None, CLSCTX_INPROC_SERVER)? };
 
-    for flags in [WTS_INCACHEONLY, WTS_FASTEXTRACT, WTS_EXTRACT] {
-        if let Ok(image) = get_thumbnail_with_flags(&cache, &shell_item, flags) {
-            return Ok(image);
+    if let Ok(result) = get_thumbnail_with_flags(&cache, &shell_item, WTS_INCACHEONLY) {
+        if !result.low_quality {
+            return Ok(result.image);
         }
     }
 
+    if let Ok(result) = get_thumbnail_with_flags(&cache, &shell_item, WTS_EXTRACT) {
+        return Ok(result.image);
+    }
+
     Err(thumbnail_error("thumbnail unavailable"))
+}
+
+struct ExtractedThumbnail {
+    image: ThumbnailImage,
+    low_quality: bool,
 }
 
 fn get_thumbnail_with_flags(
     cache: &IThumbnailCache,
     shell_item: &IShellItem,
     flags: WTS_FLAGS,
-) -> Result<ThumbnailImage> {
+) -> Result<ExtractedThumbnail> {
     let mut bitmap: Option<ISharedBitmap> = None;
     let mut out_flags = WTS_CACHEFLAGS::default();
     let mut thumbnail_id = WTS_THUMBNAILID::default();
@@ -238,7 +249,12 @@ fn get_thumbnail_with_flags(
         return Err(thumbnail_error("thumbnail bitmap missing"));
     };
 
-    shared_bitmap_to_rgba(&bitmap)
+    let image = shared_bitmap_to_rgba(&bitmap)?;
+
+    let low_quality = image.size[0] < THUMBNAIL_SOURCE_SIZE as usize
+        || image.size[1] < THUMBNAIL_SOURCE_SIZE as usize;
+
+    Ok(ExtractedThumbnail { image, low_quality })
 }
 
 fn shared_bitmap_to_rgba(bitmap: &ISharedBitmap) -> Result<ThumbnailImage> {

--- a/src/core/utils/widgets.rs
+++ b/src/core/utils/widgets.rs
@@ -9,7 +9,7 @@ pub fn clickable_active_icon(
     icon: &str,
     default_color: Color32,
     is_active: bool,
-    is_active_color: Color32,
+    palette: &ThemePalette,
 ) -> Response {
     let font_id = FontId::default();
 
@@ -20,9 +20,13 @@ pub fn clickable_active_icon(
     let (rect, resp) = ui.allocate_exact_size(galley.size(), Sense::click());
 
     let color = if is_active {
-        is_active_color
+        palette.primary
     } else {
-        default_color
+        if resp.hovered() {
+            palette.primary
+        } else {
+            default_color
+        }
     };
 
     ui.painter()
@@ -31,7 +35,7 @@ pub fn clickable_active_icon(
     resp
 }
 
-pub fn clickable_icon(ui: &mut Ui, icon: &str, hover_color: Color32) -> Response {
+pub fn clickable_icon(ui: &mut Ui, icon: &str, palette: &ThemePalette) -> Response {
     let font_id = FontId::default();
 
     let galley =
@@ -41,13 +45,41 @@ pub fn clickable_icon(ui: &mut Ui, icon: &str, hover_color: Color32) -> Response
     let (rect, resp) = ui.allocate_exact_size(galley.size(), Sense::click());
 
     let color = if resp.hovered() {
-        hover_color
+        palette.primary
     } else {
         ui.visuals().text_color()
     };
 
     ui.painter()
         .text(rect.center(), Align2::CENTER_CENTER, icon, font_id, color);
+
+    resp
+}
+
+pub fn clickable_windows_icon(
+    ui: &mut Ui,
+    icon: &str,
+    hover_bg: Color32,
+    palette: &ThemePalette,
+) -> Response {
+    const BUTTON_WIDTH: f32 = 45.0;
+    const BUTTON_HEIGHT: f32 = 26.0;
+    const ICON_SIZE: f32 = 14.0;
+
+    let (rect, resp) =
+        ui.allocate_exact_size(egui::vec2(BUTTON_WIDTH, BUTTON_HEIGHT), Sense::click());
+
+    if resp.hovered() {
+        ui.painter().rect_filled(rect, 0.0, hover_bg);
+    }
+
+    ui.painter().text(
+        rect.center(),
+        Align2::CENTER_CENTER,
+        icon,
+        FontId::proportional(ICON_SIZE),
+        palette.icon_color,
+    );
 
     resp
 }
@@ -192,7 +224,7 @@ pub fn draw_checkbox(
     ui: &mut egui::Ui,
     palette: &ThemePalette,
     checked: &mut bool,
-    id: impl std::hash::Hash,
+    id: impl std::hash::Hash + std::fmt::Debug,
 ) -> egui::Response {
     let size = ui.available_rect_before_wrap().height().min(12.0);
 
@@ -247,7 +279,7 @@ pub fn draw_checkbox(
 pub fn draw_dropdown(
     ui: &mut egui::Ui,
     palette: &ThemePalette,
-    id: impl std::hash::Hash,
+    id: impl std::hash::Hash + std::fmt::Debug,
     width: f32,
     selected_text: impl Into<egui::WidgetText>,
     add_contents: impl FnOnce(&mut egui::Ui),
@@ -259,6 +291,7 @@ pub fn draw_dropdown(
         visuals.widgets.hovered.bg_fill = palette.primary_hover;
         visuals.widgets.active.bg_fill = palette.primary_active;
         apply_eden_visual_overrides(ui, palette);
+        apply_eden_dropdown_visual_color_overrides(ui, palette);
         egui::ComboBox::from_id_salt(id)
             .width(width)
             .selected_text(selected_text)
@@ -290,6 +323,17 @@ pub fn apply_eden_visual_overrides(ui: &mut egui::Ui, palette: &ThemePalette) {
     style.spacing.item_spacing = egui::vec2(6.0, 2.0);
     style.spacing.menu_margin = egui::Margin::same(4);
     style.spacing.interact_size.y = palette.text_size + 6.0;
+}
+
+pub fn apply_eden_dropdown_visual_color_overrides(ui: &mut egui::Ui, palette: &ThemePalette) {
+    let visuals = &mut ui.style_mut().visuals;
+
+    visuals.widgets.active.bg_fill = egui::Color32::TRANSPARENT;
+    visuals.widgets.active.weak_bg_fill = egui::Color32::TRANSPARENT;
+    visuals.widgets.inactive.corner_radius = egui::CornerRadius::same(palette.medium_radius);
+    visuals.widgets.hovered.corner_radius = egui::CornerRadius::same(palette.medium_radius);
+    visuals.widgets.active.corner_radius = egui::CornerRadius::same(palette.medium_radius);
+    visuals.widgets.open.corner_radius = egui::CornerRadius::same(palette.medium_radius);
 }
 
 pub fn apply_eden_visual_color_overrides(ui: &mut egui::Ui, palette: &ThemePalette) {

--- a/src/gui/icons.rs
+++ b/src/gui/icons.rs
@@ -28,6 +28,7 @@ use windows::{
     },
     core::PCWSTR,
 };
+use egui_phosphor::regular;
 
 struct IconRequest {
     path: PathBuf,
@@ -137,6 +138,21 @@ impl IconCache {
         });
 
         None
+    }
+
+    /// Returns a custom Phosphor icon for folders with a recognized name.
+    pub fn get_custom_folder_icon(
+        &self,
+        path: &Path,
+        is_dir: bool,
+    ) -> Option<&'static str> {
+        if !is_dir {
+            return None;
+        }
+
+        let name = path.file_name()?.to_str()?;
+
+        custom_folder_icon(name)
     }
 }
 
@@ -281,5 +297,21 @@ fn icon_to_rgba(icon: HICON) -> Option<(Vec<u8>, u32, u32)> {
         }
 
         Some((pixels, width, height))
+    }
+}
+
+fn custom_folder_icon(name: &str) -> Option<&'static str> {
+    if name.eq_ignore_ascii_case("Music") {
+        Some(regular::MUSIC_NOTES)
+    } else if name.eq_ignore_ascii_case("Pictures") {
+        Some(regular::IMAGE)
+    } else if name.eq_ignore_ascii_case("Videos") {
+        Some(regular::VIDEO_CAMERA)
+    } else if name.eq_ignore_ascii_case("Downloads") {
+        Some(regular::DOWNLOAD_SIMPLE)
+    } else if name.eq_ignore_ascii_case("Documents") {
+        Some(regular::FILE_TEXT)
+    } else {
+        None
     }
 }

--- a/src/gui/icons.rs
+++ b/src/gui/icons.rs
@@ -1,6 +1,7 @@
 use crate::core::portable;
 use crossbeam_channel::{Sender, unbounded};
 use eframe::egui;
+use egui_phosphor::regular;
 use std::os::windows::ffi::OsStrExt;
 use std::{
     collections::HashMap,
@@ -28,7 +29,6 @@ use windows::{
     },
     core::PCWSTR,
 };
-use egui_phosphor::regular;
 
 struct IconRequest {
     path: PathBuf,
@@ -141,11 +141,7 @@ impl IconCache {
     }
 
     /// Returns a custom Phosphor icon for folders with a recognized name.
-    pub fn get_custom_folder_icon(
-        &self,
-        path: &Path,
-        is_dir: bool,
-    ) -> Option<&'static str> {
+    pub fn get_custom_folder_icon(&self, path: &Path, is_dir: bool) -> Option<&'static str> {
         if !is_dir {
             return None;
         }

--- a/src/gui/theme.rs
+++ b/src/gui/theme.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use std::sync::{LazyLock, RwLock};
 
-pub const THEME_VERSION: u32 = 6;
+pub const THEME_VERSION: u32 = 7;
 
 fn default_itemviewer_row_height() -> f32 {
     16.0
@@ -81,6 +81,7 @@ pub struct ThemePalette {
     pub row_bg: Color32,
     #[serde(default = "default_itemviewer_row_height")]
     pub row_height: f32,
+    pub sidebar_item_spacing_y: f32,
 
     // 🎯 Handles / borders
     pub resize_handle: Color32,
@@ -162,6 +163,7 @@ pub static DEFAULT_PALETTE_DARK: LazyLock<ThemePalette> = LazyLock::new(|| {
         row_selected_bg: Color32::from_rgb(70, 78, 86),
         row_bg: Color32::from_rgb(40, 45, 50),
         row_height: default_itemviewer_row_height(),
+        sidebar_item_spacing_y: 0.5,
 
         // 🎯 Handles / borders
         resize_handle: Color32::from_rgb(160, 170, 180),
@@ -249,6 +251,7 @@ pub static DEFAULT_PALETTE_LIGHT: LazyLock<ThemePalette> = LazyLock::new(|| {
         row_selected_bg: Color32::from_rgb(70, 78, 86),
         row_bg: Color32::from_rgb(240, 245, 250),
         row_height: default_itemviewer_row_height(),
+        sidebar_item_spacing_y: 0.5,
 
         // 🎯 Handles / borders
         resize_handle: Color32::from_rgb(160, 170, 180),
@@ -340,7 +343,12 @@ pub fn set_palette(mode: ThemeMode, palette: ThemePalette) {
 }
 
 pub fn apply_theme(ctx: &egui::Context, mode: ThemeMode) {
-    let mut style = (*ctx.style()).clone();
+    let theme = match mode {
+        ThemeMode::Dark => egui::Theme::Dark,
+        ThemeMode::Light => egui::Theme::Light,
+    };
+
+    let mut style = (*ctx.style_of(theme)).clone();
     let palette = get_palette(mode);
 
     style.visuals = match mode {
@@ -419,7 +427,8 @@ pub fn apply_theme(ctx: &egui::Context, mode: ThemeMode) {
         }
     }
 
-    ctx.set_style(style);
+    ctx.set_style_of(theme, style);
+    ctx.set_theme(theme);
 }
 
 pub fn apply_checkbox_colors(ui: &mut egui::Ui, palette: &ThemePalette, checked: bool) {

--- a/src/gui/windows/about.rs
+++ b/src/gui/windows/about.rs
@@ -43,10 +43,14 @@ pub fn draw_about_window(
         .resizable(false)
         .fixed_size([400.0, 400.0])
         .anchor(egui::Align2::CENTER_CENTER, [0.0, 0.0])
-        .frame(egui::Frame::popup(&ctx.style()).corner_radius(egui::CornerRadius::same(8)))
+        .frame(
+            egui::Frame::popup(&ctx.style_of(ctx.theme()))
+                .corner_radius(egui::CornerRadius::same(8)),
+        )
         .show(ctx, |ui| {
             // 🎯 Smaller font override (fix giant UI)
-            let mut style = (*ui.ctx().style()).clone();
+            let mut style = (**ui.style()).clone();
+
             style.text_styles = [
                 (egui::TextStyle::Heading, egui::FontId::proportional(14.0)),
                 (
@@ -63,10 +67,14 @@ pub fn draw_about_window(
                 ),
             ]
             .into();
+
             ui.set_style(style);
+
             ui.set_width(ui.available_width());
+
             ui.vertical(|ui| {
                 ui.set_width(ui.available_width());
+
                 let font_id = FontId::new(palette.text_size, egui::FontFamily::Proportional);
 
                 ui.label(
@@ -75,7 +83,9 @@ pub fn draw_about_window(
                         .size(palette.text_size)
                         .color(palette.text_normal),
                 );
+
                 ui.add_space(8.0);
+
                 ui.label(
                     egui::RichText::new(format!(
                         "{}: Matthew Tucciarone (GitHub: mtucciarone)",
@@ -85,6 +95,7 @@ pub fn draw_about_window(
                     .size(palette.text_size)
                     .color(palette.text_normal),
                 );
+
                 ui.label(
                     egui::RichText::new(format!(
                         "{}: https://github.com/mtucciarone/EdenExplorer",
@@ -94,6 +105,7 @@ pub fn draw_about_window(
                     .size(palette.text_size)
                     .color(palette.text_normal),
                 );
+
                 ui.label(
                     egui::RichText::new(format!(
                         "{}: {}",
@@ -104,13 +116,16 @@ pub fn draw_about_window(
                     .size(palette.text_size)
                     .color(palette.text_normal),
                 );
+
                 ui.label(
                     egui::RichText::new(format!("{}: MIT", &i18n.tr("about_license")))
                         .font(font_id.clone())
                         .size(palette.text_size)
                         .color(palette.text_normal),
                 );
+
                 ui.separator();
+
                 // Footer
                 ui.horizontal(|ui| {
                     ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
@@ -124,6 +139,7 @@ pub fn draw_about_window(
                 });
             });
         });
+
     // Update the open state based on should_close
     if should_close {
         settings.open = false;

--- a/src/gui/windows/containers/enums.rs
+++ b/src/gui/windows/containers/enums.rs
@@ -49,6 +49,7 @@ pub enum ItemViewerAction {
         sources: Vec<PathBuf>,
         target_dir: PathBuf,
     },
+    ColumnSizesChanged,
 }
 
 #[derive(Clone, Debug)]

--- a/src/gui/windows/containers/explorer.rs
+++ b/src/gui/windows/containers/explorer.rs
@@ -18,7 +18,7 @@ use std::collections::HashSet;
 use std::path::PathBuf;
 use windows::Win32::Foundation::HWND;
 
-const RIGHT_MARGIN: f32 = 8.0;
+const RIGHT_MARGIN: f32 = 20.0;
 const COLUMN_SPACING: f32 = 20.0;
 const FILES_COLUMN_WIDTH: f32 = 56.0;
 const FOLDERS_COLUMN_WIDTH: f32 = 56.0;
@@ -60,6 +60,7 @@ pub fn draw_tab_content(
     drop_targets: &mut DropTargets,
     is_focused: bool,
 ) -> (Option<ItemViewerNavBarAction>, Option<ItemViewerAction>) {
+    let viewport_width = ui.available_width();
     let is_drive_view = view.nav.is_root();
     let is_recycle_bin_view = view.nav.is_recycle_bin();
     let mut hovered_drop_target: Option<PathBuf> = None;
@@ -128,11 +129,14 @@ pub fn draw_tab_content(
                         hwnd,
                         is_focused,
                         tab_id,
+                        viewport_width,
                     );
                 } else {
                     ScrollArea::horizontal()
                         .id_salt(("item_viewer_horizontal_scroll", tab_id))
+                        .auto_shrink([false, false])
                         .show(ui, |ui| {
+                            ui.set_min_width(viewport_width);
                             pending_action = draw_item_viewer(
                                 ui,
                                 i18n,
@@ -165,6 +169,7 @@ pub fn draw_tab_content(
                                 hwnd,
                                 is_focused,
                                 tab_id,
+                                viewport_width,
                             );
                         });
                 }

--- a/src/gui/windows/containers/itemviewer.rs
+++ b/src/gui/windows/containers/itemviewer.rs
@@ -5,15 +5,15 @@ use crate::core::utils::widgets::draw_checkbox;
 use crate::gui::i18n::I18n;
 use crate::gui::icons::IconCache;
 use crate::gui::theme::ThemePalette;
-use crate::gui::utils::{draw_object_drag_ghost, format_size, fuzzy_match, get_file_type_name};
+use crate::gui::utils::{draw_object_drag_ghost, fuzzy_match};
 use crate::gui::windows::containers::enums::{
     ItemViewerAction, ItemViewerContextAction, ItemViewerHeaderColumn,
 };
 use crate::gui::windows::containers::itemviewer_gallery::draw_gallery_view;
 use crate::gui::windows::containers::itemviewer_helper::*;
 use crate::gui::windows::containers::structs::{
-    ItemViewerColumnFitRequest, ItemViewerDisplayMode, ItemViewerFolderSizeState,
-    ItemViewerNavBarAction, RenameState, TabView, TagsState,
+    ItemViewerDisplayMode, ItemViewerFolderSizeState, ItemViewerLayout, ItemViewerNavBarAction,
+    RenameState, TabView, TagsState,
 };
 use crate::gui::windows::structs::{SettingsWindow, ThemeCustomizer};
 use eframe::egui;
@@ -57,6 +57,7 @@ pub fn draw_item_viewer(
     hwnd: Option<HWND>,
     is_focused: bool,
     active_tab_id: u64,
+    viewport_width: f32,
 ) -> Option<ItemViewerAction> {
     let display_mode = view.display_mode;
     let files = &view.files;
@@ -78,7 +79,6 @@ pub fn draw_item_viewer(
         tags_state.picker.is_some() || theme_customizer_window.open || settings_window.open;
 
     let mut action: Option<ItemViewerAction> = None;
-    let mut any_row_hovered = false;
 
     let filter_changed = filter_state.dirty
         || filter_state.query != filter_state.last_query
@@ -223,682 +223,547 @@ pub fn draw_item_viewer(
                 || i.key_pressed(egui::Key::Home)
                 || i.key_pressed(egui::Key::End)
         });
-        let fit_request = column_state.pending_fit_request.take();
-        let layout_generation = column_state.layout_generation;
-        let show_type = column_state.show_type;
-        let show_size = column_state.show_size;
-        let show_modified = column_state.show_modified;
-        let show_created = column_state.show_created;
-        let ordered_columns = column_state.visible_order(
+
+        let column_layout = compute_item_viewer_column_layout(
+            ui,
+            i18n,
+            column_state,
+            filter_state,
+            files,
+            folder_sizes,
             is_drive_view,
             is_recycle_bin_view,
-            show_type,
-            show_size,
-            show_modified,
-            show_created,
+            show_item_viewer_icons,
+            palette,
+            &font_id,
+            file_type_cache,
+            file_size_text_cache,
+            folder_size_text_cache,
+            drive_size_text_cache,
+            viewport_width,
         );
-        let current_width = ui.available_width().max(1.0);
+
+        if column_layout.column_sizes_changed {
+            action = Some(ItemViewerAction::ColumnSizesChanged);
+        }
+
         let available_height = ui.available_height();
-        let fit_widths = fit_request.map(|_| {
-            compute_item_viewer_column_widths(
-                ui,
-                i18n,
-                files,
-                &filter_state.cached_indices,
-                folder_sizes,
-                is_drive_view,
-                show_item_viewer_icons,
-                palette,
-                &font_id,
-                file_type_cache,
-                file_size_text_cache,
-                folder_size_text_cache,
-                drive_size_text_cache,
-            )
-        });
-        let fit_widths = fit_widths.as_ref();
-        let default_name_width = (current_width * 0.35).max(200.0);
-        let default_type_width = (current_width * 0.1).max(60.0);
-        let default_size_width = if is_drive_view {
-            (current_width * 0.14).max(120.0)
-        } else {
-            (current_width * 0.1).max(75.0)
-        };
-        let default_modified_width = (current_width * 0.2).max(120.0);
-        let default_created_width = (current_width * 0.2).max(120.0);
-        let default_deleted_width = (current_width * 0.2).max(120.0);
-        let default_usage_width = (current_width * 0.2).max(150.0);
-        let name_width = if matches!(
-            fit_request,
-            Some(ItemViewerColumnFitRequest::All)
-                | Some(ItemViewerColumnFitRequest::Column(
-                    ItemViewerHeaderColumn::Name
-                ))
-        ) {
-            fit_widths.map(|w| w.name).unwrap_or(default_name_width)
-        } else {
-            default_name_width
-        };
-        let type_width = if show_type {
-            if matches!(
-                fit_request,
-                Some(ItemViewerColumnFitRequest::All)
-                    | Some(ItemViewerColumnFitRequest::Column(
-                        ItemViewerHeaderColumn::Type
-                    ))
-            ) {
-                fit_widths
-                    .map(|w| w.type_width)
-                    .unwrap_or(default_type_width)
-            } else {
-                default_type_width
-            }
-        } else {
-            0.0
-        };
-        let size_width = if show_size {
-            if matches!(
-                fit_request,
-                Some(ItemViewerColumnFitRequest::All)
-                    | Some(ItemViewerColumnFitRequest::Column(
-                        ItemViewerHeaderColumn::Size
-                    ))
-            ) {
-                fit_widths
-                    .map(|w| w.size_width)
-                    .unwrap_or(default_size_width)
-            } else {
-                default_size_width
-            }
-        } else {
-            0.0
-        };
-        let usage_width = if is_drive_view {
-            if matches!(
-                fit_request,
-                Some(ItemViewerColumnFitRequest::All)
-                    | Some(ItemViewerColumnFitRequest::Column(
-                        ItemViewerHeaderColumn::Usage
-                    ))
-            ) {
-                fit_widths
-                    .map(|w| w.usage_width)
-                    .unwrap_or(default_usage_width)
-            } else {
-                default_usage_width
-            }
-        } else {
-            0.0
-        };
-        let modified_width = if !is_drive_view && show_modified {
-            if matches!(
-                fit_request,
-                Some(ItemViewerColumnFitRequest::All)
-                    | Some(ItemViewerColumnFitRequest::Column(
-                        ItemViewerHeaderColumn::Modified
-                    ))
-            ) {
-                fit_widths
-                    .map(|w| w.modified_width)
-                    .unwrap_or(default_modified_width)
-            } else {
-                default_modified_width
-            }
-        } else {
-            0.0
-        };
-        let created_width = if !is_drive_view && show_created {
-            if matches!(
-                fit_request,
-                Some(ItemViewerColumnFitRequest::All)
-                    | Some(ItemViewerColumnFitRequest::Column(
-                        ItemViewerHeaderColumn::Created
-                    ))
-            ) {
-                fit_widths
-                    .map(|w| w.created_width)
-                    .unwrap_or(default_created_width)
-            } else {
-                default_created_width
-            }
-        } else {
-            0.0
-        };
-        let deleted_width = if is_recycle_bin_view {
-            if matches!(
-                fit_request,
-                Some(ItemViewerColumnFitRequest::All)
-                    | Some(ItemViewerColumnFitRequest::Column(
-                        ItemViewerHeaderColumn::Deleted
-                    ))
-            ) {
-                fit_widths
-                    .map(|w| w.deleted_width)
-                    .unwrap_or(default_deleted_width)
-            } else {
-                default_deleted_width
-            }
-        } else {
-            0.0
-        };
+        // IMPORTANT: register background interaction before TableBuilder.
+        let bg_response = table_background_response(ui);
+        let ctx = ui.ctx().clone();
+        let table_rect = ui.available_rect_before_wrap();
+        let left_margin = if layout.is_drive_view { 4.0 } else { 0.0 };
+        let table_rect = egui::Rect::from_min_max(
+            egui::pos2(table_rect.left() + left_margin, table_rect.top()),
+            table_rect.right_bottom(),
+        );
 
-        let mut table = TableBuilder::new(ui)
-            .vscroll(true)
-            .max_scroll_height(available_height)
-            .min_scrolled_height(0.0)
-            .striped(false)
-            .sense(if layout.is_drive_view {
-                egui::Sense::click()
-            } else {
-                egui::Sense::click_and_drag()
-            })
-            .animate_scrolling(true)
-            .resizable(true)
-            .id_salt(("item_viewer_table", active_tab_id, layout_generation));
+        ui.scope_builder(egui::UiBuilder::new().max_rect(table_rect), |ui| {
+            ui.visuals_mut().widgets.noninteractive.bg_stroke =
+                egui::Stroke::new(1.0, palette.borders_default);
+            let mut table = TableBuilder::new(ui)
+                .vscroll(true)
+                .max_scroll_height(available_height)
+                .min_scrolled_height(0.0)
+                .auto_shrink([false, false])
+                .striped(false)
+                // .sense(egui::Sense::hover())
+                .sense(if layout.is_drive_view {
+                    egui::Sense::click()
+                } else {
+                    egui::Sense::click_and_drag()
+                })
+                .animate_scrolling(true)
+                .resizable(true)
+                .id_salt((
+                    "item_viewer_table",
+                    active_tab_id,
+                    column_layout.layout_generation,
+                ));
 
-        // If we have a pending selection from a refresh, scroll to it and select it
-        if let Some(pending_paths) = explorer_state.pending_selection_paths.clone() {
-            let mut selected_indices = Vec::with_capacity(pending_paths.len());
-            let mut all_found = true;
+            // If we have a pending selection from a refresh, scroll to it and select it
+            if let Some(pending_paths) = explorer_state.pending_selection_paths.clone() {
+                let mut selected_indices = Vec::with_capacity(pending_paths.len());
+                let mut all_found = true;
 
-            for path in &pending_paths {
+                for path in &pending_paths {
+                    if let Some(idx) = filter_state
+                        .cached_indices
+                        .iter()
+                        .position(|&i| &files[i].path == path)
+                    {
+                        selected_indices.push(idx);
+                    } else {
+                        all_found = false;
+                        break;
+                    }
+                }
+
+                if all_found && !selected_indices.is_empty() {
+                    selected_indices.sort_unstable();
+                    table = table.scroll_to_row(selected_indices[0], Some(egui::Align::Center));
+
+                    explorer_state.selected_paths.clear();
+                    for path in pending_paths {
+                        explorer_state.selected_paths.insert(path);
+                    }
+                    explorer_state.selection_anchor = Some(selected_indices[0]);
+                    explorer_state.selection_focus = Some(*selected_indices.last().unwrap());
+                    explorer_state.pending_selection_paths = None;
+                }
+            }
+
+            // If we have a navigation selection, scroll to it and select it
+            if let Some(nav_path) = &explorer_state.navigation_selection {
                 if let Some(idx) = filter_state
                     .cached_indices
                     .iter()
-                    .position(|&i| &files[i].path == path)
+                    .position(|&i| &files[i].path == nav_path)
                 {
-                    selected_indices.push(idx);
-                } else {
-                    all_found = false;
-                    break;
+                    table = table.scroll_to_row(idx, Some(egui::Align::Center));
+
+                    // Auto-select the navigation item
+                    explorer_state.selected_paths.clear();
+                    explorer_state.selected_paths.insert(nav_path.clone());
+                    explorer_state.selection_anchor = Some(idx);
+                    explorer_state.selection_focus = Some(idx);
+
+                    explorer_state.navigation_selection = None;
                 }
             }
 
-            if all_found && !selected_indices.is_empty() {
-                selected_indices.sort_unstable();
-                table = table.scroll_to_row(selected_indices[0], Some(egui::Align::Center));
-
-                explorer_state.selected_paths.clear();
-                for path in pending_paths {
-                    explorer_state.selected_paths.insert(path);
-                }
-                explorer_state.selection_anchor = Some(selected_indices[0]);
-                explorer_state.selection_focus = Some(*selected_indices.last().unwrap());
-                explorer_state.pending_selection_paths = None;
-            }
-        }
-
-        // If we have a navigation selection, scroll to it and select it
-        if let Some(nav_path) = &explorer_state.navigation_selection {
-            if let Some(idx) = filter_state
-                .cached_indices
-                .iter()
-                .position(|&i| &files[i].path == nav_path)
-            {
-                table = table.scroll_to_row(idx, Some(egui::Align::Center));
-
-                // Auto-select the navigation item
-                explorer_state.selected_paths.clear();
-                explorer_state.selected_paths.insert(nav_path.clone());
-                explorer_state.selection_anchor = Some(idx);
-                explorer_state.selection_focus = Some(idx);
-
-                explorer_state.navigation_selection = None;
-            }
-        }
-
-        // If selection changed via keyboard, keep it in view
-        if arrow_nav {
-            if let Some(focus_idx) = explorer_state.selection_focus {
-                if focus_idx < filter_state.cached_indices.len() {
-                    table = table.scroll_to_row(focus_idx, Some(egui::Align::Center));
+            // If selection changed via keyboard, keep it in view
+            if arrow_nav {
+                if let Some(focus_idx) = explorer_state.selection_focus {
+                    if focus_idx < filter_state.cached_indices.len() {
+                        table = table.scroll_to_row(focus_idx, Some(egui::Align::Center));
+                    }
                 }
             }
-        }
 
-        if !layout.is_drive_view {
-            table = table.column(Column::exact(16.0));
-        }
+            if !layout.is_drive_view {
+                table = table.column(Column::exact(16.0));
+            }
 
-        table = table.column(Column::remainder().at_least(name_width).resizable(true));
+            for &column in &column_layout.ordered_columns {
+                let column = match column {
+                    ItemViewerHeaderColumn::Name => Column::initial(column_layout.name_width)
+                        .at_least(180.0)
+                        .resizable(true),
 
-        for column in &ordered_columns {
-            let (width, min_width) = match column {
-                ItemViewerHeaderColumn::Type => (type_width, 60.0),
-                ItemViewerHeaderColumn::Size => {
-                    (size_width, if is_drive_view { 120.0 } else { 75.0 })
-                }
-                ItemViewerHeaderColumn::Modified => (modified_width, 120.0),
-                ItemViewerHeaderColumn::Created => (created_width, 120.0),
-                ItemViewerHeaderColumn::Deleted => (deleted_width, 120.0),
-                ItemViewerHeaderColumn::Usage => (usage_width, 150.0),
-                ItemViewerHeaderColumn::Name => continue,
-            };
+                    ItemViewerHeaderColumn::Type => Column::initial(column_layout.type_width)
+                        .at_least(60.0)
+                        .resizable(true),
 
-            table = table.column(Column::initial(width).at_least(min_width).resizable(true));
-        }
+                    ItemViewerHeaderColumn::Size => Column::initial(column_layout.size_width)
+                        .at_least(if is_drive_view { 120.0 } else { 75.0 })
+                        .resizable(true),
 
-        table
-            .header(layout.header_height, |mut header| {
-                if let Some(a) = draw_item_viewer_header(
-                    i18n,
-                    &mut header,
-                    layout.is_drive_view,
-                    layout.is_recycle_bin_view,
-                    &ordered_columns,
-                    &filter_state.cached_indices,
-                    files,
-                    sort_column,
-                    sort_ascending,
-                    &palette,
-                    explorer_state,
-                    &*column_state,
-                ) {
-                    action = Some(a);
-                }
-            })
-            .body(|body| {
-                let hovered_drop_target = &mut hovered_drop_target;
-                let filtered_indices = &filter_state.cached_indices;
-                body.rows(layout.row_height, filtered_indices.len(), |mut row| {
-                    let idx = row.index();
-                    let file = &files[filtered_indices[idx]];
-                    let is_non_ntfs_drive =
-                        layout.is_drive_view && is_raw_physical_drive_path(&file.path);
-                    let is_selected = explorer_state.selected_paths.contains(&file.path);
-                    let tag_color = tags_state.tag_color_for_path(&file.path);
-                    row.set_selected(is_selected);
-                    let is_cut = is_cut_mode && clipboard_set.contains(&file.path);
+                    ItemViewerHeaderColumn::Modified => {
+                        Column::initial(column_layout.modified_width)
+                            .at_least(100.0)
+                            .resizable(true)
+                    }
 
-                    if !layout.is_drive_view {
-                        row.col(|ui| {
-                            let mut checked = is_selected;
+                    ItemViewerHeaderColumn::Created => Column::initial(column_layout.created_width)
+                        .at_least(100.0)
+                        .resizable(true),
 
-                            if draw_checkbox(ui, palette, &mut checked, &file.path).clicked() {
-                                if checked {
-                                    action = Some(ItemViewerAction::Select(file.path.clone()));
-                                } else {
-                                    action = Some(ItemViewerAction::Deselect(file.path.clone()));
+                    ItemViewerHeaderColumn::Deleted => Column::initial(column_layout.deleted_width)
+                        .at_least(100.0)
+                        .resizable(true),
+
+                    ItemViewerHeaderColumn::Usage => Column::initial(column_layout.usage_width)
+                        .at_least(150.0)
+                        .resizable(true),
+                };
+
+                table = table.column(column);
+            }
+
+            let mut actual_column_widths = Vec::new();
+
+            table
+                .header(layout.header_height, |mut header| {
+                    if let Some(a) = draw_item_viewer_header(
+                        i18n,
+                        &mut header,
+                        layout.is_drive_view,
+                        layout.is_recycle_bin_view,
+                        &column_layout.ordered_columns,
+                        &filter_state.cached_indices,
+                        files,
+                        sort_column,
+                        sort_ascending,
+                        &palette,
+                        explorer_state,
+                        &*column_state,
+                    ) {
+                        action = Some(a);
+                    }
+                })
+                .body(|body| {
+                    let table_body_rect = body.max_rect();
+                    // Capture the actual widths after TableBuilder has applied any
+                    // user-driven column resizing.
+                    actual_column_widths.extend_from_slice(body.widths());
+                    let hovered_drop_target = &mut hovered_drop_target;
+                    let filtered_indices = &filter_state.cached_indices;
+
+                    body.rows(layout.row_height, filtered_indices.len(), |mut row| {
+                        let idx = row.index();
+                        let file = &files[filtered_indices[idx]];
+                        let is_non_ntfs_drive =
+                            layout.is_drive_view && is_raw_physical_drive_path(&file.path);
+                        let is_selected = explorer_state.selected_paths.contains(&file.path);
+                        let tag_color = tags_state.tag_color_for_path(&file.path);
+                        row.set_selected(is_selected);
+                        let is_cut = is_cut_mode && clipboard_set.contains(&file.path);
+
+                        if !layout.is_drive_view {
+                            row.col(|ui| {
+                                let mut checked = is_selected;
+
+                                if draw_checkbox(ui, palette, &mut checked, &file.path).clicked() {
+                                    if checked {
+                                        action = Some(ItemViewerAction::Select(file.path.clone()));
+                                    } else {
+                                        action =
+                                            Some(ItemViewerAction::Deselect(file.path.clone()));
+                                    }
                                 }
-                            }
-                        });
-                    }
-
-                    row.col(|ui| {
-                        if let Some(a) = handle_draw_col_name(
-                            ui,
-                            i18n,
-                            file,
-                            &layout,
-                            icon_cache,
-                            is_selected,
-                            is_cut,
-                            palette,
-                            &font_id,
-                            rename_state,
-                            show_item_viewer_icons,
-                        ) {
-                            action = Some(a);
+                            });
                         }
-                    });
 
-                    for column in &ordered_columns {
-                        row.col(|ui| match column {
-                            ItemViewerHeaderColumn::Type => handle_draw_col_type(
-                                ui,
-                                file,
-                                &layout,
-                                is_selected,
-                                is_cut,
-                                palette,
-                                &font_id,
-                                file_type_cache,
-                            ),
-                            ItemViewerHeaderColumn::Size => handle_draw_col_size(
-                                ui,
-                                file,
-                                &layout,
-                                folder_sizes,
-                                is_selected,
-                                is_cut,
-                                palette,
-                                &font_id,
-                                file_size_text_cache,
-                                folder_size_text_cache,
-                                drive_size_text_cache,
-                            ),
-                            ItemViewerHeaderColumn::Modified => handle_draw_col_modified(
-                                ui,
-                                file,
-                                &layout,
-                                is_selected,
-                                is_cut,
-                                palette,
-                                &font_id,
-                            ),
-                            ItemViewerHeaderColumn::Created => handle_draw_col_created(
-                                ui,
-                                file,
-                                &layout,
-                                is_selected,
-                                is_cut,
-                                palette,
-                                &font_id,
-                            ),
-                            ItemViewerHeaderColumn::Usage => handle_draw_col_modified(
-                                ui,
-                                file,
-                                &layout,
-                                is_selected,
-                                is_cut,
-                                palette,
-                                &font_id,
-                            ),
-                            ItemViewerHeaderColumn::Deleted => handle_draw_col_deleted(
-                                ui,
-                                file,
-                                &layout,
-                                is_selected,
-                                is_cut,
-                                palette,
-                                &font_id,
-                            ),
-                            ItemViewerHeaderColumn::Name => {}
-                        });
-                    }
+                        for &column in &column_layout.ordered_columns {
+                            row.col(|ui| {
+                                draw_item_viewer_row_column(
+                                    ui,
+                                    column,
+                                    file,
+                                    &layout,
+                                    i18n,
+                                    icon_cache,
+                                    is_selected,
+                                    is_cut,
+                                    palette,
+                                    &font_id,
+                                    rename_state,
+                                    show_item_viewer_icons,
+                                    folder_sizes,
+                                    file_type_cache,
+                                    file_size_text_cache,
+                                    folder_size_text_cache,
+                                    drive_size_text_cache,
+                                    &mut action,
+                                );
+                            });
+                        }
 
-                    let row_resp = row.response();
+                        let row_resp = row.response();
 
-                    if let Some(tag_color) = tag_color {
-                        let tag_rect = egui::Rect::from_min_size(
-                            row_resp.rect.min,
-                            egui::vec2(row_resp.rect.width(), layout.row_height),
-                        )
-                        .shrink2(egui::vec2(0.0, 1.0));
-                        let painter = row_resp.ctx.layer_painter(egui::LayerId::new(
-                            egui::Order::Background,
-                            egui::Id::new(("tag_row_bg", active_tab_id, &file.path)),
-                        ));
-                        painter.rect_filled(
-                            tag_rect,
-                            egui::CornerRadius::same(palette.medium_radius),
-                            tag_color.linear_multiply(0.18),
+                        draw_tag_row_background(
+                            row_resp.rect,
+                            table_body_rect,
+                            layout.row_height,
+                            tag_color,
+                            palette,
+                            &ctx,
+                            active_tab_id,
+                            &file.path,
                         );
-                    }
 
-                    if drag_hover_active {
-                        if let Some(target) = hovered_target_ref {
-                            if &file.path == target && file.is_dir {
-                                current_hovered_drop_target = Some(file.path.clone());
-                                current_hovered_drop_target_rect = Some(row_resp.rect);
-                            }
-                        } else if let Some(pointer) = pointer_pos {
-                            if row_resp.rect.contains(pointer) {
-                                let is_dir = file.is_dir;
-                                let row_top = row_resp.rect.top();
-                                let row_rect = {
-                                    let row_min = row_resp.rect.min;
-                                    let row_max = egui::pos2(
-                                        row_resp.rect.max.x,
-                                        row_resp.rect.min.y + layout.row_height,
-                                    );
-                                    egui::Rect::from_min_max(row_min, row_max)
-                                };
-                                match &best_hovered_row {
-                                    Some((best_top, _, _, _)) if *best_top >= row_top => {}
-                                    _ => {
-                                        best_hovered_row =
-                                            Some((row_top, is_dir, file.path.clone(), row_rect));
+                        if drag_hover_active {
+                            if let Some(target) = hovered_target_ref {
+                                if &file.path == target && file.is_dir {
+                                    current_hovered_drop_target = Some(file.path.clone());
+                                    current_hovered_drop_target_rect = Some(row_resp.rect);
+                                }
+                            } else if let Some(pointer) = pointer_pos {
+                                if row_resp.rect.contains(pointer) {
+                                    let is_dir = file.is_dir;
+                                    let row_top = row_resp.rect.top();
+                                    let row_rect = {
+                                        let row_min = row_resp.rect.min;
+                                        let row_max = egui::pos2(
+                                            row_resp.rect.max.x,
+                                            row_resp.rect.min.y + layout.row_height,
+                                        );
+                                        egui::Rect::from_min_max(row_min, row_max)
+                                    };
+                                    match &best_hovered_row {
+                                        Some((best_top, _, _, _)) if *best_top >= row_top => {}
+                                        _ => {
+                                            best_hovered_row = Some((
+                                                row_top,
+                                                is_dir,
+                                                file.path.clone(),
+                                                row_rect,
+                                            ));
+                                        }
                                     }
                                 }
                             }
                         }
-                    }
 
-                    if row_resp.drag_started() && !is_non_ntfs_drive {
-                        drag_state.start_pos = row_resp.interact_pointer_pos();
-                        drag_state.active = false; // threshold not passed yet
-                        drag_state.source_items.clear();
+                        if row_resp.drag_started() && !is_non_ntfs_drive {
+                            drag_state.start_pos = row_resp.interact_pointer_pos();
+                            drag_state.active = false; // threshold not passed yet
+                            drag_state.source_items.clear();
 
-                        if explorer_state.selected_paths.contains(&file.path) {
-                            drag_state.source_items =
-                                explorer_state.selected_paths.iter().cloned().collect();
-                        } else {
-                            // Click-drag on a row should promote that row into the selection.
-                            explorer_state.selected_paths.clear();
-                            explorer_state.selected_paths.insert(file.path.clone());
-                            explorer_state.selection_anchor = Some(idx);
-                            explorer_state.selection_focus = Some(idx);
-                            drag_state.source_items = vec![file.path.clone()];
+                            if explorer_state.selected_paths.contains(&file.path) {
+                                drag_state.source_items =
+                                    explorer_state.selected_paths.iter().cloned().collect();
+                            } else {
+                                // Click-drag on a row should promote that row into the selection.
+                                explorer_state.selected_paths.clear();
+                                explorer_state.selected_paths.insert(file.path.clone());
+                                explorer_state.selection_anchor = Some(idx);
+                                explorer_state.selection_focus = Some(idx);
+                                drag_state.source_items = vec![file.path.clone()];
+                            }
                         }
-                    }
 
-                    if let (Some(start), Some(current)) = (
-                        drag_state.start_pos,
-                        row_resp.ctx.input(|i| i.pointer.hover_pos()),
-                    ) {
-                        if !drag_state.active
-                            && !drag_state.source_items.is_empty()
-                            && start.distance(current) > 4.0
-                        {
-                            drag_state.active = true;
-                        }
-                    }
-
-                    if row_resp.clicked() && !drag_state.active {
-                        if is_non_ntfs_drive {
-                            explorer_state.non_ntfs_popup_path = Some(file.path.clone());
-                        } else if let Some(a) = handle_row_click(
-                            idx,
-                            file,
-                            modifiers,
-                            &filter_state.cached_indices,
-                            files,
-                            drag_state,
-                            explorer_state,
-                            is_recycle_bin_view,
+                        if let (Some(start), Some(current)) = (
+                            drag_state.start_pos,
+                            row_resp.ctx.input(|i| i.pointer.hover_pos()),
                         ) {
-                            action = Some(a);
+                            if !drag_state.active
+                                && !drag_state.source_items.is_empty()
+                                && start.distance(current) > 4.0
+                            {
+                                drag_state.active = true;
+                            }
+                        }
+
+                        if row_resp.clicked() && !drag_state.active {
+                            if is_non_ntfs_drive {
+                                explorer_state.non_ntfs_popup_path = Some(file.path.clone());
+                            } else if let Some(a) = handle_row_click(
+                                idx,
+                                file,
+                                modifiers,
+                                &filter_state.cached_indices,
+                                files,
+                                drag_state,
+                                explorer_state,
+                                is_recycle_bin_view,
+                            ) {
+                                action = Some(a);
+                            }
+                        }
+
+                        if row_resp.middle_clicked()
+                            && file.is_dir
+                            && !is_non_ntfs_drive
+                            && !is_recycle_bin_view
+                        {
+                            action = Some(ItemViewerAction::OpenInNewTab(file.path.clone()));
+                        }
+
+                        if !is_non_ntfs_drive {
+                            Popup::context_menu(&row_resp)
+                                .close_behavior(PopupCloseBehavior::CloseOnClickOutside)
+                                .show(|ui| {
+                                    handle_context_menu_actions(
+                                        ui,
+                                        i18n,
+                                        file,
+                                        is_selected,
+                                        paste_enabled,
+                                        layout.is_drive_view,
+                                        is_recycle_bin_view,
+                                        is_cut,
+                                        &mut action,
+                                        palette,
+                                        explorer_state,
+                                        tags_state,
+                                        settings_window,
+                                        hwnd,
+                                    );
+                                });
+                        }
+                    });
+
+                    // ------------------- END OF ROW HANDLING -------------------
+
+                    if let Some((_, is_dir, path, rect)) = best_hovered_row.take() {
+                        if is_dir {
+                            current_hovered_drop_target = Some(path);
+                            current_hovered_drop_target_rect = Some(rect);
                         }
                     }
 
-                    if row_resp.middle_clicked()
-                        && file.is_dir
-                        && !is_non_ntfs_drive
-                        && !is_recycle_bin_view
-                    {
-                        action = Some(ItemViewerAction::OpenInNewTab(file.path.clone()));
-                    }
-
-                    if drag_hover_active {
-                        // Avoid double-hover visuals during drag; rely on drop highlight.
-                        row.set_hovered(false);
-                    } else if row_resp.hovered() {
-                        row.set_hovered(true);
-                        any_row_hovered = true;
-                    }
-
-                    if !is_non_ntfs_drive {
-                        Popup::context_menu(&row_resp)
-                            .close_behavior(PopupCloseBehavior::CloseOnClickOutside)
-                            .show(|ui| {
-                                handle_context_menu_actions(
-                                    ui,
-                                    i18n,
-                                    file,
-                                    is_selected,
-                                    paste_enabled,
-                                    layout.is_drive_view,
-                                    is_recycle_bin_view,
-                                    is_cut,
-                                    &mut action,
-                                    palette,
-                                    explorer_state,
-                                    tags_state,
-                                    settings_window,
-                                    hwnd,
-                                );
-                            });
-                    }
+                    *hovered_drop_target = current_hovered_drop_target.clone();
+                    hovered_drop_target_rect = current_hovered_drop_target_rect;
                 });
-                if let Some((_, is_dir, path, rect)) = best_hovered_row.take() {
-                    if is_dir {
-                        current_hovered_drop_target = Some(path);
-                        current_hovered_drop_target_rect = Some(rect);
-                    }
+
+            // ------------------- END OF TABLE VIEW -------------------
+            let checkbox_column_count = if layout.is_drive_view { 0 } else { 1 };
+
+            for (column_index, &column) in column_layout.ordered_columns.iter().enumerate() {
+                let table_index = column_index + checkbox_column_count;
+
+                let Some(&actual_width) = actual_column_widths.get(table_index) else {
+                    continue;
+                };
+
+                let stored_width =
+                    column_state.column_width(is_drive_view, is_recycle_bin_view, column);
+
+                if stored_width.map_or(true, |stored| (stored - actual_width).abs() > 0.5) {
+                    column_state.set_column_width(
+                        is_drive_view,
+                        is_recycle_bin_view,
+                        column,
+                        actual_width,
+                    );
+
+                    action = Some(ItemViewerAction::ColumnSizesChanged);
+                }
+            }
+
+            if let Some(rect) = hovered_drop_target_rect {
+                let painter = ui.ctx().layer_painter(egui::LayerId::new(
+                    egui::Order::Foreground,
+                    egui::Id::new("drop_highlight"),
+                ));
+                painter.rect_filled(
+                    rect,
+                    egui::CornerRadius::same(palette.medium_radius),
+                    palette.primary.linear_multiply(0.1),
+                );
+                painter.rect_stroke(
+                    rect,
+                    egui::CornerRadius::same(palette.medium_radius),
+                    egui::Stroke::new(1.5, palette.primary_active),
+                    egui::StrokeKind::Outside,
+                );
+            }
+
+            *hovered_drop_target_out = hovered_drop_target.clone();
+            *hovered_drop_target_rect_out = hovered_drop_target_rect;
+
+            if !modal_input_blocked {
+                if let Some(a) = handle_keyboard_navigation(
+                    ui.ctx(),
+                    &filter_state.cached_indices,
+                    files,
+                    layout.is_drive_view,
+                    explorer_state,
+                ) {
+                    action = Some(a);
+                }
+            }
+
+            // --- Drag and Drop Detection ---
+            *external_drag_to_internal_hover = native_drag_active || external_file_hover;
+            // Fill remaining space so empty area is interactable
+            if drag_state.active && pointer_released {
+                let target_dir = current_hovered_drop_target
+                    .clone()
+                    .or_else(|| bg_response.hovered().then(|| current_dir.clone()));
+
+                if let Some(target_dir) = target_dir {
+                    action = Some(ItemViewerAction::MoveItems {
+                        sources: drag_state.source_items.clone(),
+                        target_dir,
+                    });
+                }
+            }
+
+            if !modal_input_blocked {
+                if bg_response.clicked() {
+                    action = Some(ItemViewerAction::DeselectAll);
                 }
 
-                *hovered_drop_target = current_hovered_drop_target.clone();
-                hovered_drop_target_rect = current_hovered_drop_target_rect;
-            });
+                if !layout.is_drive_view && !is_recycle_bin_view {
+                    Popup::context_menu(&bg_response)
+                        .close_behavior(PopupCloseBehavior::CloseOnClickOutside)
+                        .show(|ui| {
+                            apply_eden_text_overrides(ui, palette);
+                            if ui.button("New Folder").clicked() {
+                                action = Some(ItemViewerAction::CreateFolder);
+                                ui.close();
+                            }
+                            if ui.button("New File").clicked() {
+                                action = Some(ItemViewerAction::CreateFile);
+                                ui.close();
+                            }
+                            if ui.button("Refresh").clicked() {
+                                action = Some(ItemViewerAction::RefreshCurrentDirectory);
+                                ui.close();
+                            }
+                            if ui.button("Open Terminal").clicked() {
+                                action = Some(ItemViewerAction::OpenTerminal);
+                                ui.close();
+                            }
 
-        if let Some(rect) = hovered_drop_target_rect {
-            let painter = ui.ctx().layer_painter(egui::LayerId::new(
-                egui::Order::Foreground,
-                egui::Id::new("drop_highlight"),
-            ));
-            painter.rect_filled(
-                rect,
-                egui::CornerRadius::same(palette.medium_radius),
-                palette.primary.linear_multiply(0.1),
-            );
-            painter.rect_stroke(
-                rect,
-                egui::CornerRadius::same(palette.medium_radius),
-                egui::Stroke::new(1.5, palette.primary_active),
-                egui::StrokeKind::Outside,
-            );
-        }
+                            ui.separator();
 
-        *hovered_drop_target_out = hovered_drop_target.clone();
-        *hovered_drop_target_rect_out = hovered_drop_target_rect;
-
-        if !modal_input_blocked {
-            if let Some(a) = handle_keyboard_navigation(
-                ui.ctx(),
-                &filter_state.cached_indices,
-                files,
-                layout.is_drive_view,
-                explorer_state,
-            ) {
-                action = Some(a);
-            }
-        }
-
-        // --- Drag and Drop Detection ---
-        *external_drag_to_internal_hover = native_drag_active || external_file_hover;
-        // Fill remaining space so empty area is interactable
-        let remaining_rect = ui.available_rect_before_wrap();
-
-        let bg_response = ui.allocate_rect(remaining_rect, egui::Sense::click());
-
-        if drag_state.active && pointer_released {
-            let target_dir = current_hovered_drop_target
-                .clone()
-                .or_else(|| bg_response.hovered().then(|| current_dir.clone()));
-
-            if let Some(target_dir) = target_dir {
-                action = Some(ItemViewerAction::MoveItems {
-                    sources: drag_state.source_items.clone(),
-                    target_dir,
-                });
-            }
-
-            // println!("769 - clearing drag_state");
-            // drag_state.active = false;
-            // drag_state.start_pos = None;
-            // drag_state.source_items.clear();
-        }
-
-        if !modal_input_blocked {
-            if bg_response.clicked() {
-                action = Some(ItemViewerAction::DeselectAll);
-            }
-
-            if !layout.is_drive_view && !is_recycle_bin_view {
-                Popup::context_menu(&bg_response)
-                    .close_behavior(PopupCloseBehavior::CloseOnClickOutside)
-                    .show(|ui| {
-                        apply_eden_text_overrides(ui, palette);
-                        // if !any_row_hovered {
-                        if ui.button("New Folder").clicked() {
-                            action = Some(ItemViewerAction::CreateFolder);
-                            ui.close();
-                        }
-                        if ui.button("New File").clicked() {
-                            action = Some(ItemViewerAction::CreateFile);
-                            ui.close();
-                        }
-                        if ui.button("Refresh").clicked() {
-                            action = Some(ItemViewerAction::RefreshCurrentDirectory);
-                            ui.close();
-                        }
-                        if ui.button("Open Terminal").clicked() {
-                            action = Some(ItemViewerAction::OpenTerminal);
-                            ui.close();
-                        }
-
-                        ui.separator();
-
-                        if ui
-                            .add_enabled(paste_enabled, egui::Button::new("Paste"))
-                            .clicked()
-                        {
-                            action =
-                                Some(ItemViewerAction::Context(ItemViewerContextAction::Paste));
-                            ui.close();
-                        }
-                        if ui.button("Properties").clicked() {
-                            action = Some(ItemViewerAction::Context(
-                                ItemViewerContextAction::Properties(vec![current_dir.clone()]),
-                            ));
-                            ui.close();
-                        }
-                        // }
-                    });
-            } else if is_recycle_bin_view {
-                Popup::context_menu(&bg_response)
-                    .close_behavior(PopupCloseBehavior::CloseOnClickOutside)
-                    .show(|ui| {
-                        apply_eden_text_overrides(ui, palette);
-                        if ui.button("Refresh").clicked() {
-                            action = Some(ItemViewerAction::RefreshCurrentDirectory);
-                            ui.close();
-                        }
-                    });
-            }
-        }
-
-        if let Some(_path) = explorer_state.non_ntfs_popup_path.clone() {
-            let mut open = true;
-            egui::Window::new(i18n.tr("non_nftsdrive"))
-                .collapsible(false)
-                .resizable(false)
-                .anchor(egui::Align2::CENTER_CENTER, egui::vec2(0.0, 0.0))
-                .open(&mut open)
-                .show(ui.ctx(), |ui| {
-                    ui.label(
-                        egui::RichText::new(i18n.tr("non_nftsdrive_fulllabel"))
-                            .size(palette.text_size)
-                            .color(palette.tooltip_text_color)
-                            .font(font_id.clone()),
-                    );
-                    ui.add_space(8.0);
-                    ui.horizontal(|ui| {
-                        ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
                             if ui
-                                .button(format!("{} {}", regular::CHECK, i18n.tr("ok")))
+                                .add_enabled(paste_enabled, egui::Button::new("Paste"))
                                 .clicked()
                             {
-                                explorer_state.non_ntfs_popup_path = None;
+                                action =
+                                    Some(ItemViewerAction::Context(ItemViewerContextAction::Paste));
+                                ui.close();
+                            }
+                            if ui.button("Properties").clicked() {
+                                action = Some(ItemViewerAction::Context(
+                                    ItemViewerContextAction::Properties(vec![current_dir.clone()]),
+                                ));
+                                ui.close();
+                            }
+                            // }
+                        });
+                } else if is_recycle_bin_view {
+                    Popup::context_menu(&bg_response)
+                        .close_behavior(PopupCloseBehavior::CloseOnClickOutside)
+                        .show(|ui| {
+                            apply_eden_text_overrides(ui, palette);
+                            if ui.button("Refresh").clicked() {
+                                action = Some(ItemViewerAction::RefreshCurrentDirectory);
+                                ui.close();
                             }
                         });
-                    });
-                });
-            if !open {
-                explorer_state.non_ntfs_popup_path = None;
+                }
             }
-        }
+
+            if let Some(_path) = explorer_state.non_ntfs_popup_path.clone() {
+                let mut open = true;
+                egui::Window::new(i18n.tr("non_nftsdrive"))
+                    .collapsible(false)
+                    .resizable(false)
+                    .anchor(egui::Align2::CENTER_CENTER, egui::vec2(0.0, 0.0))
+                    .open(&mut open)
+                    .show(ui.ctx(), |ui| {
+                        ui.label(
+                            egui::RichText::new(i18n.tr("non_nftsdrive_fulllabel"))
+                                .size(palette.text_size)
+                                .color(palette.tooltip_text_color)
+                                .font(font_id.clone()),
+                        );
+                        ui.add_space(8.0);
+                        ui.horizontal(|ui| {
+                            ui.with_layout(
+                                egui::Layout::right_to_left(egui::Align::Center),
+                                |ui| {
+                                    if ui
+                                        .button(format!("{} {}", regular::CHECK, i18n.tr("ok")))
+                                        .clicked()
+                                    {
+                                        explorer_state.non_ntfs_popup_path = None;
+                                    }
+                                },
+                            );
+                        });
+                    });
+                if !open {
+                    explorer_state.non_ntfs_popup_path = None;
+                }
+            }
+        });
 
         action
     } else {
@@ -906,220 +771,119 @@ pub fn draw_item_viewer(
     }
 }
 
-#[derive(Clone, Copy, Debug, Default)]
-struct ItemViewerColumnWidths {
-    name: f32,
-    type_width: f32,
-    size_width: f32,
-    modified_width: f32,
-    created_width: f32,
-    usage_width: f32,
-    deleted_width: f32,
-}
-
-fn compute_item_viewer_column_widths(
+fn draw_item_viewer_row_column(
     ui: &mut egui::Ui,
+    column: ItemViewerHeaderColumn,
+    file: &FileItem,
+    layout: &ItemViewerLayout,
     i18n: &I18n,
-    files: &[FileItem],
-    filtered_indices: &[usize],
-    folder_sizes: &HashMap<PathBuf, ItemViewerFolderSizeState>,
-    is_drive_view: bool,
-    show_item_viewer_icons: bool,
+    icon_cache: &IconCache,
+    is_selected: bool,
+    is_cut: bool,
     palette: &ThemePalette,
     font_id: &FontId,
+    rename_state: &mut Option<RenameState>,
+    show_item_viewer_icons: bool,
+    folder_sizes: &HashMap<PathBuf, ItemViewerFolderSizeState>,
     file_type_cache: &mut HashMap<String, String>,
     file_size_text_cache: &mut HashMap<PathBuf, (u64, String)>,
     folder_size_text_cache: &mut HashMap<PathBuf, (u64, bool, String)>,
     drive_size_text_cache: &mut HashMap<PathBuf, (u64, u64, String)>,
-) -> ItemViewerColumnWidths {
-    let mut widths = ItemViewerColumnWidths {
-        name: measure_text_width(
-            ui,
-            &i18n.tr("explorer_cols_name"),
-            font_id,
-            palette.text_header_section,
-        ),
-        type_width: measure_text_width(
-            ui,
-            &i18n.tr("explorer_cols_type"),
-            font_id,
-            palette.text_header_section,
-        ),
-        size_width: measure_text_width(
-            ui,
-            &i18n.tr("explorer_cols_size"),
-            font_id,
-            palette.text_header_section,
-        ),
-        modified_width: measure_text_width(
-            ui,
-            &i18n.tr("explorer_cols_modified"),
-            font_id,
-            palette.text_header_section,
-        ),
-        created_width: measure_text_width(
-            ui,
-            &i18n.tr("explorer_cols_created"),
-            font_id,
-            palette.text_header_section,
-        ),
-        usage_width: measure_text_width(
-            ui,
-            &i18n.tr("explorer_cols_usage"),
-            font_id,
-            palette.text_header_section,
-        ),
-        deleted_width: measure_text_width(
-            ui,
-            &i18n.tr("explorer_cols_deleted"),
-            font_id,
-            palette.text_header_section,
-        ),
-    };
+    action: &mut Option<ItemViewerAction>,
+) {
+    match column {
+        ItemViewerHeaderColumn::Name => {
+            if let Some(a) = handle_draw_col_name(
+                ui,
+                i18n,
+                file,
+                layout,
+                icon_cache,
+                is_selected,
+                is_cut,
+                palette,
+                font_id,
+                rename_state,
+                show_item_viewer_icons,
+            ) {
+                *action = Some(a);
+            }
+        }
 
-    let icon_padding = if show_item_viewer_icons {
-        palette.row_height + 6.0
-    } else {
-        0.0
-    };
-
-    for &idx in filtered_indices {
-        let file = &files[idx];
-
-        widths.name = widths
-            .name
-            .max(measure_text_width(ui, &file.name, font_id, palette.text_normal) + icon_padding);
-
-        let type_text = if file.is_dir {
-            "Folder".to_string()
-        } else if let Some(ext) = file.path.extension().and_then(|ext| ext.to_str()) {
-            get_file_type_name(ext, file_type_cache).to_string()
-        } else {
-            get_file_type_name("", file_type_cache).to_string()
-        };
-        widths.type_width = widths.type_width.max(measure_text_width(
-            ui,
-            &type_text,
-            font_id,
-            palette.text_normal,
-        ));
-
-        let size_text = resolve_size_text(
-            file,
-            folder_sizes,
-            file_size_text_cache,
-            folder_size_text_cache,
-            drive_size_text_cache,
-        );
-        widths.size_width = widths.size_width.max(measure_text_width(
-            ui,
-            &size_text,
-            font_id,
-            palette.text_normal,
-        ));
-
-        if is_drive_view {
-            widths.usage_width = widths.usage_width.max(
-                measure_text_width(
-                    ui,
-                    &i18n.tr("explorer_cols_usage"),
-                    font_id,
-                    palette.text_normal,
-                ) + 60.0,
+        ItemViewerHeaderColumn::Type => {
+            handle_draw_col_type(
+                ui,
+                file,
+                layout,
+                is_selected,
+                is_cut,
+                palette,
+                font_id,
+                file_type_cache,
             );
-        } else {
-            widths.modified_width = widths.modified_width.max(measure_text_width(
+        }
+
+        ItemViewerHeaderColumn::Size => {
+            handle_draw_col_size(
                 ui,
-                file.modified_time.as_deref().unwrap_or("—"),
+                file,
+                layout,
+                folder_sizes,
+                is_selected,
+                is_cut,
+                palette,
                 font_id,
-                palette.text_normal,
-            ));
-            widths.created_width = widths.created_width.max(measure_text_width(
-                ui,
-                file.created_time.as_deref().unwrap_or("—"),
-                font_id,
-                palette.text_normal,
-            ));
+                file_size_text_cache,
+                folder_size_text_cache,
+                drive_size_text_cache,
+            );
+        }
+
+        ItemViewerHeaderColumn::Modified => {
+            handle_draw_col_modified(ui, file, layout, is_selected, is_cut, palette, font_id);
+        }
+
+        ItemViewerHeaderColumn::Created => {
+            handle_draw_col_created(ui, file, layout, is_selected, is_cut, palette, font_id);
+        }
+
+        ItemViewerHeaderColumn::Deleted => {
+            handle_draw_col_deleted(ui, file, layout, is_selected, is_cut, palette, font_id);
+        }
+
+        ItemViewerHeaderColumn::Usage => {
+            handle_draw_col_modified(ui, file, layout, is_selected, is_cut, palette, font_id);
         }
     }
-
-    widths.name = widths.name.max(220.0);
-    widths.type_width = widths.type_width.max(60.0);
-    widths.size_width = widths.size_width.max(75.0);
-    widths.modified_width = widths.modified_width.max(120.0);
-    widths.created_width = widths.created_width.max(120.0);
-    widths.usage_width = widths.usage_width.max(150.0);
-
-    widths
 }
 
-fn resolve_size_text(
-    file: &FileItem,
-    folder_sizes: &HashMap<PathBuf, ItemViewerFolderSizeState>,
-    file_size_text_cache: &mut HashMap<PathBuf, (u64, String)>,
-    folder_size_text_cache: &mut HashMap<PathBuf, (u64, bool, String)>,
-    drive_size_text_cache: &mut HashMap<PathBuf, (u64, u64, String)>,
-) -> String {
-    if let (Some(total), Some(free)) = (file.total_space, file.free_space) {
-        let key = &file.path;
-        if let Some((cached_total, cached_free, cached_text)) = drive_size_text_cache.get(key) {
-            if *cached_total == total && *cached_free == free {
-                return cached_text.clone();
-            }
-        }
+fn draw_tag_row_background(
+    row_rect: egui::Rect,
+    table_clip_rect: egui::Rect,
+    row_height: f32,
+    tag_color: Option<egui::Color32>,
+    palette: &ThemePalette,
+    ctx: &egui::Context,
+    active_tab_id: u64,
+    path: &std::path::Path,
+) {
+    let Some(tag_color) = tag_color else {
+        return;
+    };
 
-        let formatted = format!("{} / {}", format_size(free), format_size(total));
-        drive_size_text_cache.insert(file.path.clone(), (total, free, formatted.clone()));
-        return formatted;
-    }
+    let tag_rect =
+        egui::Rect::from_min_size(row_rect.min, egui::vec2(row_rect.width(), row_height))
+            .shrink2(egui::vec2(0.0, 1.0))
+            .intersect(table_clip_rect);
 
-    if file.is_dir {
-        if let Some(state) = folder_sizes.get(&file.path) {
-            if let Some((bytes, done, value)) = folder_size_text_cache.get(&file.path) {
-                if *bytes == state.bytes && *done == state.done {
-                    return value.clone();
-                }
-            }
+    let painter = ctx.layer_painter(egui::LayerId::new(
+        egui::Order::Background,
+        egui::Id::new(("tag_row_bg", active_tab_id, path)),
+    ));
 
-            let label = format_size(state.bytes);
-            let value = if state.done {
-                label
-            } else {
-                format!("⏳ {}", label)
-            };
-            folder_size_text_cache
-                .insert(file.path.clone(), (state.bytes, state.done, value.clone()));
-            return value;
-        }
-
-        return "—".to_string();
-    }
-
-    if let Some(size) = file.file_size {
-        if let Some((cached_size, value)) = file_size_text_cache.get(&file.path) {
-            if *cached_size == size {
-                return value.clone();
-            }
-        }
-
-        let value = format_size(size);
-        file_size_text_cache.insert(file.path.clone(), (size, value.clone()));
-        return value;
-    }
-
-    "—".to_string()
-}
-
-fn measure_text_width(
-    ui: &mut egui::Ui,
-    text: &str,
-    font_id: &FontId,
-    color: egui::Color32,
-) -> f32 {
-    ui.fonts_mut(|fonts| {
-        fonts
-            .layout_no_wrap(text.to_owned(), font_id.clone(), color)
-            .size()
-            .x
-    })
+    painter.rect_filled(
+        tag_rect,
+        egui::CornerRadius::same(palette.medium_radius),
+        tag_color.linear_multiply(0.18),
+    );
 }

--- a/src/gui/windows/containers/itemviewer_gallery.rs
+++ b/src/gui/windows/containers/itemviewer_gallery.rs
@@ -2,7 +2,9 @@ use crate::core::drives::is_raw_physical_drive_path;
 use crate::core::fs::FileItem;
 use crate::core::utils::text::apply_eden_text_overrides;
 use crate::core::utils::thumbnails::{ThumbnailPriority, ThumbnailService};
-use crate::core::utils::widgets::{apply_eden_visual_overrides, draw_dropdown};
+use crate::core::utils::widgets::{
+    apply_eden_dropdown_visual_color_overrides, apply_eden_visual_overrides, draw_dropdown,
+};
 use crate::gui::i18n::I18n;
 use crate::gui::icons::IconCache;
 use crate::gui::theme::ThemePalette;
@@ -24,8 +26,6 @@ use std::collections::HashSet;
 use std::path::PathBuf;
 use windows::Win32::Foundation::HWND;
 
-const TILE_GAP: f32 = 12.0;
-const TILE_PADDING: f32 = 10.0;
 const LABEL_HEIGHT: f32 = 34.0;
 const TOOLBAR_HEIGHT: f32 = 24.0;
 const GALLERY_TOOLBAR_GAP: f32 = 6.0;
@@ -96,12 +96,14 @@ pub fn draw_gallery_view(
     let pointer_released = ui.ctx().input(|i| i.pointer.primary_released());
     let hovered_target_ref = drag_hover_target.as_ref();
     let thumb_size = gallery_state.thumbnail_size.pixel_size();
-    let tile_width = thumb_size + TILE_PADDING * 2.0 + 26.0;
-    let tile_height = thumb_size + TILE_PADDING * 2.0 + LABEL_HEIGHT;
-    let row_pitch = tile_height + TILE_GAP;
-    let col_pitch = tile_width + TILE_GAP;
+    let tile_width = thumb_size + gallery_state.thumbnail_padding * 2.0 + 26.0;
+    let tile_height = thumb_size + gallery_state.thumbnail_padding * 2.0 + LABEL_HEIGHT;
+    let row_pitch = tile_height + gallery_state.thumbnail_gap;
+    let col_pitch = tile_width + gallery_state.thumbnail_gap;
     let available_width = ui.available_width().max(tile_width);
-    let columns = ((available_width + TILE_GAP) / col_pitch).floor().max(1.0) as usize;
+    let columns = ((available_width + gallery_state.thumbnail_gap) / col_pitch)
+        .floor()
+        .max(1.0) as usize;
     let rows = filtered_indices.len().div_ceil(columns);
     let content_height = (rows as f32 * row_pitch).max(ui.available_height());
     let font_id = FontId::new(palette.text_size, FontFamily::Proportional);
@@ -185,6 +187,7 @@ pub fn draw_gallery_view(
                             is_cut_mode,
                             palette,
                             &font_id,
+                            &gallery_state,
                         );
 
                         if let Some(a) = tile_action {
@@ -411,8 +414,14 @@ fn draw_gallery_toolbar(
             .max_rect(rect)
             .layout(egui::Layout::left_to_right(egui::Align::Min)),
         |ui| {
+            ui.add_space(2.25);
             apply_eden_visual_overrides(ui, palette);
+            apply_eden_dropdown_visual_color_overrides(ui, palette);
             apply_eden_text_overrides(ui, palette);
+            ui.style_mut().visuals.widgets.inactive.bg_fill = egui::Color32::TRANSPARENT;
+            ui.style_mut().visuals.widgets.inactive.weak_bg_fill = egui::Color32::TRANSPARENT;
+            ui.style_mut().visuals.widgets.open.bg_fill = egui::Color32::TRANSPARENT;
+            ui.style_mut().visuals.widgets.open.weak_bg_fill = egui::Color32::TRANSPARENT;
 
             const GALLERY_SORT_COMBO_WIDTH: f32 = 120.0;
 
@@ -448,6 +457,7 @@ fn draw_gallery_toolbar(
             );
 
             for size in [
+                GalleryThumbnailSize::ExtraSmall,
                 GalleryThumbnailSize::Small,
                 GalleryThumbnailSize::Medium,
                 GalleryThumbnailSize::Large,
@@ -467,6 +477,20 @@ fn draw_gallery_toolbar(
                     .clicked()
                 {
                     gallery_state.thumbnail_size = size;
+                    gallery_state.thumbnail_gap = match size {
+                        GalleryThumbnailSize::ExtraSmall => 0.0,
+                        GalleryThumbnailSize::Small => 4.0,
+                        GalleryThumbnailSize::Medium => 8.0,
+                        GalleryThumbnailSize::Large => 12.0,
+                        GalleryThumbnailSize::ExtraLarge => 16.0,
+                    };
+                    gallery_state.thumbnail_padding = match size {
+                        GalleryThumbnailSize::ExtraSmall => 0.0,
+                        GalleryThumbnailSize::Small => 2.0,
+                        GalleryThumbnailSize::Medium => 6.0,
+                        GalleryThumbnailSize::Large => 8.0,
+                        GalleryThumbnailSize::ExtraLarge => 10.0,
+                    };
                 }
             }
         },
@@ -491,6 +515,7 @@ fn draw_gallery_tile(
     is_cut_mode: bool,
     palette: &ThemePalette,
     font_id: &FontId,
+    gallery_state: &GalleryState,
 ) -> (egui::Response, Option<ItemViewerAction>) {
     let response = ui.interact(
         rect,
@@ -520,7 +545,7 @@ fn draw_gallery_tile(
     let preview_rect = egui::Rect::from_center_size(
         egui::pos2(
             rect.center().x,
-            rect.top() + TILE_PADDING + thumb_size * 0.5,
+            rect.top() + gallery_state.thumbnail_padding + thumb_size * 0.5,
         ),
         egui::vec2(thumb_size, thumb_size),
     );
@@ -555,7 +580,7 @@ fn draw_gallery_tile(
             },
         );
     } else if let Some(icon) = icon_cache.get(&file.path, file.is_dir) {
-        let icon_size = (thumb_size * 0.42).clamp(32.0, 96.0);
+        let icon_size = (thumb_size * 0.35).clamp(24.0, 80.0);
 
         let icon_rect =
             egui::Rect::from_center_size(preview_rect.center(), egui::vec2(icon_size, icon_size));
@@ -581,8 +606,14 @@ fn draw_gallery_tile(
     }
 
     let text_rect = egui::Rect::from_min_max(
-        egui::pos2(rect.left() + TILE_PADDING, preview_rect.bottom() + 8.0),
-        egui::pos2(rect.right() - TILE_PADDING, rect.bottom() - 4.0),
+        egui::pos2(
+            rect.left() + gallery_state.thumbnail_padding,
+            preview_rect.bottom() + 8.0,
+        ),
+        egui::pos2(
+            rect.right() - gallery_state.thumbnail_padding,
+            rect.bottom() - 4.0,
+        ),
     );
 
     let editing_path = rename_state.as_ref().map(|rs| rs.path.clone());

--- a/src/gui/windows/containers/itemviewer_helper.rs
+++ b/src/gui/windows/containers/itemviewer_helper.rs
@@ -16,8 +16,9 @@ use crate::gui::windows::containers::enums::{
     ItemViewerAction, ItemViewerContextAction, ItemViewerHeaderColumn, ItemViewerNavAction,
 };
 use crate::gui::windows::containers::structs::{
-    DragState, ExplorerState, FilterState, ItemViewerColumnState, ItemViewerFolderSizeState,
-    ItemViewerLayout, ItemViewerNavBarAction, RenameState, TagsState,
+    DragState, ExplorerState, FilterState, ItemViewerColumnFitRequest, ItemViewerColumnLayout,
+    ItemViewerColumnState, ItemViewerColumnWidths, ItemViewerFolderSizeState, ItemViewerLayout,
+    ItemViewerNavBarAction, RenameState, TagsState,
 };
 use crate::gui::windows::shell_context_menu::ShellContextMenu;
 use crate::gui::windows::structs::{SettingsWindow, ThemeCustomizer};
@@ -370,36 +371,55 @@ pub fn handle_draw_col_name(
         egui::Sense::hover(),
     );
 
-    // Reserve a fixed area for the icon.
-    let icon_size = egui::vec2(layout.icon_size, layout.icon_size);
-    let icon_area_width = icon_size.x + ICON_HORIZONTAL_PADDING * 2.0;
+// Reserve a fixed area for the icon.
+let icon_size = egui::vec2(layout.icon_size, layout.icon_size);
+let icon_area_width = icon_size.x + ICON_HORIZONTAL_PADDING * 2.0;
 
-    let text_offset_x = if show_item_viewer_icons {
-        if let Some(icon) = icon_cache.get(&file.path, file.is_dir) {
-            let icon_area =
-                egui::Rect::from_min_size(rect.min, egui::vec2(icon_area_width, layout.row_height));
+let text_offset_x = if show_item_viewer_icons {
+    let icon_area =
+        egui::Rect::from_min_size(rect.min, egui::vec2(icon_area_width, layout.row_height));
 
-            let icon_pos = egui::pos2(
-                icon_area.center().x - icon_size.x * 0.5,
-                icon_area.center().y - icon_size.y * 0.5,
-            );
-
-            ui.painter().image(
-                (&icon).into(),
-                egui::Rect::from_min_size(icon_pos, icon_size),
-                egui::Rect::from_min_size(egui::pos2(0.0, 0.0), egui::vec2(1.0, 1.0)),
-                if is_cut {
-                    palette.icon_colored_hover.linear_multiply(0.5)
-                } else {
-                    palette.icon_colored_hover
-                },
-            );
-        }
-
-        icon_area_width
+    let icon_color = if is_cut {
+        palette.icon_colored_hover.linear_multiply(0.5)
     } else {
-        TEXT_LEFT_PADDING
+        palette.icon_colored_hover
     };
+
+    // Use a custom Phosphor icon for recognized folder names.
+    if let Some(glyph) = icon_cache.get_custom_folder_icon(&file.path, file.is_dir) {
+        let font_id = egui::FontId::new(
+            icon_size.x,
+            egui::FontFamily::Proportional,
+        );
+
+        ui.painter().text(
+            icon_area.center(),
+            egui::Align2::CENTER_CENTER,
+            glyph,
+            font_id,
+            icon_color,
+        );
+    } else if let Some(icon) = icon_cache.get(&file.path, file.is_dir) {
+        let icon_pos = egui::pos2(
+            icon_area.center().x - icon_size.x * 0.5,
+            icon_area.center().y - icon_size.y * 0.5,
+        );
+
+        ui.painter().image(
+            (&icon).into(),
+            egui::Rect::from_min_size(icon_pos, icon_size),
+            egui::Rect::from_min_size(
+                egui::pos2(0.0, 0.0),
+                egui::vec2(1.0, 1.0),
+            ),
+            icon_color,
+        );
+    }
+
+    icon_area_width
+} else {
+    TEXT_LEFT_PADDING
+};
 
     let text_rect =
         egui::Rect::from_min_max(egui::pos2(rect.min.x + text_offset_x, rect.min.y), rect.max);
@@ -1099,29 +1119,14 @@ pub fn draw_item_viewer_header(
         });
     }
 
-    draw_header_cell(
-        header,
-        i18n,
-        palette,
-        &font_id,
-        sort_column,
-        sort_ascending,
-        ItemViewerHeaderColumn::Name,
-        i18n.tr("explorer_cols_name"),
-        &mut action,
-        column_state,
-        is_drive_view,
-        is_recycle_bin_view,
-    );
-
     for &column in ordered_columns {
         let label = match column {
+            ItemViewerHeaderColumn::Name => i18n.tr("explorer_cols_name"),
             ItemViewerHeaderColumn::Type => i18n.tr("explorer_cols_type"),
             ItemViewerHeaderColumn::Size => i18n.tr("explorer_cols_size"),
             ItemViewerHeaderColumn::Modified => i18n.tr("explorer_cols_modified"),
             ItemViewerHeaderColumn::Created => i18n.tr("explorer_cols_created"),
             ItemViewerHeaderColumn::Usage => i18n.tr("explorer_cols_usage"),
-            ItemViewerHeaderColumn::Name => i18n.tr("explorer_cols_name"),
             ItemViewerHeaderColumn::Deleted => i18n.tr("explorer_cols_deleted"),
         };
         draw_header_cell(
@@ -1303,6 +1308,7 @@ fn draw_header_context_menu(
             *action = Some(ItemViewerAction::MoveColumnLeft(clicked_column));
             ui.close();
         }
+
         if ui
             .add_enabled(can_move_right, egui::Button::new("Move right"))
             .clicked()
@@ -1310,6 +1316,7 @@ fn draw_header_context_menu(
             *action = Some(ItemViewerAction::MoveColumnRight(clicked_column));
             ui.close();
         }
+
         if ui
             .add_enabled(can_move_left, egui::Button::new("Move to start"))
             .clicked()
@@ -1317,6 +1324,7 @@ fn draw_header_context_menu(
             *action = Some(ItemViewerAction::MoveColumnToStart(clicked_column));
             ui.close();
         }
+
         if ui
             .add_enabled(can_move_right, egui::Button::new("Move to end"))
             .clicked()
@@ -1328,20 +1336,33 @@ fn draw_header_context_menu(
         ui.separator();
     }
 
+    // Name is always visible.
     let mut name_checked = true;
     ui.add_enabled(
         false,
         egui::Checkbox::new(&mut name_checked, i18n.tr("explorer_cols_name")),
     );
 
-    if draw_visibility_checkbox(ui, i18n.tr("explorer_cols_type"), column_state.show_type) {
+    let type_visible = column_state.is_column_visible(
+        is_drive_view,
+        is_recycle_bin_view,
+        ItemViewerHeaderColumn::Type,
+    );
+
+    if draw_visibility_checkbox(ui, i18n.tr("explorer_cols_type"), type_visible) {
         *action = Some(ItemViewerAction::ToggleColumnVisibility(
             ItemViewerHeaderColumn::Type,
         ));
         ui.close();
     }
 
-    if draw_visibility_checkbox(ui, i18n.tr("explorer_cols_size"), column_state.show_size) {
+    let size_visible = column_state.is_column_visible(
+        is_drive_view,
+        is_recycle_bin_view,
+        ItemViewerHeaderColumn::Size,
+    );
+
+    if draw_visibility_checkbox(ui, i18n.tr("explorer_cols_size"), size_visible) {
         *action = Some(ItemViewerAction::ToggleColumnVisibility(
             ItemViewerHeaderColumn::Size,
         ));
@@ -1349,44 +1370,53 @@ fn draw_header_context_menu(
     }
 
     if is_drive_view {
+        // Usage is always visible in drive view.
         let mut usage_checked = true;
         ui.add_enabled(
             false,
             egui::Checkbox::new(&mut usage_checked, i18n.tr("explorer_cols_usage")),
         );
     } else if is_recycle_bin_view {
+        // Deleted is always visible in recycle-bin view.
         let mut deleted_checked = true;
         ui.add_enabled(
             false,
             egui::Checkbox::new(&mut deleted_checked, i18n.tr("explorer_cols_deleted")),
         );
-        if draw_visibility_checkbox(
-            ui,
-            i18n.tr("explorer_cols_created"),
-            column_state.show_created,
-        ) {
+
+        let created_visible = column_state.is_column_visible(
+            is_drive_view,
+            is_recycle_bin_view,
+            ItemViewerHeaderColumn::Created,
+        );
+
+        if draw_visibility_checkbox(ui, i18n.tr("explorer_cols_created"), created_visible) {
             *action = Some(ItemViewerAction::ToggleColumnVisibility(
                 ItemViewerHeaderColumn::Created,
             ));
             ui.close();
         }
     } else {
-        if draw_visibility_checkbox(
-            ui,
-            i18n.tr("explorer_cols_modified"),
-            column_state.show_modified,
-        ) {
+        let modified_visible = column_state.is_column_visible(
+            is_drive_view,
+            is_recycle_bin_view,
+            ItemViewerHeaderColumn::Modified,
+        );
+
+        if draw_visibility_checkbox(ui, i18n.tr("explorer_cols_modified"), modified_visible) {
             *action = Some(ItemViewerAction::ToggleColumnVisibility(
                 ItemViewerHeaderColumn::Modified,
             ));
             ui.close();
         }
 
-        if draw_visibility_checkbox(
-            ui,
-            i18n.tr("explorer_cols_created"),
-            column_state.show_created,
-        ) {
+        let created_visible = column_state.is_column_visible(
+            is_drive_view,
+            is_recycle_bin_view,
+            ItemViewerHeaderColumn::Created,
+        );
+
+        if draw_visibility_checkbox(ui, i18n.tr("explorer_cols_created"), created_visible) {
             *action = Some(ItemViewerAction::ToggleColumnVisibility(
                 ItemViewerHeaderColumn::Created,
             ));
@@ -1696,4 +1726,403 @@ pub fn draw_table_text(
     );
 
     response.on_hover_cursor(egui::CursorIcon::Default)
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn compute_item_viewer_column_layout(
+    ui: &mut egui::Ui,
+    i18n: &I18n,
+    column_state: &mut ItemViewerColumnState,
+    filter_state: &FilterState,
+    files: &[FileItem],
+    folder_sizes: &HashMap<PathBuf, ItemViewerFolderSizeState>,
+    is_drive_view: bool,
+    is_recycle_bin_view: bool,
+    show_item_viewer_icons: bool,
+    palette: &ThemePalette,
+    font_id: &FontId,
+    file_type_cache: &mut HashMap<String, String>,
+    file_size_text_cache: &mut HashMap<PathBuf, (u64, String)>,
+    folder_size_text_cache: &mut HashMap<PathBuf, (u64, bool, String)>,
+    drive_size_text_cache: &mut HashMap<PathBuf, (u64, u64, String)>,
+    viewport_width: f32,
+) -> ItemViewerColumnLayout {
+    let fit_request = column_state.pending_fit_request.take();
+    let layout_generation = column_state.layout_generation;
+    let ordered_columns = column_state.visible_order(is_drive_view, is_recycle_bin_view);
+
+    let mut column_sizes_changed = false;
+    let current_width = viewport_width.max(1.0);
+
+    // Handle any pending auto-fit request. The calculated widths are stored
+    // back into column_state so they persist across frames and column reordering.
+    if let Some(fit_request) = fit_request {
+        let widths = compute_item_viewer_column_widths(
+            ui,
+            i18n,
+            files,
+            &filter_state.cached_indices,
+            folder_sizes,
+            is_drive_view,
+            show_item_viewer_icons,
+            palette,
+            font_id,
+            file_type_cache,
+            file_size_text_cache,
+            folder_size_text_cache,
+            drive_size_text_cache,
+        );
+
+        match fit_request {
+            ItemViewerColumnFitRequest::All => {
+                column_state.set_all_column_widths(is_drive_view, is_recycle_bin_view, &widths);
+
+                column_sizes_changed = true;
+            }
+
+            ItemViewerColumnFitRequest::Column(column) => {
+                let width = match column {
+                    ItemViewerHeaderColumn::Name => widths.name,
+                    ItemViewerHeaderColumn::Type => widths.type_width,
+                    ItemViewerHeaderColumn::Size => widths.size_width,
+                    ItemViewerHeaderColumn::Modified => widths.modified_width,
+                    ItemViewerHeaderColumn::Created => widths.created_width,
+                    ItemViewerHeaderColumn::Deleted => widths.deleted_width,
+                    ItemViewerHeaderColumn::Usage => widths.usage_width,
+                };
+
+                column_state.set_column_width(is_drive_view, is_recycle_bin_view, column, width);
+
+                column_sizes_changed = true;
+            }
+        }
+    }
+
+    // Default widths are only used when a column has never been explicitly
+    // sized or fitted.
+    let default_name_width = (current_width * 0.35).max(180.0);
+    let default_type_width = (current_width * 0.10).max(60.0);
+
+    let default_size_width = if is_drive_view {
+        (current_width * 0.14).max(120.0)
+    } else {
+        (current_width * 0.10).max(75.0)
+    };
+
+    let default_modified_width = (current_width * 0.20).max(100.0);
+    let default_created_width = (current_width * 0.20).max(100.0);
+    let default_deleted_width = (current_width * 0.20).max(100.0);
+    let default_usage_width = (current_width * 0.20).max(150.0);
+
+    let name_width = column_state
+        .column_width(
+            is_drive_view,
+            is_recycle_bin_view,
+            ItemViewerHeaderColumn::Name,
+        )
+        .unwrap_or(default_name_width);
+
+    let type_width = if ordered_columns.contains(&ItemViewerHeaderColumn::Type) {
+        column_state
+            .column_width(
+                is_drive_view,
+                is_recycle_bin_view,
+                ItemViewerHeaderColumn::Type,
+            )
+            .unwrap_or(default_type_width)
+    } else {
+        0.0
+    };
+
+    let size_width = if ordered_columns.contains(&ItemViewerHeaderColumn::Size) {
+        column_state
+            .column_width(
+                is_drive_view,
+                is_recycle_bin_view,
+                ItemViewerHeaderColumn::Size,
+            )
+            .unwrap_or(default_size_width)
+    } else {
+        0.0
+    };
+
+    let usage_width = if ordered_columns.contains(&ItemViewerHeaderColumn::Usage) {
+        column_state
+            .column_width(
+                is_drive_view,
+                is_recycle_bin_view,
+                ItemViewerHeaderColumn::Usage,
+            )
+            .unwrap_or(default_usage_width)
+    } else {
+        0.0
+    };
+
+    let modified_width = if ordered_columns.contains(&ItemViewerHeaderColumn::Modified) {
+        column_state
+            .column_width(
+                is_drive_view,
+                is_recycle_bin_view,
+                ItemViewerHeaderColumn::Modified,
+            )
+            .unwrap_or(default_modified_width)
+    } else {
+        0.0
+    };
+
+    let created_width = if ordered_columns.contains(&ItemViewerHeaderColumn::Created) {
+        column_state
+            .column_width(
+                is_drive_view,
+                is_recycle_bin_view,
+                ItemViewerHeaderColumn::Created,
+            )
+            .unwrap_or(default_created_width)
+    } else {
+        0.0
+    };
+
+    let deleted_width = if ordered_columns.contains(&ItemViewerHeaderColumn::Deleted) {
+        column_state
+            .column_width(
+                is_drive_view,
+                is_recycle_bin_view,
+                ItemViewerHeaderColumn::Deleted,
+            )
+            .unwrap_or(default_deleted_width)
+    } else {
+        0.0
+    };
+
+    ItemViewerColumnLayout {
+        layout_generation,
+        ordered_columns,
+        name_width,
+        type_width,
+        size_width,
+        usage_width,
+        modified_width,
+        created_width,
+        deleted_width,
+        column_sizes_changed,
+    }
+}
+
+fn compute_item_viewer_column_widths(
+    ui: &mut egui::Ui,
+    i18n: &I18n,
+    files: &[FileItem],
+    filtered_indices: &[usize],
+    folder_sizes: &HashMap<PathBuf, ItemViewerFolderSizeState>,
+    is_drive_view: bool,
+    show_item_viewer_icons: bool,
+    palette: &ThemePalette,
+    font_id: &FontId,
+    file_type_cache: &mut HashMap<String, String>,
+    file_size_text_cache: &mut HashMap<PathBuf, (u64, String)>,
+    folder_size_text_cache: &mut HashMap<PathBuf, (u64, bool, String)>,
+    drive_size_text_cache: &mut HashMap<PathBuf, (u64, u64, String)>,
+) -> ItemViewerColumnWidths {
+    let mut widths = ItemViewerColumnWidths {
+        name: measure_text_width(
+            ui,
+            &i18n.tr("explorer_cols_name"),
+            font_id,
+            palette.text_header_section,
+        ),
+        type_width: measure_text_width(
+            ui,
+            &i18n.tr("explorer_cols_type"),
+            font_id,
+            palette.text_header_section,
+        ),
+        size_width: measure_text_width(
+            ui,
+            &i18n.tr("explorer_cols_size"),
+            font_id,
+            palette.text_header_section,
+        ),
+        modified_width: measure_text_width(
+            ui,
+            &i18n.tr("explorer_cols_modified"),
+            font_id,
+            palette.text_header_section,
+        ),
+        created_width: measure_text_width(
+            ui,
+            &i18n.tr("explorer_cols_created"),
+            font_id,
+            palette.text_header_section,
+        ),
+        usage_width: measure_text_width(
+            ui,
+            &i18n.tr("explorer_cols_usage"),
+            font_id,
+            palette.text_header_section,
+        ),
+        deleted_width: measure_text_width(
+            ui,
+            &i18n.tr("explorer_cols_deleted"),
+            font_id,
+            palette.text_header_section,
+        ),
+    };
+
+    let icon_padding = if show_item_viewer_icons {
+        palette.row_height + 6.0
+    } else {
+        0.0
+    };
+
+    for &idx in filtered_indices {
+        let file = &files[idx];
+
+        widths.name = widths
+            .name
+            .max(measure_text_width(ui, &file.name, font_id, palette.text_normal) + icon_padding);
+
+        let type_text = if file.is_dir {
+            "Folder".to_string()
+        } else if let Some(ext) = file.path.extension().and_then(|ext| ext.to_str()) {
+            get_file_type_name(ext, file_type_cache).to_string()
+        } else {
+            get_file_type_name("", file_type_cache).to_string()
+        };
+        widths.type_width = widths.type_width.max(measure_text_width(
+            ui,
+            &type_text,
+            font_id,
+            palette.text_normal,
+        ));
+
+        let size_text = resolve_size_text(
+            file,
+            folder_sizes,
+            file_size_text_cache,
+            folder_size_text_cache,
+            drive_size_text_cache,
+        );
+        widths.size_width = widths.size_width.max(measure_text_width(
+            ui,
+            &size_text,
+            font_id,
+            palette.text_normal,
+        ));
+
+        if is_drive_view {
+            widths.usage_width = widths.usage_width.max(
+                measure_text_width(
+                    ui,
+                    &i18n.tr("explorer_cols_usage"),
+                    font_id,
+                    palette.text_normal,
+                ) + 60.0,
+            );
+        } else {
+            widths.modified_width = widths.modified_width.max(measure_text_width(
+                ui,
+                file.modified_time.as_deref().unwrap_or("—"),
+                font_id,
+                palette.text_normal,
+            ));
+            widths.created_width = widths.created_width.max(measure_text_width(
+                ui,
+                file.created_time.as_deref().unwrap_or("—"),
+                font_id,
+                palette.text_normal,
+            ));
+        }
+    }
+
+    widths.name = widths.name.max(220.0);
+    widths.type_width = widths.type_width.max(60.0);
+    widths.size_width = widths.size_width.max(75.0);
+    widths.modified_width = widths.modified_width.max(120.0);
+    widths.created_width = widths.created_width.max(120.0);
+    widths.usage_width = widths.usage_width.max(150.0);
+
+    widths
+}
+
+fn measure_text_width(
+    ui: &mut egui::Ui,
+    text: &str,
+    font_id: &FontId,
+    color: egui::Color32,
+) -> f32 {
+    ui.fonts_mut(|fonts| {
+        fonts
+            .layout_no_wrap(text.to_owned(), font_id.clone(), color)
+            .size()
+            .x
+    })
+}
+
+fn resolve_size_text(
+    file: &FileItem,
+    folder_sizes: &HashMap<PathBuf, ItemViewerFolderSizeState>,
+    file_size_text_cache: &mut HashMap<PathBuf, (u64, String)>,
+    folder_size_text_cache: &mut HashMap<PathBuf, (u64, bool, String)>,
+    drive_size_text_cache: &mut HashMap<PathBuf, (u64, u64, String)>,
+) -> String {
+    if let (Some(total), Some(free)) = (file.total_space, file.free_space) {
+        let key = &file.path;
+        if let Some((cached_total, cached_free, cached_text)) = drive_size_text_cache.get(key) {
+            if *cached_total == total && *cached_free == free {
+                return cached_text.clone();
+            }
+        }
+
+        let formatted = format!("{} / {}", format_size(free), format_size(total));
+        drive_size_text_cache.insert(file.path.clone(), (total, free, formatted.clone()));
+        return formatted;
+    }
+
+    if file.is_dir {
+        if let Some(state) = folder_sizes.get(&file.path) {
+            if let Some((bytes, done, value)) = folder_size_text_cache.get(&file.path) {
+                if *bytes == state.bytes && *done == state.done {
+                    return value.clone();
+                }
+            }
+
+            let label = format_size(state.bytes);
+            let value = if state.done {
+                label
+            } else {
+                format!("⏳ {}", label)
+            };
+            folder_size_text_cache
+                .insert(file.path.clone(), (state.bytes, state.done, value.clone()));
+            return value;
+        }
+
+        return "—".to_string();
+    }
+
+    if let Some(size) = file.file_size {
+        if let Some((cached_size, value)) = file_size_text_cache.get(&file.path) {
+            if *cached_size == size {
+                return value.clone();
+            }
+        }
+
+        let value = format_size(size);
+        file_size_text_cache.insert(file.path.clone(), (size, value.clone()));
+        return value;
+    }
+
+    "—".to_string()
+}
+
+pub fn table_background_response(ui: &mut egui::Ui) -> egui::Response {
+    let mut rect = ui.available_rect_before_wrap();
+
+    rect.max.x -= ui.spacing().scroll.allocated_width();
+
+    ui.interact(
+        rect,
+        ui.id().with("item_viewer_background"),
+        egui::Sense::click(),
+    )
 }

--- a/src/gui/windows/containers/itemviewer_helper.rs
+++ b/src/gui/windows/containers/itemviewer_helper.rs
@@ -371,55 +371,49 @@ pub fn handle_draw_col_name(
         egui::Sense::hover(),
     );
 
-// Reserve a fixed area for the icon.
-let icon_size = egui::vec2(layout.icon_size, layout.icon_size);
-let icon_area_width = icon_size.x + ICON_HORIZONTAL_PADDING * 2.0;
+    // Reserve a fixed area for the icon.
+    let icon_size = egui::vec2(layout.icon_size, layout.icon_size);
+    let icon_area_width = icon_size.x + ICON_HORIZONTAL_PADDING * 2.0;
 
-let text_offset_x = if show_item_viewer_icons {
-    let icon_area =
-        egui::Rect::from_min_size(rect.min, egui::vec2(icon_area_width, layout.row_height));
+    let text_offset_x = if show_item_viewer_icons {
+        let icon_area =
+            egui::Rect::from_min_size(rect.min, egui::vec2(icon_area_width, layout.row_height));
 
-    let icon_color = if is_cut {
-        palette.icon_colored_hover.linear_multiply(0.5)
+        let icon_color = if is_cut {
+            palette.icon_colored_hover.linear_multiply(0.5)
+        } else {
+            palette.icon_colored_hover
+        };
+
+        // Use a custom Phosphor icon for recognized folder names.
+        if let Some(glyph) = icon_cache.get_custom_folder_icon(&file.path, file.is_dir) {
+            let font_id = egui::FontId::new(icon_size.x, egui::FontFamily::Proportional);
+
+            ui.painter().text(
+                icon_area.center(),
+                egui::Align2::CENTER_CENTER,
+                glyph,
+                font_id,
+                icon_color,
+            );
+        } else if let Some(icon) = icon_cache.get(&file.path, file.is_dir) {
+            let icon_pos = egui::pos2(
+                icon_area.center().x - icon_size.x * 0.5,
+                icon_area.center().y - icon_size.y * 0.5,
+            );
+
+            ui.painter().image(
+                (&icon).into(),
+                egui::Rect::from_min_size(icon_pos, icon_size),
+                egui::Rect::from_min_size(egui::pos2(0.0, 0.0), egui::vec2(1.0, 1.0)),
+                icon_color,
+            );
+        }
+
+        icon_area_width
     } else {
-        palette.icon_colored_hover
+        TEXT_LEFT_PADDING
     };
-
-    // Use a custom Phosphor icon for recognized folder names.
-    if let Some(glyph) = icon_cache.get_custom_folder_icon(&file.path, file.is_dir) {
-        let font_id = egui::FontId::new(
-            icon_size.x,
-            egui::FontFamily::Proportional,
-        );
-
-        ui.painter().text(
-            icon_area.center(),
-            egui::Align2::CENTER_CENTER,
-            glyph,
-            font_id,
-            icon_color,
-        );
-    } else if let Some(icon) = icon_cache.get(&file.path, file.is_dir) {
-        let icon_pos = egui::pos2(
-            icon_area.center().x - icon_size.x * 0.5,
-            icon_area.center().y - icon_size.y * 0.5,
-        );
-
-        ui.painter().image(
-            (&icon).into(),
-            egui::Rect::from_min_size(icon_pos, icon_size),
-            egui::Rect::from_min_size(
-                egui::pos2(0.0, 0.0),
-                egui::vec2(1.0, 1.0),
-            ),
-            icon_color,
-        );
-    }
-
-    icon_area_width
-} else {
-    TEXT_LEFT_PADDING
-};
 
     let text_rect =
         egui::Rect::from_min_max(egui::pos2(rect.min.x + text_offset_x, rect.min.y), rect.max);

--- a/src/gui/windows/containers/itemviewer_navbar.rs
+++ b/src/gui/windows/containers/itemviewer_navbar.rs
@@ -43,6 +43,7 @@ pub fn draw_itemviewer_navigation_bar(
     let is_recycle_bin = tab.nav.is_recycle_bin();
 
     ui.horizontal(|ui| {
+        ui.add_space(1.5);
         let toolbar_action = draw_navigation_bar_buttons(
             ui,
             i18n,
@@ -113,7 +114,11 @@ pub fn draw_itemviewer_navigation_bar(
                     ui.add(
                         egui::TextEdit::singleline(&mut tab.breadcrumb_path_buffer)
                             .id(text_edit_id)
-                            .frame(!tab.breadcrumb_path_error)
+                            .frame(if tab.breadcrumb_path_error {
+                                egui::Frame::NONE
+                            } else {
+                                egui::Frame::default()
+                            })
                             .desired_width(ui.available_width() - 40.0)
                             .font(FontId::new(
                                 palette.text_size,
@@ -397,7 +402,7 @@ fn draw_navigation_bar_buttons(
         action.nav = Some(ItemViewerNavAction::Up);
     }
 
-    if clickable_icon(ui, regular::ARROWS_CLOCKWISE, palette.primary)
+    if clickable_icon(ui, regular::ARROWS_CLOCKWISE, palette)
         .on_hover_text(
             egui::RichText::new(i18n.tr("tooltip_refresh"))
                 .size(palette.tooltip_text_size)

--- a/src/gui/windows/containers/sidebar.rs
+++ b/src/gui/windows/containers/sidebar.rs
@@ -458,63 +458,45 @@ pub fn draw_sidebar_item(
     }
 
     // --- Icon ---
-let icon_size = egui::vec2(palette.sidebar_icon_size, palette.sidebar_icon_size);
-let icon_padding = 4.0;
+    let icon_size = egui::vec2(palette.sidebar_icon_size, palette.sidebar_icon_size);
+    let icon_padding = 4.0;
 
-let icon_pos = egui::pos2(
-    rect.min.x + 4.0,
-    rect.center().y - icon_size.y / 2.0,
-);
+    let icon_pos = egui::pos2(rect.min.x + 4.0, rect.center().y - icon_size.y / 2.0);
 
-let text_offset_x = if is_recycle_bin {
-    ui.painter().text(
-        egui::pos2(
-            icon_pos.x + icon_size.x * 0.5,
-            rect.center().y,
-        ),
-        egui::Align2::CENTER_CENTER,
-        regular::TRASH,
-        egui::FontId::new(
-            icon_size.y * 0.85,
-            egui::FontFamily::Proportional,
-        ),
-        palette.icon_color,
-    );
+    let text_offset_x = if is_recycle_bin {
+        ui.painter().text(
+            egui::pos2(icon_pos.x + icon_size.x * 0.5, rect.center().y),
+            egui::Align2::CENTER_CENTER,
+            regular::TRASH,
+            egui::FontId::new(icon_size.y * 0.85, egui::FontFamily::Proportional),
+            palette.icon_color,
+        );
 
-    palette.text_size + icon_size.x + icon_padding
-} else if let Some(glyph) = icon_cache.get_custom_folder_icon(path, is_dir) {
-    // Custom Phosphor icon for recognized folders.
-    ui.painter().text(
-        egui::pos2(
-            icon_pos.x + icon_size.x * 0.5,
-            rect.center().y,
-        ),
-        egui::Align2::CENTER_CENTER,
-        glyph,
-        egui::FontId::new(
-            icon_size.y,
-            egui::FontFamily::Proportional,
-        ),
-        palette.icon_color,
-    );
+        palette.text_size + icon_size.x + icon_padding
+    } else if let Some(glyph) = icon_cache.get_custom_folder_icon(path, is_dir) {
+        // Custom Phosphor icon for recognized folders.
+        ui.painter().text(
+            egui::pos2(icon_pos.x + icon_size.x * 0.5, rect.center().y),
+            egui::Align2::CENTER_CENTER,
+            glyph,
+            egui::FontId::new(icon_size.y, egui::FontFamily::Proportional),
+            palette.icon_color,
+        );
 
-    palette.text_size + icon_size.x + icon_padding
-} else if let Some(icon) = icon_cache.get(path, is_dir) {
-    // Windows shell icon fallback.
-    ui.painter().image(
-        (&icon).into(),
-        egui::Rect::from_min_size(icon_pos, icon_size),
-        egui::Rect::from_min_size(
-            egui::pos2(0.0, 0.0),
-            egui::vec2(1.0, 1.0),
-        ),
-        egui::Color32::WHITE,
-    );
+        palette.text_size + icon_size.x + icon_padding
+    } else if let Some(icon) = icon_cache.get(path, is_dir) {
+        // Windows shell icon fallback.
+        ui.painter().image(
+            (&icon).into(),
+            egui::Rect::from_min_size(icon_pos, icon_size),
+            egui::Rect::from_min_size(egui::pos2(0.0, 0.0), egui::vec2(1.0, 1.0)),
+            egui::Color32::WHITE,
+        );
 
-    palette.text_size + icon_size.x + icon_padding
-} else {
-    palette.text_size + 20.0 + icon_padding
-};
+        palette.text_size + icon_size.x + icon_padding
+    } else {
+        palette.text_size + 20.0 + icon_padding
+    };
 
     // --- Text ---
     let text_width = rect.width() - text_offset_x;

--- a/src/gui/windows/containers/sidebar.rs
+++ b/src/gui/windows/containers/sidebar.rs
@@ -16,270 +16,6 @@ use egui_phosphor::regular;
 use std::path::PathBuf;
 use std::time::{Duration, Instant};
 
-pub fn draw_sidebar_item(
-    ui: &mut egui::Ui,
-    icon_cache: &IconCache,
-    path: &PathBuf,
-    label: &str,
-    is_dir: bool,
-    is_recycle_bin: bool,
-    palette: &ThemePalette,
-    draggable: bool,
-    rect_and_resp: Option<(egui::Rect, egui::Response)>,
-) -> egui::Response {
-    let height = 18.0;
-
-    // --- Get rect + response ---
-    let (rect, resp) = if let Some((rect, resp)) = rect_and_resp {
-        (rect, resp)
-    } else {
-        let available_width = ui.available_width();
-        ui.allocate_exact_size(
-            egui::vec2(available_width, height),
-            if draggable {
-                egui::Sense::click_and_drag()
-            } else {
-                egui::Sense::click()
-            },
-        )
-    };
-
-    // --- Hover background + cursor ---
-    if resp.hovered() {
-        ui.ctx().set_cursor_icon(if draggable {
-            egui::CursorIcon::Grab
-        } else {
-            egui::CursorIcon::Default
-        });
-
-        ui.painter().rect_filled(
-            rect,
-            egui::CornerRadius::same(palette.medium_radius),
-            palette.primary_hover,
-        );
-
-        if draggable {
-            let handle_width = 12.0;
-            let handle_rect = egui::Rect::from_min_size(
-                egui::pos2(rect.right() - handle_width - 4.0, rect.top()),
-                egui::vec2(handle_width, rect.height()),
-            );
-
-            ui.painter().text(
-                handle_rect.center(),
-                egui::Align2::CENTER_CENTER,
-                regular::DOTS_SIX_VERTICAL,
-                egui::FontId::new(14.0, egui::FontFamily::Proportional),
-                palette.icon_color,
-            );
-        }
-    }
-
-    // --- Icon ---
-    let icon_size = egui::vec2(palette.sidebar_icon_size, palette.sidebar_icon_size);
-    let icon_padding = 4.0;
-
-    let icon_pos = egui::pos2(rect.min.x + 4.0, rect.center().y - icon_size.y / 2.0);
-    let text_offset_x = if is_recycle_bin {
-        ui.painter().text(
-            egui::pos2(icon_pos.x + icon_size.x * 0.5, rect.center().y),
-            egui::Align2::CENTER_CENTER,
-            regular::TRASH,
-            egui::FontId::new(icon_size.y * 0.85, egui::FontFamily::Proportional),
-            palette.icon_color,
-        );
-        palette.text_size + icon_size.x + icon_padding
-    } else if let Some(icon) = icon_cache.get(path, is_dir) {
-        ui.painter().image(
-            (&icon).into(),
-            egui::Rect::from_min_size(icon_pos, icon_size),
-            egui::Rect::from_min_size(egui::pos2(0.0, 0.0), egui::vec2(1.0, 1.0)),
-            egui::Color32::WHITE,
-        );
-
-        palette.text_size + icon_size.x + icon_padding
-    } else {
-        palette.text_size + 20.0 + icon_padding
-    };
-
-    // --- Text ---
-    let text_width = rect.width() - text_offset_x;
-    let font_id = egui::FontId::new(palette.text_size, egui::FontFamily::Proportional);
-    let color = ui.visuals().text_color();
-
-    let (display_name, truncated) = truncate_item_text(ui, label, text_width, &font_id, color);
-
-    let text_pos = egui::pos2(rect.min.x + text_offset_x, rect.center().y - 2.0);
-
-    ui.painter().text(
-        text_pos,
-        egui::Align2::LEFT_CENTER,
-        display_name,
-        font_id,
-        color,
-    );
-
-    // --- Tooltip + cursor ---
-    let resp = resp.on_hover_cursor(egui::CursorIcon::PointingHand);
-
-    if truncated {
-        resp.on_hover_text(
-            egui::RichText::new(label)
-                .size(palette.tooltip_text_size)
-                .color(palette.tooltip_text_color),
-        )
-    } else {
-        resp.on_hover_text(
-            egui::RichText::new(path.to_string_lossy())
-                .size(palette.tooltip_text_size)
-                .color(palette.tooltip_text_color),
-        )
-    }
-}
-
-fn favorites_item_layout(ui: &mut egui::Ui) -> (egui::Rect, egui::Response) {
-    let available_width = ui.available_width();
-    let height = 18.0;
-
-    ui.allocate_exact_size(
-        egui::vec2(available_width, height),
-        egui::Sense::click_and_drag(),
-    )
-}
-
-/// Draw a drive item with usage bar and size on hover
-fn sidebar_drive_item(
-    ui: &mut egui::Ui,
-    icon_cache: &IconCache,
-    drive: &DriveInfo,
-    palette: &ThemePalette,
-    selected: bool,
-) -> egui::Response {
-    let available_width = ui.available_width();
-    let height = 32.0;
-
-    let (rect, mut resp) =
-        ui.allocate_exact_size(egui::vec2(available_width, height), egui::Sense::click());
-
-    // Background (selected > active click > hover)
-    let fill_color = if selected {
-        palette.primary_active
-    } else if resp.is_pointer_button_down_on() {
-        palette.primary_active
-    } else if resp.hovered() {
-        palette.primary_hover
-    } else {
-        egui::Color32::TRANSPARENT
-    };
-
-    if fill_color != egui::Color32::TRANSPARENT {
-        ui.painter().rect_filled(
-            rect,
-            egui::CornerRadius::same(palette.medium_radius),
-            fill_color,
-        );
-    }
-
-    if resp.hovered() {
-        ui.ctx().set_cursor_icon(egui::CursorIcon::PointingHand);
-    }
-
-    // --- Top row: icon + label ---
-    let icon_size = egui::vec2(palette.sidebar_icon_size, palette.sidebar_icon_size);
-    let icon_padding = 4.0;
-
-    let text_offset_x = if let Some(icon) = icon_cache.get(&drive.path, true) {
-        let icon_pos = egui::pos2(rect.min.x + 4.0, rect.min.y + 4.0);
-
-        ui.painter().image(
-            (&icon).into(),
-            egui::Rect::from_min_size(icon_pos, icon_size),
-            egui::Rect::from_min_size(egui::pos2(0.0, 0.0), egui::vec2(1.0, 1.0)),
-            palette.icon_windows,
-        );
-
-        palette.text_size + icon_size.x + icon_padding
-    } else {
-        palette.text_size + 20.0 + icon_padding
-    };
-
-    // --- DISPLAY TEXT ---
-    let text_width = available_width - text_offset_x;
-    let max_chars = (text_width / 7.0) as usize;
-
-    let display_name = if drive.display.len() > max_chars && max_chars > 3 {
-        // Use character boundaries instead of byte indices
-        let mut char_count = 0;
-        let mut byte_end = 0;
-        for (i, _) in drive.display.char_indices() {
-            if char_count >= max_chars - 3 {
-                break;
-            }
-            char_count += 1;
-            byte_end = i;
-        }
-        format!("{}...", &drive.display[..byte_end])
-    } else {
-        drive.display.clone()
-    };
-
-    let text_y = rect.min.y + 4.0 + icon_size.y / 2.0;
-    let text_pos = egui::pos2(rect.min.x + text_offset_x, text_y);
-    let font_id = FontId::new(palette.text_size, FontFamily::Proportional);
-
-    ui.painter().text(
-        text_pos,
-        egui::Align2::LEFT_CENTER,
-        display_name,
-        font_id,
-        ui.visuals().text_color(),
-    );
-
-    // --- Bottom row: progress bar ---
-    if let (Some(total), Some(free)) = (drive.total_space, drive.free_space) {
-        let bar_height = 6.0;
-        let max_bar_width = 180.0;
-        let bar_width = (available_width - 8.0).min(max_bar_width);
-
-        let bar_rect = egui::Rect::from_min_size(
-            egui::pos2(rect.min.x + 4.0, rect.bottom() - bar_height),
-            egui::vec2(bar_width, bar_height),
-        );
-
-        let bar_bg = palette.drive_usage_background;
-        let bar_fill = drive_usage_color((total - free) as f32 / total as f32, palette);
-
-        ui.painter().rect_filled(
-            bar_rect,
-            egui::CornerRadius::same(palette.small_radius),
-            bar_bg,
-        );
-
-        let used_ratio = (total - free) as f32 / total as f32;
-        let fill_width = bar_rect.width() * used_ratio;
-
-        let fill_rect = egui::Rect::from_min_size(bar_rect.min, egui::vec2(fill_width, bar_height));
-
-        ui.painter().rect_filled(
-            fill_rect,
-            egui::CornerRadius::same(palette.small_radius),
-            bar_fill,
-        );
-
-        let gb = 1024.0 * 1024.0 * 1024.0;
-        let used_gb = (total - free) as f64 / gb;
-        let total_gb = total as f64 / gb;
-
-        resp = resp.on_hover_text(
-            egui::RichText::new(format!("{:.1}/{:.1}GB", used_gb, total_gb))
-                .size(palette.tooltip_text_size)
-                .color(palette.tooltip_text_color),
-        );
-    }
-
-    resp
-}
-
 /// Draw the sidebar, supporting favorites reordering
 pub fn draw_sidebar(
     ui: &mut egui::Ui,
@@ -306,7 +42,7 @@ pub fn draw_sidebar(
                 ui.add_space(12.0);
                 ui.vertical(|ui| {
                     ui.add_space(8.0);
-                    ui.spacing_mut().item_spacing.y *= 0.5;
+                    ui.spacing_mut().item_spacing.y *= palette.sidebar_item_spacing_y;
 
                     ui.add(egui::Label::new(
                         egui::RichText::new(&i18n.tr("places"))
@@ -417,7 +153,7 @@ pub fn draw_sidebar(
                     let mut item_layouts = Vec::with_capacity(sidebar_state.favorites.len());
 
                     for (i, _favorite) in sidebar_state.favorites.iter().enumerate() {
-                        let (rect, resp) = favorites_item_layout(ui);
+                        let (rect, resp) = favorites_item_layout(ui, palette);
 
                         if !is_dragging && resp.drag_started() {
                             sidebar_state.dragging_favorite = Some(i);
@@ -656,4 +392,316 @@ pub fn draw_sidebar(
 
     action.move_files_to_sidebar_dir = tab_drop_target;
     action
+}
+
+pub fn draw_sidebar_item(
+    ui: &mut egui::Ui,
+    icon_cache: &IconCache,
+    path: &PathBuf,
+    label: &str,
+    is_dir: bool,
+    is_recycle_bin: bool,
+    palette: &ThemePalette,
+    draggable: bool,
+    rect_and_resp: Option<(egui::Rect, egui::Response)>,
+) -> egui::Response {
+    let height = if palette.sidebar_item_spacing_y > 1.0 {
+        18.0 * palette.sidebar_item_spacing_y
+    } else {
+        18.0
+    };
+
+    // --- Get rect + response ---
+    let (rect, resp) = if let Some((rect, resp)) = rect_and_resp {
+        (rect, resp)
+    } else {
+        let available_width = ui.available_width();
+        ui.allocate_exact_size(
+            egui::vec2(available_width, height),
+            if draggable {
+                egui::Sense::click_and_drag()
+            } else {
+                egui::Sense::click()
+            },
+        )
+    };
+
+    // --- Hover background + cursor ---
+    if resp.hovered() {
+        ui.ctx().set_cursor_icon(if draggable {
+            egui::CursorIcon::Grab
+        } else {
+            egui::CursorIcon::Default
+        });
+
+        ui.painter().rect_filled(
+            rect,
+            egui::CornerRadius::same(palette.medium_radius),
+            palette.primary_hover,
+        );
+
+        if draggable {
+            let handle_width = 12.0;
+            let handle_rect = egui::Rect::from_min_size(
+                egui::pos2(rect.right() - handle_width - 4.0, rect.top()),
+                egui::vec2(handle_width, rect.height()),
+            );
+
+            ui.painter().text(
+                handle_rect.center(),
+                egui::Align2::CENTER_CENTER,
+                regular::DOTS_SIX_VERTICAL,
+                egui::FontId::new(14.0, egui::FontFamily::Proportional),
+                palette.icon_color,
+            );
+        }
+    }
+
+    // --- Icon ---
+let icon_size = egui::vec2(palette.sidebar_icon_size, palette.sidebar_icon_size);
+let icon_padding = 4.0;
+
+let icon_pos = egui::pos2(
+    rect.min.x + 4.0,
+    rect.center().y - icon_size.y / 2.0,
+);
+
+let text_offset_x = if is_recycle_bin {
+    ui.painter().text(
+        egui::pos2(
+            icon_pos.x + icon_size.x * 0.5,
+            rect.center().y,
+        ),
+        egui::Align2::CENTER_CENTER,
+        regular::TRASH,
+        egui::FontId::new(
+            icon_size.y * 0.85,
+            egui::FontFamily::Proportional,
+        ),
+        palette.icon_color,
+    );
+
+    palette.text_size + icon_size.x + icon_padding
+} else if let Some(glyph) = icon_cache.get_custom_folder_icon(path, is_dir) {
+    // Custom Phosphor icon for recognized folders.
+    ui.painter().text(
+        egui::pos2(
+            icon_pos.x + icon_size.x * 0.5,
+            rect.center().y,
+        ),
+        egui::Align2::CENTER_CENTER,
+        glyph,
+        egui::FontId::new(
+            icon_size.y,
+            egui::FontFamily::Proportional,
+        ),
+        palette.icon_color,
+    );
+
+    palette.text_size + icon_size.x + icon_padding
+} else if let Some(icon) = icon_cache.get(path, is_dir) {
+    // Windows shell icon fallback.
+    ui.painter().image(
+        (&icon).into(),
+        egui::Rect::from_min_size(icon_pos, icon_size),
+        egui::Rect::from_min_size(
+            egui::pos2(0.0, 0.0),
+            egui::vec2(1.0, 1.0),
+        ),
+        egui::Color32::WHITE,
+    );
+
+    palette.text_size + icon_size.x + icon_padding
+} else {
+    palette.text_size + 20.0 + icon_padding
+};
+
+    // --- Text ---
+    let text_width = rect.width() - text_offset_x;
+    let font_id = egui::FontId::new(palette.text_size, egui::FontFamily::Proportional);
+    let color = ui.visuals().text_color();
+
+    let (display_name, truncated) = truncate_item_text(ui, label, text_width, &font_id, color);
+
+    let text_pos = egui::pos2(rect.min.x + text_offset_x, rect.center().y - 2.0);
+
+    ui.painter().text(
+        text_pos,
+        egui::Align2::LEFT_CENTER,
+        display_name,
+        font_id,
+        color,
+    );
+
+    // --- Tooltip + cursor ---
+    let resp = resp.on_hover_cursor(egui::CursorIcon::PointingHand);
+
+    if truncated {
+        resp.on_hover_text(
+            egui::RichText::new(label)
+                .size(palette.tooltip_text_size)
+                .color(palette.tooltip_text_color),
+        )
+    } else {
+        resp.on_hover_text(
+            egui::RichText::new(path.to_string_lossy())
+                .size(palette.tooltip_text_size)
+                .color(palette.tooltip_text_color),
+        )
+    }
+}
+
+fn favorites_item_layout(
+    ui: &mut egui::Ui,
+    palette: &ThemePalette,
+) -> (egui::Rect, egui::Response) {
+    let available_width = ui.available_width();
+
+    let height = if palette.sidebar_item_spacing_y > 1.0 {
+        18.0 * palette.sidebar_item_spacing_y
+    } else {
+        18.0
+    };
+
+    ui.allocate_exact_size(
+        egui::vec2(available_width, height),
+        egui::Sense::click_and_drag(),
+    )
+}
+
+/// Draw a drive item with usage bar and size on hover
+fn sidebar_drive_item(
+    ui: &mut egui::Ui,
+    icon_cache: &IconCache,
+    drive: &DriveInfo,
+    palette: &ThemePalette,
+    selected: bool,
+) -> egui::Response {
+    let available_width = ui.available_width();
+    let height = if palette.sidebar_item_spacing_y > 1.0 {
+        32.0 * palette.sidebar_item_spacing_y
+    } else {
+        32.0
+    };
+
+    let (rect, mut resp) =
+        ui.allocate_exact_size(egui::vec2(available_width, height), egui::Sense::click());
+
+    // Background (selected > active click > hover)
+    let fill_color = if selected {
+        palette.primary_active
+    } else if resp.is_pointer_button_down_on() {
+        palette.primary_active
+    } else if resp.hovered() {
+        palette.primary_hover
+    } else {
+        egui::Color32::TRANSPARENT
+    };
+
+    if fill_color != egui::Color32::TRANSPARENT {
+        ui.painter().rect_filled(
+            rect,
+            egui::CornerRadius::same(palette.medium_radius),
+            fill_color,
+        );
+    }
+
+    if resp.hovered() {
+        ui.ctx().set_cursor_icon(egui::CursorIcon::PointingHand);
+    }
+
+    // --- Top row: icon + label ---
+    let icon_size = egui::vec2(palette.sidebar_icon_size, palette.sidebar_icon_size);
+    let icon_padding = 4.0;
+
+    let text_offset_x = if let Some(icon) = icon_cache.get(&drive.path, true) {
+        let icon_pos = egui::pos2(rect.min.x + 4.0, rect.min.y + 4.0);
+
+        ui.painter().image(
+            (&icon).into(),
+            egui::Rect::from_min_size(icon_pos, icon_size),
+            egui::Rect::from_min_size(egui::pos2(0.0, 0.0), egui::vec2(1.0, 1.0)),
+            palette.icon_windows,
+        );
+
+        palette.text_size + icon_size.x + icon_padding
+    } else {
+        palette.text_size + 20.0 + icon_padding
+    };
+
+    // --- DISPLAY TEXT ---
+    let text_width = available_width - text_offset_x;
+    let max_chars = (text_width / 7.0) as usize;
+
+    let display_name = if drive.display.len() > max_chars && max_chars > 3 {
+        // Use character boundaries instead of byte indices
+        let mut char_count = 0;
+        let mut byte_end = 0;
+        for (i, _) in drive.display.char_indices() {
+            if char_count >= max_chars - 3 {
+                break;
+            }
+            char_count += 1;
+            byte_end = i;
+        }
+        format!("{}...", &drive.display[..byte_end])
+    } else {
+        drive.display.clone()
+    };
+
+    let text_y = rect.min.y + 4.0 + icon_size.y / 2.0;
+    let text_pos = egui::pos2(rect.min.x + text_offset_x, text_y);
+    let font_id = FontId::new(palette.text_size, FontFamily::Proportional);
+
+    ui.painter().text(
+        text_pos,
+        egui::Align2::LEFT_CENTER,
+        display_name,
+        font_id,
+        ui.visuals().text_color(),
+    );
+
+    // --- Bottom row: progress bar ---
+    if let (Some(total), Some(free)) = (drive.total_space, drive.free_space) {
+        let bar_height = 6.0;
+        let max_bar_width = 180.0;
+        let bar_width = (available_width - 8.0).min(max_bar_width);
+
+        let bar_rect = egui::Rect::from_min_size(
+            egui::pos2(rect.min.x + 4.0, rect.bottom() - bar_height),
+            egui::vec2(bar_width, bar_height),
+        );
+
+        let bar_bg = palette.drive_usage_background;
+        let bar_fill = drive_usage_color((total - free) as f32 / total as f32, palette);
+
+        ui.painter().rect_filled(
+            bar_rect,
+            egui::CornerRadius::same(palette.small_radius),
+            bar_bg,
+        );
+
+        let used_ratio = (total - free) as f32 / total as f32;
+        let fill_width = bar_rect.width() * used_ratio;
+
+        let fill_rect = egui::Rect::from_min_size(bar_rect.min, egui::vec2(fill_width, bar_height));
+
+        ui.painter().rect_filled(
+            fill_rect,
+            egui::CornerRadius::same(palette.small_radius),
+            bar_fill,
+        );
+
+        let gb = 1024.0 * 1024.0 * 1024.0;
+        let used_gb = (total - free) as f64 / gb;
+        let total_gb = total as f64 / gb;
+
+        resp = resp.on_hover_text(
+            egui::RichText::new(format!("{:.1}/{:.1}GB", used_gb, total_gb))
+                .size(palette.tooltip_text_size)
+                .color(palette.tooltip_text_color),
+        );
+    }
+
+    resp
 }

--- a/src/gui/windows/containers/structs.rs
+++ b/src/gui/windows/containers/structs.rs
@@ -1,5 +1,9 @@
 use crate::core::fs::FileItem;
 use crate::core::indexer::TagsSnapshot;
+use crate::core::indexer::{
+    default_item_viewer_drive_column_size, default_item_viewer_file_column_size,
+    default_recycle_bin_column_size,
+};
 use crate::core::utils::thumbnails::ThumbnailService;
 use crate::gui::utils::hsl_to_color32;
 use crate::gui::windows::containers::enums::{
@@ -45,12 +49,14 @@ pub struct TabsAction {
     pub activate: Option<u64>,
     pub close: Option<u64>,
     pub open_new: bool,
-    pub toggle_split: bool,
     pub toggle_pin: Option<PathBuf>,
     pub move_files_to_tab_dir: Option<PathBuf>,
+    pub scroll_left: bool,
+    pub scroll_right: bool,
+    pub max_scroll_offset: f32,
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum SplitSide {
     Primary,
     Secondary,
@@ -139,6 +145,7 @@ pub enum ItemViewerDisplayMode {
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum GalleryThumbnailSize {
+    ExtraSmall,
     Small,
     Medium,
     Large,
@@ -148,6 +155,7 @@ pub enum GalleryThumbnailSize {
 impl GalleryThumbnailSize {
     pub fn pixel_size(self) -> f32 {
         match self {
+            Self::ExtraSmall => 24.0,
             Self::Small => 48.0,
             Self::Medium => 96.0,
             Self::Large => 128.0,
@@ -157,6 +165,7 @@ impl GalleryThumbnailSize {
 
     pub fn label(self) -> &'static str {
         match self {
+            Self::ExtraSmall => "Extra Small",
             Self::Small => "Small",
             Self::Medium => "Medium",
             Self::Large => "Large",
@@ -168,12 +177,16 @@ impl GalleryThumbnailSize {
 #[derive(Clone, Copy, Debug)]
 pub struct GalleryState {
     pub thumbnail_size: GalleryThumbnailSize,
+    pub thumbnail_gap: f32,
+    pub thumbnail_padding: f32,
 }
 
 impl Default for GalleryState {
     fn default() -> Self {
         Self {
             thumbnail_size: GalleryThumbnailSize::Medium,
+            thumbnail_gap: 12.0,
+            thumbnail_padding: 6.0,
         }
     }
 }
@@ -186,13 +199,14 @@ pub enum ItemViewerColumnFitRequest {
 
 #[derive(Clone, Debug)]
 pub struct ItemViewerColumnState {
-    pub show_type: bool,
-    pub show_size: bool,
-    pub show_modified: bool,
-    pub show_created: bool,
     pub file_column_order: Vec<ItemViewerHeaderColumn>,
     pub drive_column_order: Vec<ItemViewerHeaderColumn>,
     pub recycle_bin_column_order: Vec<ItemViewerHeaderColumn>,
+
+    pub file_column_sizes: Vec<f32>,
+    pub drive_column_sizes: Vec<f32>,
+    pub recycle_bin_column_sizes: Vec<f32>,
+
     pub layout_generation: u64,
     pub pending_fit_request: Option<ItemViewerColumnFitRequest>,
 }
@@ -200,13 +214,12 @@ pub struct ItemViewerColumnState {
 impl Default for ItemViewerColumnState {
     fn default() -> Self {
         Self {
-            show_type: true,
-            show_size: true,
-            show_modified: true,
-            show_created: true,
             file_column_order: default_file_column_order(),
             drive_column_order: default_drive_column_order(),
             recycle_bin_column_order: default_recycle_bin_column_order(),
+            file_column_sizes: default_item_viewer_file_column_size(),
+            drive_column_sizes: default_item_viewer_drive_column_size(),
+            recycle_bin_column_sizes: default_recycle_bin_column_size(),
             layout_generation: 0,
             pending_fit_request: None,
         }
@@ -214,10 +227,223 @@ impl Default for ItemViewerColumnState {
 }
 
 impl ItemViewerColumnState {
+    pub fn toggle_column_visibility(
+        &mut self,
+        is_drive_view: bool,
+        is_recycle_bin_view: bool,
+        column: ItemViewerHeaderColumn,
+    ) -> bool {
+        if column == ItemViewerHeaderColumn::Name {
+            return false;
+        }
+
+        let order = self.order_mut(is_drive_view, is_recycle_bin_view);
+
+        if let Some(index) = order.iter().position(|c| *c == column) {
+            order.remove(index);
+            return true;
+        }
+
+        let default_order = if is_drive_view {
+            default_drive_column_order()
+        } else if is_recycle_bin_view {
+            default_recycle_bin_column_order()
+        } else {
+            default_file_column_order()
+        };
+
+        let default_index = default_order
+            .iter()
+            .position(|c| *c == column)
+            .unwrap_or(order.len());
+
+        let insert_index = order
+            .iter()
+            .filter_map(|existing| default_order.iter().position(|c| c == existing))
+            .filter(|&index| index < default_index)
+            .count();
+
+        order.insert(insert_index, column);
+
+        true
+    }
+    pub fn is_column_visible(
+        &self,
+        is_drive_view: bool,
+        is_recycle_bin_view: bool,
+        column: ItemViewerHeaderColumn,
+    ) -> bool {
+        if column == ItemViewerHeaderColumn::Name {
+            return true;
+        }
+
+        self.order(is_drive_view, is_recycle_bin_view)
+            .contains(&column)
+    }
+
+    pub fn column_width(
+        &self,
+        is_drive_view: bool,
+        is_recycle_bin_view: bool,
+        column: ItemViewerHeaderColumn,
+    ) -> Option<f32> {
+        let sizes = if is_drive_view {
+            &self.drive_column_sizes
+        } else if is_recycle_bin_view {
+            &self.recycle_bin_column_sizes
+        } else {
+            &self.file_column_sizes
+        };
+
+        let index = if is_drive_view {
+            match column {
+                ItemViewerHeaderColumn::Name => 0,
+                ItemViewerHeaderColumn::Size => 1,
+                ItemViewerHeaderColumn::Usage => 2,
+                _ => return None,
+            }
+        } else if is_recycle_bin_view {
+            match column {
+                ItemViewerHeaderColumn::Name => 0,
+                ItemViewerHeaderColumn::Type => 1,
+                ItemViewerHeaderColumn::Size => 2,
+                ItemViewerHeaderColumn::Deleted => 3,
+                ItemViewerHeaderColumn::Created => 4,
+                _ => return None,
+            }
+        } else {
+            match column {
+                ItemViewerHeaderColumn::Name => 0,
+                ItemViewerHeaderColumn::Type => 1,
+                ItemViewerHeaderColumn::Size => 2,
+                ItemViewerHeaderColumn::Modified => 3,
+                ItemViewerHeaderColumn::Created => 4,
+                _ => return None,
+            }
+        };
+
+        sizes.get(index).copied()
+    }
+
+    pub fn set_column_width(
+        &mut self,
+        is_drive_view: bool,
+        is_recycle_bin_view: bool,
+        column: ItemViewerHeaderColumn,
+        width: f32,
+    ) {
+        let sizes = if is_drive_view {
+            &mut self.drive_column_sizes
+        } else if is_recycle_bin_view {
+            &mut self.recycle_bin_column_sizes
+        } else {
+            &mut self.file_column_sizes
+        };
+
+        let index = if is_drive_view {
+            match column {
+                ItemViewerHeaderColumn::Name => 0,
+                ItemViewerHeaderColumn::Size => 1,
+                ItemViewerHeaderColumn::Usage => 2,
+                _ => return,
+            }
+        } else if is_recycle_bin_view {
+            match column {
+                ItemViewerHeaderColumn::Name => 0,
+                ItemViewerHeaderColumn::Type => 1,
+                ItemViewerHeaderColumn::Size => 2,
+                ItemViewerHeaderColumn::Deleted => 3,
+                ItemViewerHeaderColumn::Created => 4,
+                _ => return,
+            }
+        } else {
+            match column {
+                ItemViewerHeaderColumn::Name => 0,
+                ItemViewerHeaderColumn::Type => 1,
+                ItemViewerHeaderColumn::Size => 2,
+                ItemViewerHeaderColumn::Modified => 3,
+                ItemViewerHeaderColumn::Created => 4,
+                _ => return,
+            }
+        };
+
+        if let Some(slot) = sizes.get_mut(index) {
+            *slot = width;
+        }
+    }
+
+    pub fn set_all_column_widths(
+        &mut self,
+        is_drive_view: bool,
+        is_recycle_bin_view: bool,
+        widths: &ItemViewerColumnWidths,
+    ) {
+        self.set_column_width(
+            is_drive_view,
+            is_recycle_bin_view,
+            ItemViewerHeaderColumn::Name,
+            widths.name,
+        );
+
+        self.set_column_width(
+            is_drive_view,
+            is_recycle_bin_view,
+            ItemViewerHeaderColumn::Type,
+            widths.type_width,
+        );
+
+        self.set_column_width(
+            is_drive_view,
+            is_recycle_bin_view,
+            ItemViewerHeaderColumn::Size,
+            widths.size_width,
+        );
+
+        self.set_column_width(
+            is_drive_view,
+            is_recycle_bin_view,
+            ItemViewerHeaderColumn::Modified,
+            widths.modified_width,
+        );
+
+        self.set_column_width(
+            is_drive_view,
+            is_recycle_bin_view,
+            ItemViewerHeaderColumn::Created,
+            widths.created_width,
+        );
+
+        self.set_column_width(
+            is_drive_view,
+            is_recycle_bin_view,
+            ItemViewerHeaderColumn::Deleted,
+            widths.deleted_width,
+        );
+
+        self.set_column_width(
+            is_drive_view,
+            is_recycle_bin_view,
+            ItemViewerHeaderColumn::Usage,
+            widths.usage_width,
+        );
+    }
+    pub fn column_sizes(&self, is_drive_view: bool, is_recycle_bin_view: bool) -> &[f32] {
+        if is_drive_view {
+            &self.drive_column_sizes
+        } else if is_recycle_bin_view {
+            &self.recycle_bin_column_sizes
+        } else {
+            &self.file_column_sizes
+        }
+    }
+
     pub fn from_orders(
         file_column_order: Vec<ItemViewerHeaderColumn>,
         drive_column_order: Vec<ItemViewerHeaderColumn>,
         recycle_bin_column_order: Vec<ItemViewerHeaderColumn>,
+        file_column_sizes: Vec<f32>,
+        drive_column_sizes: Vec<f32>,
+        recycle_bin_column_sizes: Vec<f32>,
     ) -> Self {
         let mut state = Self::default();
         state.file_column_order =
@@ -228,6 +454,12 @@ impl ItemViewerColumnState {
             recycle_bin_column_order,
             &default_recycle_bin_column_order(),
         );
+        state.file_column_sizes =
+            sanitize_column_sizes(file_column_sizes, &default_item_viewer_file_column_size());
+        state.drive_column_sizes =
+            sanitize_column_sizes(drive_column_sizes, &default_item_viewer_drive_column_size());
+        state.recycle_bin_column_sizes =
+            sanitize_column_sizes(recycle_bin_column_sizes, &default_recycle_bin_column_size());
         state
     }
 
@@ -326,42 +558,38 @@ impl ItemViewerColumnState {
         &self,
         is_drive_view: bool,
         is_recycle_bin_view: bool,
-        show_type: bool,
-        show_size: bool,
-        show_modified: bool,
-        show_created: bool,
     ) -> Vec<ItemViewerHeaderColumn> {
-        let allowed = if is_drive_view {
-            vec![
-                ItemViewerHeaderColumn::Type,
+        let allowed: &[ItemViewerHeaderColumn] = if is_drive_view {
+            &[
+                ItemViewerHeaderColumn::Name,
                 ItemViewerHeaderColumn::Size,
                 ItemViewerHeaderColumn::Usage,
             ]
+        } else if is_recycle_bin_view {
+            &[
+                ItemViewerHeaderColumn::Name,
+                ItemViewerHeaderColumn::Type,
+                ItemViewerHeaderColumn::Size,
+                ItemViewerHeaderColumn::Deleted,
+                ItemViewerHeaderColumn::Created,
+            ]
         } else {
-            vec![
+            &[
+                ItemViewerHeaderColumn::Name,
                 ItemViewerHeaderColumn::Type,
                 ItemViewerHeaderColumn::Size,
                 ItemViewerHeaderColumn::Modified,
                 ItemViewerHeaderColumn::Created,
-                ItemViewerHeaderColumn::Deleted,
             ]
         };
 
-        let mut visible = Vec::new();
+        let mut visible = Vec::with_capacity(allowed.len());
+
+        // Name is always visible and always first.
+        visible.push(ItemViewerHeaderColumn::Name);
+
         for column in self.order(is_drive_view, is_recycle_bin_view) {
-            if !allowed.contains(column) {
-                continue;
-            }
-            let shown = match column {
-                ItemViewerHeaderColumn::Type => show_type,
-                ItemViewerHeaderColumn::Size => show_size,
-                ItemViewerHeaderColumn::Modified => show_modified,
-                ItemViewerHeaderColumn::Created => show_created,
-                ItemViewerHeaderColumn::Usage => true,
-                ItemViewerHeaderColumn::Name => true,
-                ItemViewerHeaderColumn::Deleted => true,
-            };
-            if shown {
+            if allowed.contains(column) && *column != ItemViewerHeaderColumn::Name {
                 visible.push(*column);
             }
         }
@@ -370,8 +598,27 @@ impl ItemViewerColumnState {
     }
 }
 
+fn sanitize_column_sizes(sizes: Vec<f32>, defaults: &[f32]) -> Vec<f32> {
+    if sizes.len() != defaults.len() {
+        return defaults.to_vec();
+    }
+
+    sizes
+        .into_iter()
+        .zip(defaults.iter().copied())
+        .map(|(size, default)| {
+            if size.is_finite() && size > 0.0 {
+                size
+            } else {
+                default
+            }
+        })
+        .collect()
+}
+
 fn default_file_column_order() -> Vec<ItemViewerHeaderColumn> {
     vec![
+        ItemViewerHeaderColumn::Name,
         ItemViewerHeaderColumn::Type,
         ItemViewerHeaderColumn::Size,
         ItemViewerHeaderColumn::Modified,
@@ -381,6 +628,7 @@ fn default_file_column_order() -> Vec<ItemViewerHeaderColumn> {
 
 fn default_drive_column_order() -> Vec<ItemViewerHeaderColumn> {
     vec![
+        ItemViewerHeaderColumn::Name,
         ItemViewerHeaderColumn::Type,
         ItemViewerHeaderColumn::Size,
         ItemViewerHeaderColumn::Usage,
@@ -389,6 +637,7 @@ fn default_drive_column_order() -> Vec<ItemViewerHeaderColumn> {
 
 fn default_recycle_bin_column_order() -> Vec<ItemViewerHeaderColumn> {
     vec![
+        ItemViewerHeaderColumn::Name,
         ItemViewerHeaderColumn::Type,
         ItemViewerHeaderColumn::Size,
         ItemViewerHeaderColumn::Deleted,
@@ -400,15 +649,14 @@ fn sanitize_column_order(
     order: Vec<ItemViewerHeaderColumn>,
     default_order: &[ItemViewerHeaderColumn],
 ) -> Vec<ItemViewerHeaderColumn> {
-    let mut sanitized = Vec::with_capacity(default_order.len());
+    let mut sanitized = Vec::with_capacity(order.len());
+
     for column in order {
         if default_order.contains(&column) && !sanitized.contains(&column) {
             sanitized.push(column);
         }
     }
-    if sanitized.len() != default_order.len() {
-        return default_order.to_vec();
-    }
+
     sanitized
 }
 
@@ -516,6 +764,7 @@ pub struct TopbarAction {
     pub exit: bool,
     pub toggle_file_explorer: bool,
     pub toggle_sidebar: bool,
+    pub toggle_active_tab_split: bool,
 }
 
 #[derive(Default)]
@@ -823,4 +1072,28 @@ impl TagsState {
 pub fn default_tag_color() -> Color32 {
     let hue = rand::rng().random_range(0.0..360.0);
     hsl_to_color32(hue, 0.55, 0.88)
+}
+
+pub struct ItemViewerColumnLayout {
+    pub layout_generation: u64,
+    pub ordered_columns: Vec<ItemViewerHeaderColumn>,
+    pub name_width: f32,
+    pub type_width: f32,
+    pub size_width: f32,
+    pub usage_width: f32,
+    pub modified_width: f32,
+    pub created_width: f32,
+    pub deleted_width: f32,
+    pub column_sizes_changed: bool,
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+pub struct ItemViewerColumnWidths {
+    pub name: f32,
+    pub type_width: f32,
+    pub size_width: f32,
+    pub modified_width: f32,
+    pub created_width: f32,
+    pub usage_width: f32,
+    pub deleted_width: f32,
 }

--- a/src/gui/windows/containers/tabs.rs
+++ b/src/gui/windows/containers/tabs.rs
@@ -1,28 +1,32 @@
 use crate::core::fs::{MY_PC_PATH, MY_RECYCLE_BIN_PATH};
 use crate::gui::i18n::I18n;
 use crate::gui::theme::ThemePalette;
-use crate::gui::utils::{clickable_icon, truncate_item_text};
+use crate::gui::utils::truncate_item_text;
 use crate::gui::windows::containers::structs::{TabInfo, TabsAction};
-use crate::gui::windows::windowsoverrides::{
-    handle_draw_windows_buttons, toggle_window_fullscreen,
-};
+use crate::gui::windows::windowsoverrides::toggle_window_fullscreen;
 use eframe::egui;
 use egui::{FontFamily, FontId};
 use egui_phosphor::{fill, regular};
 use std::path::PathBuf;
 use windows::Win32::Foundation::HWND;
 
+const PREFERRED_TAB_WIDTH: f32 = 180.0;
+const MIN_TAB_WIDTH: f32 = 80.0;
+const ADD_TAB_WIDTH: f32 = 28.0;
+const TAB_HEIGHT: f32 = 32.0;
+const TAB_NAV_BUTTON_WIDTH: f32 = 28.0;
+
 pub fn draw_tabs(
     ui: &mut egui::Ui,
     i18n: &I18n,
     tabs: &[TabInfo],
+    tab_scroll_offset: f32,
     active_id: u64,
     palette: &ThemePalette,
     hwnd: Option<HWND>,
     scroll_to_id: Option<u64>,
     drag_active: bool,
     drag_hover_target: Option<PathBuf>,
-    has_split: bool,
 ) -> TabsAction {
     let mut action: TabsAction = TabsAction::default();
     let pointer_pos = ui.input(|i| i.pointer.interact_pos().or_else(|| i.pointer.hover_pos()));
@@ -30,32 +34,93 @@ pub fn draw_tabs(
         ui.input(|i| i.pointer.any_released() && i.pointer.interact_pos().is_some());
     let hovered_target_ref = drag_hover_target.as_ref();
     let mut tab_drop_target: Option<PathBuf> = None;
-    let controls_width = 90.0;
+    let windows_buttons_width = 45.0 * 3.0;
+    let split_button_width = 32.0;
+    let controls_width = windows_buttons_width + split_button_width;
     let full_width = ui.available_width();
-    let tabs_width = (full_width - controls_width).max(0.0);
+    let spacing = ui.spacing().item_spacing.x;
+    // Reserve the + button outside the tab viewport.
+    let tab_count = tabs.len() as f32;
+    let gaps = (tab_count - 1.0).max(0.0);
+    // Space reserved for the entire tab region.
+    // This includes the tabs and, when needed, the left/right navigation buttons.
+    // The + button and window controls remain outside this region.
+    let tab_region_width = (full_width - controls_width - ADD_TAB_WIDTH - spacing).max(0.0);
+
+    // Determine how wide the tabs can be when there are no navigation buttons.
+    let natural_tab_width = if tab_count > 0.0 {
+        ((tab_region_width - gaps * spacing) / tab_count).max(0.0)
+    } else {
+        PREFERRED_TAB_WIDTH
+    };
+
+    let tabs_need_scroll = tab_count > 0.0 && natural_tab_width < MIN_TAB_WIDTH;
+
+    let tab_width = if tabs_need_scroll {
+        MIN_TAB_WIDTH
+    } else {
+        natural_tab_width.min(PREFERRED_TAB_WIDTH)
+    };
+
+    let tabs_content_width = tab_count * tab_width + gaps * spacing;
+
+    // The navigation buttons live INSIDE the fixed tab region.
+    let tab_view_width = if tabs_need_scroll {
+        (tab_region_width - TAB_NAV_BUTTON_WIDTH * 2.0).max(0.0)
+    } else {
+        tabs_content_width
+    };
+
+    let max_scroll_offset = (tabs_content_width - tab_view_width).max(0.0);
+
+    let effective_scroll_offset = if tabs_need_scroll {
+        tab_scroll_offset.min(max_scroll_offset)
+    } else {
+        0.0
+    };
 
     ui.allocate_ui_with_layout(
         egui::vec2(ui.available_width(), 32.0),
         egui::Layout::left_to_right(egui::Align::Center),
         |ui| {
+            ui.add_space(-2.0);
+            // ---------- LEFT NAVIGATION ----------
+            if tabs_need_scroll && handle_draw_nav_button(ui, palette, "left") {
+                action.scroll_left = true;
+            }
+            // ---------- TABS ----------
             ui.allocate_ui_with_layout(
-                egui::vec2(tabs_width, 32.0),
+                egui::vec2(tab_view_width, 32.0),
                 egui::Layout::left_to_right(egui::Align::Min),
                 |ui| {
                     let tabs_rect = ui.available_rect_before_wrap();
+
+                    let pointer_over_tabs = ui
+                        .input(|i| i.pointer.hover_pos())
+                        .is_some_and(|pos| tabs_rect.contains(pos));
+
+                    if pointer_over_tabs && tabs_need_scroll {
+                        let scroll_delta = ui.input(|i| i.smooth_scroll_delta.y);
+
+                        if scroll_delta > 0.0 {
+                            action.scroll_left = true;
+                        } else if scroll_delta < 0.0 {
+                            action.scroll_right = true;
+                        }
+                    }
                     egui::ScrollArea::horizontal()
                         .id_salt("tabs_scroll")
                         .auto_shrink([false, true])
                         .scroll_bar_visibility(egui::scroll_area::ScrollBarVisibility::AlwaysHidden)
+                        .scroll_offset(egui::vec2(effective_scroll_offset, 0.0))
                         .show(ui, |ui| {
-                            ui.add_space(-2.0);
                             ui.horizontal(|ui| {
                                 for tab in tabs {
-                                    let tab_width = 140.0;
                                     let (rect, resp) = ui.allocate_exact_size(
-                                        egui::vec2(tab_width, 28.0),
+                                        egui::vec2(tab_width, TAB_HEIGHT),
                                         egui::Sense::click(),
                                     );
+
                                     if Some(tab.id) == scroll_to_id {
                                         resp.scroll_to_me(Some(egui::Align::Center));
                                     }
@@ -68,6 +133,7 @@ pub fn draw_tabs(
                                                     .map(|pointer| rect.contains(pointer))
                                                     .unwrap_or(false)
                                             });
+
                                         if hovered {
                                             let painter = ui
                                                 .ctx()
@@ -76,6 +142,7 @@ pub fn draw_tabs(
                                                     ui.id().with("tab_drop_bg").with(tab.id),
                                                 ))
                                                 .with_clip_rect(ui.clip_rect());
+
                                             painter.rect_filled(
                                                 rect,
                                                 egui::CornerRadius::same(palette.medium_radius),
@@ -100,73 +167,48 @@ pub fn draw_tabs(
                                     );
                                 }
                             });
-                            handle_draw_add_new_tab_button(ui, palette, &mut action);
                         });
-
-                    // Drag region: empty space to the right of the last tab
-                    let tab_width = 140.0;
-                    let add_tab_width = 28.0;
-                    let spacing = ui.spacing().item_spacing.x;
-                    let tab_count = tabs.len() as f32;
-                    let gaps = if tab_count > 0.0 {
-                        tab_count - 1.0
-                    } else {
-                        0.0
-                    };
-                    let content_width =
-                        tab_count * tab_width + gaps * spacing + spacing + add_tab_width;
-
-                    if content_width < tabs_rect.width() {
-                        let empty_left = tabs_rect.min.x + content_width;
-                        let drag_rect = egui::Rect::from_min_max(
-                            egui::pos2(empty_left, tabs_rect.min.y),
-                            tabs_rect.max,
-                        );
-                        if drag_rect.width() > 4.0 {
-                            let resp = ui.allocate_rect(drag_rect, egui::Sense::click_and_drag());
-                            if resp.double_clicked() {
-                                if let Some(hwnd) = hwnd {
-                                    toggle_window_fullscreen(hwnd);
-                                }
-                            }
-                            if resp.drag_started() || resp.dragged() {
-                                ui.ctx().send_viewport_cmd(egui::ViewportCommand::StartDrag);
-                            }
-                            if resp.hovered() {
-                                ui.ctx().set_cursor_icon(egui::CursorIcon::Grab);
-                            }
-                        }
-                    }
                 },
             );
 
-            // --- RIGHT SIDE ---
-            ui.allocate_ui_with_layout(
-                egui::vec2(controls_width, 32.0),
-                egui::Layout::right_to_left(egui::Align::Center),
-                |ui| {
-                    handle_draw_windows_buttons(ui, hwnd, palette);
-                    let (icon, tooltip_key) = if has_split {
-                        (regular::ARROWS_MERGE, "tooltip_close_split")
-                    } else {
-                        (regular::COLUMNS_PLUS_RIGHT, "tooltip_open_split")
-                    };
-                    if clickable_icon(ui, icon, palette.primary)
-                        .on_hover_text(
-                            egui::RichText::new(i18n.tr(tooltip_key))
-                                .size(palette.tooltip_text_size)
-                                .color(palette.tooltip_text_color),
-                        )
-                        .on_hover_cursor(egui::CursorIcon::PointingHand)
-                        .clicked()
-                    {
-                        action.toggle_split = true;
+            // ---------- RIGHT NAVIGATION ----------
+            if tabs_need_scroll && handle_draw_nav_button(ui, palette, "right") {
+                action.scroll_right = true;
+            }
+
+            // ---------- ADD NEW TAB BUTTON ----------
+            handle_draw_add_new_tab_button(ui, palette, &mut action);
+
+            // ---------- WINDOWS DRAG AREA ----------
+            let drag_width = ui.available_width();
+
+            if drag_width > 4.0 {
+                let drag_rect = ui.allocate_space(egui::vec2(drag_width, 32.0)).1;
+
+                let resp = ui.interact(
+                    drag_rect,
+                    ui.id().with("tabs_window_drag_area"),
+                    egui::Sense::click_and_drag(),
+                );
+
+                if resp.double_clicked() {
+                    if let Some(hwnd) = hwnd {
+                        toggle_window_fullscreen(hwnd);
                     }
-                },
-            );
+                }
+
+                if resp.drag_started() || resp.dragged() {
+                    ui.ctx().send_viewport_cmd(egui::ViewportCommand::StartDrag);
+                }
+
+                if resp.hovered() {
+                    ui.ctx().set_cursor_icon(egui::CursorIcon::Grab);
+                }
+            }
         },
     );
     action.move_files_to_tab_dir = tab_drop_target;
+    action.max_scroll_offset = max_scroll_offset;
     action
 }
 
@@ -343,7 +385,7 @@ fn handle_draw_add_new_tab_button(
     palette: &ThemePalette,
     action: &mut TabsAction,
 ) {
-    let size = egui::vec2(28.0, 28.0);
+    let size = egui::vec2(32.0, 32.0);
 
     let (rect, resp) = ui.allocate_exact_size(size, egui::Sense::click());
 
@@ -384,6 +426,48 @@ fn handle_draw_add_new_tab_button(
     if resp.clicked() {
         action.open_new = true;
     }
+}
+
+fn handle_draw_nav_button(ui: &mut egui::Ui, palette: &ThemePalette, direction: &str) -> bool {
+    let size = egui::vec2(32.0, 32.0);
+
+    let (rect, resp) = ui.allocate_exact_size(size, egui::Sense::click());
+
+    let rect = egui::Rect::from_min_max(rect.min.round(), rect.max.round());
+
+    let hovered = resp.hovered();
+
+    let fill = if hovered {
+        ui.visuals().widgets.hovered.bg_fill
+    } else {
+        egui::Color32::TRANSPARENT
+    };
+
+    let stroke = if hovered {
+        egui::Stroke::new(1.0, palette.borders_active)
+    } else {
+        egui::Stroke::new(1.0, palette.borders_default)
+    };
+
+    let rounding = egui::CornerRadius {
+        nw: palette.tab_inactive_radius.nw,
+        ne: palette.tab_inactive_radius.ne,
+        sw: 0,
+        se: 0,
+    };
+
+    let painter = ui.painter();
+
+    painter.rect_filled(rect, rounding, fill);
+    painter.rect_stroke(rect, rounding, stroke, egui::StrokeKind::Inside);
+
+    let _ = tab_nav_button(ui, rect.shrink(3.0), resp.clone(), palette, direction);
+
+    if resp.hovered() {
+        ui.ctx().set_cursor_icon(egui::CursorIcon::PointingHand);
+    }
+
+    resp.clicked()
 }
 
 fn tab_close_button(
@@ -471,6 +555,53 @@ fn tab_add_button(
         rect.center(),
         egui::Align2::CENTER_CENTER,
         regular::PLUS,
+        font_id,
+        color,
+    );
+
+    if hovered {
+        ui.ctx().set_cursor_icon(egui::CursorIcon::PointingHand);
+    }
+
+    resp
+}
+
+fn tab_nav_button(
+    ui: &mut egui::Ui,
+    rect: egui::Rect,
+    resp: egui::Response,
+    palette: &ThemePalette,
+    direction: &str,
+) -> egui::Response {
+    let hovered = resp.hovered();
+
+    let bg = if hovered {
+        palette.tab_add_hover
+    } else {
+        egui::Color32::TRANSPARENT
+    };
+
+    let visual_rect = rect.shrink(4.0);
+
+    ui.painter()
+        .rect_filled(visual_rect, palette.tab_button_radius, bg);
+
+    let color = if hovered {
+        palette.icon_colored_hover
+    } else {
+        palette.icon_color
+    };
+
+    let font_id = FontId::new(palette.tab_icon_size, FontFamily::Proportional);
+
+    ui.painter().text(
+        rect.center(),
+        egui::Align2::CENTER_CENTER,
+        if direction == "left" {
+            regular::CARET_LEFT
+        } else {
+            regular::CARET_RIGHT
+        },
         font_id,
         color,
     );

--- a/src/gui/windows/containers/tags.rs
+++ b/src/gui/windows/containers/tags.rs
@@ -720,7 +720,12 @@ fn draw_insert_line(ui: &mut egui::Ui, palette: &ThemePalette, y: f32, left: f32
     );
 }
 
-pub fn draw_container_header(i18n: &I18n, ui: &mut egui::Ui, palette: &ThemePalette, hwnd: Option<HWND>) {
+pub fn draw_container_header(
+    i18n: &I18n,
+    ui: &mut egui::Ui,
+    palette: &ThemePalette,
+    hwnd: Option<HWND>,
+) {
     let controls_width = 64.0;
     let full_width = ui.available_width();
     let tabs_width = (full_width - controls_width).max(0.0);

--- a/src/gui/windows/containers/tags.rs
+++ b/src/gui/windows/containers/tags.rs
@@ -41,6 +41,7 @@ pub fn draw_tags(
             egui::Frame::NONE.show(ui, |ui| {
                 ui.add_space(8.0);
                 draw_container_header(
+                    i18n,
                     ui,
                     palette,
                     hwnd
@@ -160,14 +161,14 @@ pub fn draw_tags(
                                                 .size(palette.text_size)
                                                 .color(palette.tooltip_text_color),
                                         );
-                                        if clickable_icon(ui, regular::TRASH, palette.primary)
+                                        if clickable_icon(ui, regular::TRASH, palette)
                                             .on_hover_text(i18n.tr("tag_delete_group"))
                                             .on_hover_cursor(egui::CursorIcon::PointingHand)
                                             .clicked()
                                         {
                                             delete_confirmation = Some(group_id);
                                         }
-                                            if clickable_icon(ui, regular::PENCIL_SIMPLE, palette.primary)
+                                        if clickable_icon(ui, regular::PENCIL_SIMPLE, palette)
                                             .on_hover_text(i18n.tr("inputs_rename"))
                                             .on_hover_cursor(egui::CursorIcon::PointingHand)
                                             .clicked()
@@ -440,9 +441,12 @@ pub fn draw_delete_confirmation_popup(
         .resizable(false)
         .default_width(360.0)
         .anchor(egui::Align2::CENTER_CENTER, [0.0, 0.0])
-        .frame(egui::Frame::popup(&ctx.style()).corner_radius(egui::CornerRadius::same(8)))
+        .frame(
+            egui::Frame::popup(&ctx.style_of(ctx.theme()))
+                .corner_radius(egui::CornerRadius::same(8)),
+        )
         .show(ctx, |ui| {
-            let mut style = (*ui.ctx().style()).clone();
+            let mut style = (**ui.style()).clone();
             style.text_styles = [
                 (egui::TextStyle::Heading, egui::FontId::proportional(14.0)),
                 (
@@ -529,9 +533,12 @@ pub fn draw_tag_picker_popup(
         .resizable(false)
         .default_width(360.0)
         .anchor(egui::Align2::CENTER_CENTER, [0.0, 0.0])
-        .frame(egui::Frame::popup(&ctx.style()).corner_radius(egui::CornerRadius::same(8)))
+        .frame(
+            egui::Frame::popup(&ctx.style_of(ctx.theme()))
+                .corner_radius(egui::CornerRadius::same(8)),
+        )
         .show(ctx, |ui| {
-            let mut style = (*ui.ctx().style()).clone();
+            let mut style = (**ui.style()).clone();
             style.text_styles = [
                 (egui::TextStyle::Heading, egui::FontId::proportional(14.0)),
                 (
@@ -713,7 +720,7 @@ fn draw_insert_line(ui: &mut egui::Ui, palette: &ThemePalette, y: f32, left: f32
     );
 }
 
-pub fn draw_container_header(ui: &mut egui::Ui, palette: &ThemePalette, hwnd: Option<HWND>) {
+pub fn draw_container_header(i18n: &I18n, ui: &mut egui::Ui, palette: &ThemePalette, hwnd: Option<HWND>) {
     let controls_width = 64.0;
     let full_width = ui.available_width();
     let tabs_width = (full_width - controls_width).max(0.0);
@@ -749,7 +756,7 @@ pub fn draw_container_header(ui: &mut egui::Ui, palette: &ThemePalette, hwnd: Op
                 egui::vec2(controls_width, 32.0),
                 egui::Layout::right_to_left(egui::Align::Center),
                 |ui| {
-                    handle_draw_windows_buttons(ui, hwnd, palette);
+                    handle_draw_windows_buttons(i18n, ui, hwnd, palette);
                 },
             );
         },
@@ -765,7 +772,7 @@ fn handle_context_menu_actions_tags(
     is_tagged: bool,
 ) {
     // Apply context-menu-specific typography
-    let mut style = (*ui.ctx().style()).clone();
+    let mut style = (**ui.style()).clone();
     style.text_styles = [
         (
             egui::TextStyle::Body,

--- a/src/gui/windows/containers/topbar.rs
+++ b/src/gui/windows/containers/topbar.rs
@@ -15,6 +15,7 @@ pub fn draw_topbar(
     sidebar_collapsed: bool,
     hwnd: Option<HWND>,
     palette: &crate::gui::theme::ThemePalette,
+    has_split: bool,
 ) -> TopbarAction {
     let mut action = TopbarAction::default();
 
@@ -31,6 +32,7 @@ pub fn draw_topbar(
                 hwnd,
                 palette,
                 &mut action,
+                has_split,
             );
             draw_drag_region(ui, hwnd);
         });
@@ -50,6 +52,7 @@ pub fn draw_topbar(
                     hwnd,
                     palette,
                     &mut action,
+                    has_split,
                 );
             });
 
@@ -70,7 +73,7 @@ fn draw_hamburger_menu(
 
     let menu_open = ui.memory(|mem| mem.data.get_temp::<bool>(menu_id).unwrap_or(false));
 
-    if clickable_icon(ui, regular::LIST, palette.primary)
+    if clickable_icon(ui, regular::LIST, palette)
         .on_hover_text(
             egui::RichText::new(&i18n.tr("tooltip_mainmenu"))
                 .size(palette.tooltip_text_size)
@@ -130,10 +133,34 @@ fn draw_mode_icons(
     _hwnd: Option<HWND>,
     palette: &crate::gui::theme::ThemePalette,
     action: &mut TopbarAction,
+    has_split: bool,
 ) {
+    let sidebar_tooltip_key = if sidebar_collapsed {
+        "tooltip_show_sidebar"
+    } else {
+        "tooltip_hide_sidebar"
+    };
+    if clickable_active_icon(
+        ui,
+        regular::SIDEBAR_SIMPLE,
+        ui.visuals().text_color(),
+        !sidebar_collapsed,
+        palette,
+    )
+    .on_hover_text(
+        egui::RichText::new(&i18n.tr(sidebar_tooltip_key))
+            .size(palette.tooltip_text_size)
+            .color(palette.tooltip_text_color),
+    )
+    .on_hover_cursor(egui::CursorIcon::PointingHand)
+    .clicked()
+    {
+        action.toggle_sidebar = true;
+    }
+
     let icon = if is_dark { regular::SUN } else { regular::MOON };
 
-    if clickable_icon(ui, icon, palette.primary)
+    if clickable_icon(ui, icon, palette)
         .on_hover_text(
             egui::RichText::new(&i18n.tr("tooltip_theme"))
                 .size(palette.tooltip_text_size)
@@ -145,10 +172,12 @@ fn draw_mode_icons(
         action.toggle_theme = true;
     }
 
+    ui.separator();
+
     let file_explorer_icon = if is_file_explorer {
-        regular::FOLDER_OPEN
+        regular::TABS
     } else {
-        regular::FOLDER
+        regular::TABS
     };
 
     if clickable_active_icon(
@@ -156,7 +185,7 @@ fn draw_mode_icons(
         file_explorer_icon,
         ui.visuals().text_color(),
         is_file_explorer,
-        palette.primary,
+        palette,
     )
     .on_hover_text(
         egui::RichText::new(&i18n.tr("tooltip_show_file_explorer"))
@@ -174,7 +203,7 @@ fn draw_mode_icons(
         regular::TAG,
         ui.visuals().text_color(),
         !is_file_explorer,
-        palette.primary,
+        palette,
     )
     .on_hover_text(
         egui::RichText::new(&i18n.tr("tooltip_show_tags"))
@@ -187,28 +216,23 @@ fn draw_mode_icons(
         action.toggle_file_explorer = true;
     }
 
-    let sidebar_tooltip_key = if sidebar_collapsed {
-        "tooltip_show_sidebar"
-    } else {
-        "tooltip_hide_sidebar"
-    };
-
-    if clickable_active_icon(
-        ui,
-        regular::SIDEBAR_SIMPLE,
-        ui.visuals().text_color(),
-        !sidebar_collapsed,
-        palette.primary,
-    )
-    .on_hover_text(
-        egui::RichText::new(&i18n.tr(sidebar_tooltip_key))
-            .size(palette.tooltip_text_size)
-            .color(palette.tooltip_text_color),
-    )
-    .on_hover_cursor(egui::CursorIcon::PointingHand)
-    .clicked()
-    {
-        action.toggle_sidebar = true;
+    if is_file_explorer {
+        let (icon, tooltip_key) = if has_split {
+            (regular::ARROWS_IN_LINE_HORIZONTAL, "tooltip_close_split")
+        } else {
+            (regular::SPLIT_HORIZONTAL, "tooltip_open_split")
+        };
+        if clickable_icon(ui, icon, palette)
+            .on_hover_text(
+                egui::RichText::new(i18n.tr(tooltip_key))
+                    .size(palette.tooltip_text_size)
+                    .color(palette.tooltip_text_color),
+            )
+            .on_hover_cursor(egui::CursorIcon::PointingHand)
+            .clicked()
+        {
+            action.toggle_active_tab_split = true;
+        }
     }
 }
 

--- a/src/gui/windows/customizetheme.rs
+++ b/src/gui/windows/customizetheme.rs
@@ -5,14 +5,12 @@ use crate::gui::theme::{
     regenerate_base_derived_colors,
 };
 use crate::gui::utils::rgba_color_edit_button;
-use crate::gui::utils::text::apply_eden_text_overrides;
 use crate::gui::utils::widgets::{
     apply_eden_visual_overrides, draw_dropdown, eden_button, eden_text_label, eden_toggle_button,
 };
 use crate::gui::windows::enums::ThemeCustomizerAction;
 use crate::gui::windows::structs::ThemeCustomizer;
 use eframe::egui;
-use egui::{FontFamily, FontId};
 
 fn selectable_mode(
     ui: &mut egui::Ui,
@@ -60,15 +58,15 @@ pub fn draw_theme_customizer(
     egui::Window::new(i18n.tr("theme_title"))
         .collapsible(false)
         .resizable(false)
-        .fixed_size([600.0, 500.0])
+        .fixed_size([600.0, 550.0])
         .anchor(egui::Align2::CENTER_CENTER, [0.0, 0.0])
         .open(&mut customizer.open)
-        .frame(egui::Frame::popup(&ctx.style()).corner_radius(egui::CornerRadius::same(8)))
+        .frame(
+            egui::Frame::popup(&ctx.style_of(ctx.theme()))
+                .corner_radius(egui::CornerRadius::same(8)),
+        )
         .show(ctx, |ui| {
             ui.set_width(ui.available_width());
-
-            let label_color = palette.text_normal;
-            let font_id = FontId::new(palette.text_size, FontFamily::Proportional);
             // TOP SECTION: select which palette to edit
             ui.horizontal(|ui| {
                 if selectable_mode(
@@ -224,6 +222,29 @@ pub fn draw_theme_customizer(
                                                 )
                                                 .range(8.0..=32.0)
                                                 .speed(0.2),
+                                            )
+                                            .changed();
+                                    },
+                                );
+                                ui.end_row();
+
+                                eden_text_label(
+                                    ui,
+                                    palette,
+                                    &i18n.tr("theme_sidebar_item_spacing_y"),
+                                );
+                                ui.with_layout(
+                                    egui::Layout::right_to_left(egui::Align::Center),
+                                    |ui| {
+                                        apply_eden_visual_overrides(ui, palette);
+                                        changed |= ui
+                                            .add_sized(
+                                                egui::vec2(90.0, 0.0),
+                                                egui::DragValue::new(
+                                                    &mut editing_palette.sidebar_item_spacing_y,
+                                                )
+                                                .range(-0.3..=2.0)
+                                                .speed(0.1),
                                             )
                                             .changed();
                                     },

--- a/src/gui/windows/mainwindow.rs
+++ b/src/gui/windows/mainwindow.rs
@@ -29,7 +29,7 @@ use crate::gui::windows::structs::{
     AboutWindow, AppSettings, Navigation, SettingsWindow, SidebarState, ThemeCustomizer,
 };
 use crate::gui::windows::windowsoverrides::{
-    apply_window_override, consume_clipboard_dirty, install_wndproc,
+    apply_window_override, consume_clipboard_dirty, handle_draw_windows_buttons, install_wndproc,
 };
 use eframe::egui;
 use std::collections::HashMap;
@@ -64,6 +64,7 @@ pub struct MainWindow {
     pub(crate) active_tab: usize,
     pub(crate) tab_infos_cache: Vec<TabInfo>,
     pub(crate) tab_infos_dirty: bool,
+    pub(crate) tab_scroll_offset: f32,
     pub(crate) pending_tab_scroll_id: Option<u64>,
     pub(crate) focused_split: SplitSide,
     pub(crate) next_tab_id: u64,
@@ -110,6 +111,9 @@ impl Default for MainWindow {
             item_viewer_file_column_order,
             item_viewer_drive_column_order,
             recycle_bin_column_order,
+            item_viewer_file_column_sizes,
+            item_viewer_drive_column_sizes,
+            recycle_bin_column_sizes,
         ) = load_app_settings();
         let loaded_settings = AppSettings {
             folder_scanning_enabled,
@@ -127,6 +131,9 @@ impl Default for MainWindow {
             item_viewer_file_column_order,
             item_viewer_drive_column_order,
             recycle_bin_column_order,
+            item_viewer_file_column_sizes,
+            item_viewer_drive_column_sizes,
+            recycle_bin_column_sizes,
         };
 
         let system_locale = sys_locale::get_locale().unwrap_or_else(|| "en-US".to_string());
@@ -155,6 +162,9 @@ impl Default for MainWindow {
                 loaded_settings.item_viewer_file_column_order.clone(),
                 loaded_settings.item_viewer_drive_column_order.clone(),
                 loaded_settings.recycle_bin_column_order.clone(),
+                loaded_settings.item_viewer_file_column_sizes.clone(),
+                loaded_settings.item_viewer_drive_column_sizes.clone(),
+                loaded_settings.recycle_bin_column_sizes.clone(),
             );
             next_tab_id += 1;
         } else {
@@ -170,6 +180,9 @@ impl Default for MainWindow {
                         loaded_settings.item_viewer_file_column_order.clone(),
                         loaded_settings.item_viewer_drive_column_order.clone(),
                         loaded_settings.recycle_bin_column_order.clone(),
+                        loaded_settings.item_viewer_file_column_sizes.clone(),
+                        loaded_settings.item_viewer_drive_column_sizes.clone(),
+                        loaded_settings.recycle_bin_column_sizes.clone(),
                     );
                 next_tab_id += 1;
             }
@@ -180,6 +193,8 @@ impl Default for MainWindow {
             active_tab: 0,
             tab_infos_cache: Vec::new(),
             tab_infos_dirty: true,
+
+            tab_scroll_offset: 0.0,
             pending_tab_scroll_id: None,
             focused_split: SplitSide::Primary,
             next_tab_id,
@@ -294,7 +309,7 @@ impl MainWindow {
 }
 
 impl eframe::App for MainWindow {
-    fn update(&mut self, ctx: &egui::Context, frame: &mut eframe::Frame) {
+    fn ui(&mut self, ui: &mut egui::Ui, frame: &mut eframe::Frame) {
         {
             let forwarded_paths = take_forwarded_paths();
             for path in &forwarded_paths {
@@ -352,12 +367,12 @@ impl eframe::App for MainWindow {
                     .unwrap_or(false)
         } || native_drag_active;
         if let Some(backend) = dragdrop {
-            backend.set_scale_factor(ctx.pixels_per_point());
+            backend.set_scale_factor(ui.ctx().pixels_per_point());
         }
 
         if self.theme_dirty {
-            apply_theme(ctx, self.theme);
-            apply_font_to_context(ctx, &palette);
+            apply_theme(ui.ctx(), self.theme);
+            apply_font_to_context(ui.ctx(), &palette);
             if let Some(hwnd) = self.hwnd {
                 apply_window_override(hwnd, &palette);
             }
@@ -365,7 +380,7 @@ impl eframe::App for MainWindow {
         }
 
         // Auto-save window size when it changes (including maximize/restore)
-        if let Some(viewport_rect) = ctx.input(|i| i.viewport().inner_rect) {
+        if let Some(viewport_rect) = ui.ctx().input(|i| i.viewport().inner_rect) {
             let current_size = (viewport_rect.width(), viewport_rect.height());
 
             // Check if window size changed from last recorded size
@@ -422,6 +437,18 @@ impl eframe::App for MainWindow {
                             .settings_window
                             .current_settings
                             .recycle_bin_column_order,
+                        &self
+                            .settings_window
+                            .current_settings
+                            .item_viewer_file_column_sizes,
+                        &self
+                            .settings_window
+                            .current_settings
+                            .item_viewer_drive_column_sizes,
+                        &self
+                            .settings_window
+                            .current_settings
+                            .recycle_bin_column_sizes,
                     );
 
                     self.last_window_size = Some(current_size);
@@ -440,13 +467,12 @@ impl eframe::App for MainWindow {
         }
 
         // Increase scroll speed for the explorer view.
-        ctx.input_mut(|i| {
-            // i.raw_scroll_delta *= 8.0;
+        ui.ctx().input_mut(|i| {
             i.smooth_scroll_delta *= 6.0;
         });
 
         if self.icon_cache.is_none() {
-            self.icon_cache = Some(IconCache::new(ctx.clone()));
+            self.icon_cache = Some(IconCache::new(ui.ctx().clone()));
         }
 
         let icon_cache = self.icon_cache.take().unwrap();
@@ -458,14 +484,12 @@ impl eframe::App for MainWindow {
         let mut tabbar_action = None;
         let mut secondary_tabbar_action: Option<ItemViewerNavBarAction> = None;
         let mut secondary_pending_action: Option<ItemViewerAction> = None;
-        let mut primary_focus_click = false;
-        let mut secondary_focus_click = false;
-        let mut trigger_toggle_split = false;
         let mut tags_changed = false;
+        let has_split = self.tabs[self.active_tab].split_view.is_some();
 
         let offset = egui::vec2(8.0, 8.0);
 
-        egui::CentralPanel::default().show(ctx, |ui| {
+        egui::CentralPanel::default().show(ui, |ui| {
             // CentralPanel available rect
             let rect = ui.min_rect();
 
@@ -513,6 +537,7 @@ impl eframe::App for MainWindow {
                                         self.sidebar_collapsed,
                                         self.hwnd,
                                         &palette,
+                                        has_split,
                                     ));
                                 });
                                 if !self.sidebar_collapsed {
@@ -585,38 +610,86 @@ impl eframe::App for MainWindow {
                                 egui::Layout::top_down(egui::Align::Min),
                                 |ui| {
                                     let active_id = self.tabs[self.active_tab].id;
-                                    let has_split = self.tabs[self.active_tab].split_view.is_some();
 
                                     egui::Frame::NONE.show(ui, |ui| {
-                                        ui.add_space(8.0);
+                                        let topbar_rect = ui.allocate_exact_size(
+                                            egui::vec2(ui.available_width(), 32.0),
+                                            egui::Sense::hover(),
+                                        ).0;
+
+                                        // -------------------------
+                                        // Tabs
+                                        // -------------------------
+
+                                        let tabs_rect = egui::Rect::from_min_size(
+                                            topbar_rect.min + egui::vec2(0.0, 4.0),
+                                            egui::vec2(topbar_rect.width(), 24.0),
+                                        );
+
                                         let scroll_to_id = self.pending_tab_scroll_id;
-                                        tabs_action = Some(draw_tabs(
-                                            ui,
-                                            &self.i18n,
-                                            &self.tab_infos_cache,
-                                            active_id,
-                                            &palette,
-                                            self.hwnd,
-                                            scroll_to_id,
-                                            drag_active,
-                                            drag_hover_target.clone(),
-                                            has_split,
-                                        ));
+
+                                        ui.scope_builder(
+                                            egui::UiBuilder::new().max_rect(tabs_rect),
+                                            |ui| {
+                                                tabs_action = Some(draw_tabs(
+                                                    ui,
+                                                    &self.i18n,
+                                                    &self.tab_infos_cache,
+                                                    self.tab_scroll_offset,
+                                                    active_id,
+                                                    &palette,
+                                                    self.hwnd,
+                                                    scroll_to_id,
+                                                    drag_active,
+                                                    drag_hover_target.clone(),
+                                                ));
+                                            },
+                                        );
+
                                         if scroll_to_id.is_some() {
                                             self.pending_tab_scroll_id = None;
                                         }
-                                    });
 
+                                        // -------------------------
+                                        // Window controls
+                                        // -------------------------
+
+                                        let controls_width = 45.0 * 3.0;
+
+                                        let viewport_rect = ui.ctx().viewport_rect();
+
+                                        let controls_rect = egui::Rect::from_min_size(
+                                            egui::pos2(
+                                                viewport_rect.right() - controls_width,
+                                                topbar_rect.top(),
+                                            ),
+                                            egui::vec2(controls_width, 32.0),
+                                        );
+
+                                        ui.scope_builder(
+                                            egui::UiBuilder::new().max_rect(controls_rect),
+                                            |ui| {
+                                                ui.with_layout(
+                                                    egui::Layout::right_to_left(egui::Align::Min),
+                                                    |ui| {
+                                                        handle_draw_windows_buttons(&self.i18n, ui, self.hwnd, &palette);
+                                                    },
+                                                );
+                                            },
+                                        );
+                                    });
                                     let container = egui::Frame::NONE
                                         .stroke(egui::Stroke::NONE)
                                         .fill(egui::Color32::TRANSPARENT)
-                                        .inner_margin(egui::Margin::symmetric(10, 0));
+                                        .inner_margin(egui::Margin {
+                                            left: 3,
+                                            right: 0,
+                                            top: 0,
+                                            bottom: 0,
+                                        });
 
                                     container.show(ui, |ui| {
                                         if has_split {
-                                            let primary_focused =
-                                                self.focused_split == SplitSide::Primary;
-                                            let secondary_focused = !primary_focused;
                                             let split_rect = ui.available_rect_before_wrap();
                                             let (split_rect, _) = ui.allocate_exact_size(
                                                 split_rect.size(),
@@ -641,6 +714,29 @@ impl eframe::App for MainWindow {
                                                 egui::vec2(secondary_width, split_height),
                                             );
 
+                                            let (pointer_pos, primary_clicked) = ui.ctx().input(|i| {
+                                                (
+                                                    i.pointer.interact_pos(),
+                                                    i.pointer.primary_clicked(),
+                                                )
+                                            });
+
+                                            if primary_clicked {
+                                                if let Some(pos) = pointer_pos {
+                                                    let in_primary = primary_rect.contains(pos);
+                                                    let in_secondary = secondary_rect.contains(pos);
+
+                                                    if in_primary {
+                                                        self.focused_split = SplitSide::Primary;
+                                                    } else if in_secondary {
+                                                        self.focused_split = SplitSide::Secondary;
+                                                    }
+                                                }
+                                            }
+
+                                            let primary_focused = self.focused_split == SplitSide::Primary;
+                                            let secondary_focused = !primary_focused;
+
                                             ui.scope_builder(
                                                 egui::UiBuilder::new().max_rect(primary_rect),
                                                 |ui| {
@@ -663,21 +759,6 @@ impl eframe::App for MainWindow {
                                                                 );
                                                             }
                                                             ui.add_space(2.0);
-
-                                                            let catch_rect =
-                                                                ui.available_rect_before_wrap();
-                                                            if ui
-                                                                .interact(
-                                                                    catch_rect,
-                                                                    ui.id().with(
-                                                                        "pane_focus_catch_primary",
-                                                                    ),
-                                                                    egui::Sense::click(),
-                                                                )
-                                                                .clicked()
-                                                            {
-                                                                primary_focus_click = true;
-                                                            }
 
                                                             let tab_id = self.tabs[self.active_tab].id;
                                                             let is_favorited = self
@@ -757,21 +838,6 @@ impl eframe::App for MainWindow {
                                                             }
                                                             ui.add_space(2.0);
 
-                                                            let catch_rect =
-                                                                ui.available_rect_before_wrap();
-                                                            if ui
-                                                                .interact(
-                                                                    catch_rect,
-                                                                    ui.id().with(
-                                                                        "pane_focus_catch_secondary",
-                                                                    ),
-                                                                    egui::Sense::click(),
-                                                                )
-                                                                .clicked()
-                                                            {
-                                                                secondary_focus_click = true;
-                                                            }
-
                                                             let tab_id = self.tabs[self.active_tab].id;
                                                             let is_favorited = self.tabs
                                                                 [self.active_tab]
@@ -830,19 +896,6 @@ impl eframe::App for MainWindow {
                                                     );
                                                 });
                                             });
-
-                                            if primary_focus_click
-                                                || tabbar_action.is_some()
-                                                || pending_action.is_some()
-                                            {
-                                                self.focused_split = SplitSide::Primary;
-                                            }
-                                            if secondary_focus_click
-                                                || secondary_tabbar_action.is_some()
-                                                || secondary_pending_action.is_some()
-                                            {
-                                                self.focused_split = SplitSide::Secondary;
-                                            }
                                         } else {
                                             let tab_id = self.tabs[self.active_tab].id;
                                             let is_favorited =
@@ -893,14 +946,6 @@ impl eframe::App for MainWindow {
                                     });
                                 },
                             );
-
-                            if tabs_action
-                                .as_ref()
-                                .map(|a| a.toggle_split)
-                                .unwrap_or(false)
-                            {
-                                trigger_toggle_split = true;
-                            }
                         } else if draw_tags(
                             ui,
                             &self.i18n,
@@ -929,16 +974,12 @@ impl eframe::App for MainWindow {
             });
         });
 
-        if trigger_toggle_split {
-            self.toggle_split_for_active_tab();
-        }
-
         if let Some(backend) = self.dragdrop.as_ref() {
             backend.update_drop_targets(drop_targets);
         }
 
         if pending_action.is_none() {
-            let dropped_paths: Vec<PathBuf> = ctx.input(|i| {
+            let dropped_paths: Vec<PathBuf> = ui.ctx().input(|i| {
                 i.raw
                     .dropped_files
                     .iter()
@@ -1050,9 +1091,9 @@ impl eframe::App for MainWindow {
             .and_then(|a| a.move_files_to_breadcrumb_dir.as_ref())
             .is_some();
 
-        self.handle_directory_batch_recieve(ctx);
-        self.handle_directory_size_updates(ctx);
-        self.handle_throttle_size_requests(ctx);
+        self.handle_directory_batch_recieve(ui.ctx());
+        self.handle_directory_size_updates(ui.ctx());
+        self.handle_throttle_size_requests(ui.ctx());
         self.handle_topbar_action(topbar_action);
         self.handle_sidebar_action(sidebar_action, sidebar_drag_sources.as_deref());
         self.handle_tabs_action(tabs_action, tabs_drag_sources.as_deref());
@@ -1115,20 +1156,20 @@ impl eframe::App for MainWindow {
             handle_pending_actions(secondary_pending_action, self);
         }
         self.focused_split = restore_focus;
-        if draw_tag_picker_popup(ctx, &self.i18n, &palette, &mut self.tags_state) {
+        if draw_tag_picker_popup(ui.ctx(), &self.i18n, &palette, &mut self.tags_state) {
             tags_changed = true;
         }
         handle_draw_customizetheme_window(
             &mut self.i18n,
-            ctx,
+            ui.ctx(),
             &mut self.theme_customizer,
             &palette,
             self.theme,
             &mut self.theme_dirty,
         );
-        self.handle_draw_settings_window(ctx, &palette);
-        self.handle_draw_about_window(ctx, &palette);
-        self.handle_global_shortcuts(ctx);
+        self.handle_draw_settings_window(ui.ctx(), &palette);
+        self.handle_draw_about_window(ui.ctx(), &palette);
+        self.handle_global_shortcuts(ui.ctx());
 
         if tags_changed {
             self.persist_tags();

--- a/src/gui/windows/mainwindow_imp.rs
+++ b/src/gui/windows/mainwindow_imp.rs
@@ -146,6 +146,18 @@ impl MainWindow {
                 .current_settings
                 .recycle_bin_column_order
                 .clone(),
+            self.settings_window
+                .current_settings
+                .item_viewer_file_column_sizes
+                .clone(),
+            self.settings_window
+                .current_settings
+                .item_viewer_drive_column_sizes
+                .clone(),
+            self.settings_window
+                .current_settings
+                .recycle_bin_column_sizes
+                .clone(),
         );
         self.tabs.last_mut().unwrap().primary_view.column_state = column_state;
         self.active_tab = self.tabs.len() - 1;
@@ -275,6 +287,18 @@ impl MainWindow {
                 .settings_window
                 .current_settings
                 .recycle_bin_column_order,
+            &self
+                .settings_window
+                .current_settings
+                .item_viewer_file_column_sizes,
+            &self
+                .settings_window
+                .current_settings
+                .item_viewer_drive_column_sizes,
+            &self
+                .settings_window
+                .current_settings
+                .recycle_bin_column_sizes,
         );
     }
 
@@ -300,6 +324,10 @@ impl MainWindow {
                 .current_settings
                 .item_viewer_file_column_order
         };
+        eprintln!(
+            "SAVE COLUMN ORDER: drive={} recycle={} order={:?}",
+            is_drive_view, is_recycle_bin_view, order
+        );
         *target_order = order.to_vec();
 
         for tab in &mut self.tabs {
@@ -1356,6 +1384,9 @@ impl MainWindow {
                         _item_viewer_file_column_order,
                         _item_viewer_drive_column_order,
                         _recycle_bin_column_order,
+                        _item_viewer_file_column_sizes,
+                        _item_viewer_drive_column_sizes,
+                        _recycle_bin_column_sizes,
                     ) = load_app_settings();
                     self.tabs[0].primary_view.nav = Navigation::new(start_path);
                     self.tabs[0].split_view = None;
@@ -1389,6 +1420,14 @@ impl MainWindow {
                 if let Some(sources) = drag_sources {
                     self.move_selected_paths_to_dir(sources, target_dir.clone());
                 }
+            }
+            if action.scroll_left {
+                self.tab_scroll_offset = (self.tab_scroll_offset - 180.0).max(0.0);
+            }
+
+            if action.scroll_right {
+                self.tab_scroll_offset =
+                    (self.tab_scroll_offset + 180.0).min(action.max_scroll_offset);
             }
         }
     }
@@ -1576,6 +1615,9 @@ impl MainWindow {
             }
             if action.toggle_sidebar {
                 self.sidebar_collapsed = !self.sidebar_collapsed;
+            }
+            if action.toggle_active_tab_split {
+                self.toggle_split_for_active_tab();
             }
         }
     }
@@ -2083,48 +2125,48 @@ pub fn handle_pending_actions(pending_action: Option<ItemViewerAction>, explorer
         match action {
             ItemViewerAction::Sort(col) => explorer.toggle_sort(col),
             ItemViewerAction::ToggleColumnVisibility(column) => {
-                let view = explorer.active_tab_mut().view_mut(side);
-                let column_state = &mut view.column_state;
+                let new_order = {
+                    let view = explorer.active_tab_mut().view_mut(side);
+                    let column_state = &mut view.column_state;
 
-                match column {
-                    ItemViewerHeaderColumn::Name => {}
-                    ItemViewerHeaderColumn::Type => {
-                        column_state.show_type = !column_state.show_type;
-                        column_state.layout_generation =
-                            column_state.layout_generation.wrapping_add(1);
+                    if column_state.toggle_column_visibility(
+                        is_drive_view,
+                        is_recycle_bin_view,
+                        column,
+                    ) {
+                        Some(
+                            column_state
+                                .order(is_drive_view, is_recycle_bin_view)
+                                .to_vec(),
+                        )
+                    } else {
+                        None
                     }
-                    ItemViewerHeaderColumn::Size => {
-                        column_state.show_size = !column_state.show_size;
-                        column_state.layout_generation =
-                            column_state.layout_generation.wrapping_add(1);
-                    }
-                    ItemViewerHeaderColumn::Modified => {
-                        column_state.show_modified = !column_state.show_modified;
-                        column_state.layout_generation =
-                            column_state.layout_generation.wrapping_add(1);
-                    }
-                    ItemViewerHeaderColumn::Created => {
-                        column_state.show_created = !column_state.show_created;
-                        column_state.layout_generation =
-                            column_state.layout_generation.wrapping_add(1);
-                    }
-                    ItemViewerHeaderColumn::Usage => {}
-                    ItemViewerHeaderColumn::Deleted => {
-                        column_state.layout_generation =
-                            column_state.layout_generation.wrapping_add(1);
-                    }
+                };
+
+                if let Some(order) = new_order {
+                    explorer.apply_item_viewer_column_order(
+                        is_drive_view,
+                        is_recycle_bin_view,
+                        &order,
+                    );
                 }
             }
             ItemViewerAction::FitColumn(column) => {
                 let view = explorer.active_tab_mut().view_mut(side);
+
                 view.column_state.pending_fit_request =
                     Some(ItemViewerColumnFitRequest::Column(column));
+
                 view.column_state.layout_generation =
                     view.column_state.layout_generation.wrapping_add(1);
             }
+
             ItemViewerAction::FitAllColumns => {
                 let view = explorer.active_tab_mut().view_mut(side);
+
                 view.column_state.pending_fit_request = Some(ItemViewerColumnFitRequest::All);
+
                 view.column_state.layout_generation =
                     view.column_state.layout_generation.wrapping_add(1);
             }
@@ -2509,6 +2551,36 @@ pub fn handle_pending_actions(pending_action: Option<ItemViewerAction>, explorer
                     view.explorer_state.selection_focus = None;
                 }
                 explorer.load_path();
+            }
+            ItemViewerAction::ColumnSizesChanged => {
+                let sizes = {
+                    let view = explorer.active_tab().view(side);
+
+                    view.column_state
+                        .column_sizes(is_drive_view, is_recycle_bin_view)
+                        .to_vec()
+                };
+
+                let target_sizes = if is_drive_view {
+                    &mut explorer
+                        .settings_window
+                        .current_settings
+                        .item_viewer_drive_column_sizes
+                } else if is_recycle_bin_view {
+                    &mut explorer
+                        .settings_window
+                        .current_settings
+                        .recycle_bin_column_sizes
+                } else {
+                    &mut explorer
+                        .settings_window
+                        .current_settings
+                        .item_viewer_file_column_sizes
+                };
+
+                *target_sizes = sizes;
+
+                explorer.save_app_settings_to_disk();
             }
         }
     }

--- a/src/gui/windows/settings.rs
+++ b/src/gui/windows/settings.rs
@@ -51,6 +51,9 @@ impl Default for AppSettings {
                 ItemViewerHeaderColumn::Deleted,
                 ItemViewerHeaderColumn::Created,
             ],
+            item_viewer_file_column_sizes: vec![],
+            item_viewer_drive_column_sizes: vec![],
+            recycle_bin_column_sizes: vec![],
         }
     }
 }
@@ -115,7 +118,7 @@ fn setting_checkbox(
     palette: &ThemePalette,
     checked: &mut bool,
     label: RichText,
-    id: impl std::hash::Hash,
+    id: impl std::hash::Hash + std::fmt::Debug,
 ) -> bool {
     let mut changed = false;
 
@@ -169,7 +172,7 @@ where
 pub fn combo_box_string(
     ui: &mut egui::Ui,
     palette: &ThemePalette,
-    id: impl std::hash::Hash,
+    id: impl std::hash::Hash + std::fmt::Debug,
     width: f32,
     value: &mut String,
     options: &[(&str, String)],
@@ -232,13 +235,16 @@ pub fn draw_settings_window(
     egui::Window::new(i18n.tr("settings"))
         .collapsible(false)
         .resizable(false)
-        .fixed_size([600.0, 500.0])
+        .fixed_size([600.0, 550.0])
         .anchor(egui::Align2::CENTER_CENTER, [0.0, 0.0])
         .open(&mut settings.open)
-        .frame(egui::Frame::popup(&ctx.style()).corner_radius(egui::CornerRadius::same(8)))
+        .frame(
+            egui::Frame::popup(&ctx.style_of(ctx.theme()))
+                .corner_radius(egui::CornerRadius::same(8)),
+        )
         .show(ctx, |ui| {
             // 🎯 Smaller font override (fix giant UI)
-            let mut style = (*ui.ctx().style()).clone();
+            let mut style = (**ui.style()).clone();
             style.text_styles = [
                 (egui::TextStyle::Heading, egui::FontId::proportional(14.0)),
                 (
@@ -664,7 +670,7 @@ pub fn draw_settings_window(
                             .fixed_size([400.0, 150.0])
                             .anchor(egui::Align2::CENTER_CENTER, [0.0, 0.0])
                             .frame(
-                                egui::Frame::popup(&ctx.style())
+                                egui::Frame::popup(&ctx.style_of(ctx.theme()))
                                     .corner_radius(egui::CornerRadius::same(8)),
                             )
                             .show(ctx, |ui| {

--- a/src/gui/windows/structs.rs
+++ b/src/gui/windows/structs.rs
@@ -55,6 +55,9 @@ pub struct AppSettings {
     pub item_viewer_file_column_order: Vec<ItemViewerHeaderColumn>,
     pub item_viewer_drive_column_order: Vec<ItemViewerHeaderColumn>,
     pub recycle_bin_column_order: Vec<ItemViewerHeaderColumn>,
+    pub item_viewer_file_column_sizes: Vec<f32>,
+    pub item_viewer_drive_column_sizes: Vec<f32>,
+    pub recycle_bin_column_sizes: Vec<f32>,
 }
 
 #[derive(Default)]

--- a/src/gui/windows/windowsoverrides.rs
+++ b/src/gui/windows/windowsoverrides.rs
@@ -1,6 +1,7 @@
 use crate::core::drives::mark_drive_cache_dirty;
 use crate::core::indexer::{WindowSizeMode, load_app_settings, save_app_settings};
 use crate::core::launch::receive_copydata;
+use crate::gui::i18n::I18n;
 use crate::gui::theme::ThemePalette;
 use crate::gui::utils::clickable_windows_icon;
 use eframe::egui;
@@ -20,7 +21,6 @@ use windows::Win32::System::DataExchange::{
 };
 use windows::Win32::UI::Controls::MARGINS;
 use windows::Win32::UI::WindowsAndMessaging::*;
-use crate::gui::i18n::I18n;
 
 const MIN_WIDTH: i32 = 600;
 const MIN_HEIGHT: i32 = 400;
@@ -405,7 +405,12 @@ fn get_y_lparam(lparam: LPARAM) -> i32 {
     ((lparam.0 >> 16) & 0xFFFF) as i16 as i32
 }
 
-pub fn handle_draw_windows_buttons(i18n: &I18n, ui: &mut egui::Ui, hwnd: Option<HWND>, palette: &ThemePalette) {
+pub fn handle_draw_windows_buttons(
+    i18n: &I18n,
+    ui: &mut egui::Ui,
+    hwnd: Option<HWND>,
+    palette: &ThemePalette,
+) {
     let old_item_spacing_x = ui.spacing().item_spacing.x;
     ui.spacing_mut().item_spacing.x = 0.0;
 
@@ -434,9 +439,13 @@ pub fn handle_draw_windows_buttons(i18n: &I18n, ui: &mut egui::Ui, hwnd: Option<
 
         if clickable_windows_icon(ui, maximize_icon, palette.primary, palette)
             .on_hover_text(
-                egui::RichText::new(if is_maximized { i18n.tr("restore") } else { i18n.tr("maximize") })
-                    .size(palette.tooltip_text_size)
-                    .color(palette.tooltip_text_color),
+                egui::RichText::new(if is_maximized {
+                    i18n.tr("restore")
+                } else {
+                    i18n.tr("maximize")
+                })
+                .size(palette.tooltip_text_size)
+                .color(palette.tooltip_text_color),
             )
             .on_hover_cursor(egui::CursorIcon::PointingHand)
             .clicked()

--- a/src/gui/windows/windowsoverrides.rs
+++ b/src/gui/windows/windowsoverrides.rs
@@ -2,7 +2,7 @@ use crate::core::drives::mark_drive_cache_dirty;
 use crate::core::indexer::{WindowSizeMode, load_app_settings, save_app_settings};
 use crate::core::launch::receive_copydata;
 use crate::gui::theme::ThemePalette;
-use crate::gui::utils::clickable_icon;
+use crate::gui::utils::clickable_windows_icon;
 use eframe::egui;
 use egui::Context;
 use egui_phosphor::regular;
@@ -13,19 +13,20 @@ use windows::Win32::Foundation::HWND;
 use windows::Win32::Foundation::*;
 use windows::Win32::Graphics::Dwm::*;
 use windows::Win32::Graphics::Gdi::{
-    GetMonitorInfoW, MONITOR_DEFAULTTONEAREST, MONITORINFO, MonitorFromWindow,
+    ClientToScreen, GetMonitorInfoW, MONITOR_DEFAULTTONEAREST, MONITORINFO, MonitorFromWindow,
 };
 use windows::Win32::System::DataExchange::{
     AddClipboardFormatListener, RemoveClipboardFormatListener,
 };
 use windows::Win32::UI::Controls::MARGINS;
 use windows::Win32::UI::WindowsAndMessaging::*;
+use crate::gui::i18n::I18n;
 
 const MIN_WIDTH: i32 = 600;
 const MIN_HEIGHT: i32 = 400;
-const RESIZE_BORDER: i32 = 6;
+/// Width of the client-area region reserved for native window resizing.
+const RESIZE_BORDER: i32 = 2;
 
-// ✅ Fixed: Use AtomicPtr instead of static mut
 static ORIGINAL_WNDPROC: AtomicPtr<std::ffi::c_void> = AtomicPtr::new(std::ptr::null_mut());
 
 fn get_original_wndproc() -> Option<WNDPROC> {
@@ -104,6 +105,9 @@ fn save_manual_window_size(hwnd: HWND) {
             item_viewer_file_column_order,
             item_viewer_drive_column_order,
             recycle_bin_column_order,
+            item_viewer_file_column_sizes,
+            item_viewer_drive_column_sizes,
+            recycle_bin_column_sizes,
         ) = load_app_settings();
         let window_size_mode = WindowSizeMode::Custom { width, height };
 
@@ -124,6 +128,9 @@ fn save_manual_window_size(hwnd: HWND) {
             &item_viewer_file_column_order,
             &item_viewer_drive_column_order,
             &recycle_bin_column_order,
+            &item_viewer_file_column_sizes,
+            &item_viewer_drive_column_sizes,
+            &recycle_bin_column_sizes,
         );
     }
 }
@@ -308,45 +315,76 @@ unsafe extern "system" fn custom_wndproc(
             let x = get_x_lparam(lparam);
             let y = get_y_lparam(lparam);
 
-            let mut rect = RECT::default();
-
             unsafe {
-                let _ = GetWindowRect(hwnd, &mut rect);
-            }
+                let mut client_rect = RECT::default();
 
-            let width = rect.right - rect.left;
-            let height = rect.bottom - rect.top;
+                if GetClientRect(hwnd, &mut client_rect).is_err() {
+                    return DefWindowProcW(hwnd, msg, wparam, lparam);
+                }
 
-            let local_x = x - rect.left;
-            let local_y = y - rect.top;
+                // Convert client top-left and bottom-right to screen coordinates.
+                let mut top_left = POINT {
+                    x: client_rect.left,
+                    y: client_rect.top,
+                };
 
-            if local_x < RESIZE_BORDER && local_y < RESIZE_BORDER {
-                return LRESULT(HTTOPLEFT as _);
-            }
-            if local_x >= width - RESIZE_BORDER && local_y < RESIZE_BORDER {
-                return LRESULT(HTTOPRIGHT as _);
-            }
-            if local_x < RESIZE_BORDER && local_y >= height - RESIZE_BORDER {
-                return LRESULT(HTBOTTOMLEFT as _);
-            }
-            if local_x >= width - RESIZE_BORDER && local_y >= height - RESIZE_BORDER {
-                return LRESULT(HTBOTTOMRIGHT as _);
-            }
+                let mut bottom_right = POINT {
+                    x: client_rect.right,
+                    y: client_rect.bottom,
+                };
 
-            if local_x < RESIZE_BORDER {
-                return LRESULT(HTLEFT as _);
-            }
-            if local_x >= width - RESIZE_BORDER {
-                return LRESULT(HTRIGHT as _);
-            }
-            if local_y < RESIZE_BORDER {
-                return LRESULT(HTTOP as _);
-            }
-            if local_y >= height - RESIZE_BORDER {
-                return LRESULT(HTBOTTOM as _);
-            }
+                let _ = ClientToScreen(hwnd, &mut top_left);
+                let _ = ClientToScreen(hwnd, &mut bottom_right);
 
-            LRESULT(HTCLIENT as _)
+                let left = top_left.x;
+                let top = top_left.y;
+                let right = bottom_right.x;
+                let bottom = bottom_right.y;
+
+                let resize = RESIZE_BORDER;
+
+                // Top-left
+                if x >= left && x < left + resize && y >= top && y < top + resize {
+                    return LRESULT(HTTOPLEFT as _);
+                }
+
+                // Top-right
+                if x >= right - resize && x < right && y >= top && y < top + resize {
+                    return LRESULT(HTTOPRIGHT as _);
+                }
+
+                // Bottom-left
+                if x >= left && x < left + resize && y >= bottom - resize && y < bottom {
+                    return LRESULT(HTBOTTOMLEFT as _);
+                }
+
+                // Bottom-right
+                if x >= right - resize && x < right && y >= bottom - resize && y < bottom {
+                    return LRESULT(HTBOTTOMRIGHT as _);
+                }
+
+                // Left
+                if x >= left && x < left + resize {
+                    return LRESULT(HTLEFT as _);
+                }
+
+                // Right
+                if x >= right - resize && x < right {
+                    return LRESULT(HTRIGHT as _);
+                }
+
+                // Top
+                if y >= top && y < top + resize {
+                    return LRESULT(HTTOP as _);
+                }
+
+                // Bottom
+                if y >= bottom - resize && y < bottom {
+                    return LRESULT(HTBOTTOM as _);
+                }
+
+                LRESULT(HTCLIENT as _)
+            }
         }
 
         _ => unsafe {
@@ -367,11 +405,22 @@ fn get_y_lparam(lparam: LPARAM) -> i32 {
     ((lparam.0 >> 16) & 0xFFFF) as i16 as i32
 }
 
-pub fn handle_draw_windows_buttons(ui: &mut egui::Ui, hwnd: Option<HWND>, palette: &ThemePalette) {
+pub fn handle_draw_windows_buttons(i18n: &I18n, ui: &mut egui::Ui, hwnd: Option<HWND>, palette: &ThemePalette) {
+    let old_item_spacing_x = ui.spacing().item_spacing.x;
+    ui.spacing_mut().item_spacing.x = 0.0;
+
     if let Some(hwnd) = hwnd {
-        if clickable_icon(ui, regular::X, palette.primary)
+        let is_maximized = unsafe { IsZoomed(hwnd).as_bool() };
+
+        let maximize_icon = if is_maximized {
+            regular::COPY
+        } else {
+            regular::SQUARE
+        };
+
+        if clickable_windows_icon(ui, regular::X, palette.tab_close_hover, palette)
             .on_hover_text(
-                egui::RichText::new("Close")
+                egui::RichText::new(i18n.tr("close"))
                     .size(palette.tooltip_text_size)
                     .color(palette.tooltip_text_color),
             )
@@ -383,9 +432,9 @@ pub fn handle_draw_windows_buttons(ui: &mut egui::Ui, hwnd: Option<HWND>, palett
             }
         }
 
-        if clickable_icon(ui, regular::SQUARE, palette.primary)
+        if clickable_windows_icon(ui, maximize_icon, palette.primary, palette)
             .on_hover_text(
-                egui::RichText::new("Maximize")
+                egui::RichText::new(if is_maximized { i18n.tr("restore") } else { i18n.tr("maximize") })
                     .size(palette.tooltip_text_size)
                     .color(palette.tooltip_text_color),
             )
@@ -395,9 +444,9 @@ pub fn handle_draw_windows_buttons(ui: &mut egui::Ui, hwnd: Option<HWND>, palett
             toggle_window_fullscreen(hwnd);
         }
 
-        if clickable_icon(ui, regular::MINUS, palette.primary)
+        if clickable_windows_icon(ui, regular::MINUS, palette.primary, palette)
             .on_hover_text(
-                egui::RichText::new("Minimize")
+                egui::RichText::new(i18n.tr("minimize"))
                     .size(palette.tooltip_text_size)
                     .color(palette.tooltip_text_color),
             )
@@ -409,6 +458,7 @@ pub fn handle_draw_windows_buttons(ui: &mut egui::Ui, hwnd: Option<HWND>, palett
             }
         }
     }
+    ui.spacing_mut().item_spacing.x = old_item_spacing_x;
 }
 
 pub fn toggle_window_fullscreen(hwnd: HWND) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,7 +30,7 @@ fn main() -> eframe::Result<()> {
         }
     };
 
-    let _instance_guard = if launch_options.new_window {
+    let _instance_guard = if launch_options.new_window || launch_paths.is_empty() {
         None
     } else {
         match acquire_or_forward(&launch_paths) {


### PR DESCRIPTION
## 🆕 What's New

- Tabs now grow smaller as you add more, until there's too many tabs and now there's navigation buttons
- Tabs area can now be scrolled with the mousewheel
- Special folder icons for folders like Music, My Documents, Videos, etc
- Sidebar Item Vertical Spacing customization (Theme)
- Extra Small gallery view size
- All column sizes and visibility are persisted across app runs and they are divided into 3 categories; file explorer, drive view, and recycle bin view

## 🔄 What's Changed

- egui updated to 0.35.0
- EdenExplorer customization of dropdown controls
- Windows buttons are now perfectly aligned and are larger, more consistent with Windows 11 UI
- File Explorer icon updated to the new phosphor tabs icon
- Split view icons updated to be more in line with UI standards
- Tab split view appears in the topbar and only displays when in Tab/File Explorer view
- Re-order topbar items and added a separator
- Vertical scrollbar hit detection now consistent regardless of window size or tablebuilder size

## 🐛 What's Fixed

- Icons and padding in gallery view (or thumbnails) scale dynamically according to the size
- Tab split view was heavily under-architectured and wasn't following my pattern designs, so gave it a large overhaul and fixed focus issues
