### PR TITLE
feat: persist directory settings, add multi-col sort, fix Win10 bug

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "EdenExplorer"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "bincode",
  "chrono",

--- a/README.md
+++ b/README.md
@@ -276,9 +276,10 @@
 - [x] New Explorer view that displays media files in small/medium/large/extra large format
 - [x] Add special icons for Desktop, Downloads, My User Home, Music, Videos, My Documents
 - [x] CLI now accepts `::MY_PC::`, `::RECYCLE_BIN::`, `shell:MyComputerFolder`, and `shell:RecycleBinFolder` as valid directories
+- [x] Lexicographic multi-column sorting using Shift+Click to add columns to sort rows or Ctrl+Click to remove column sorting
+- [x] Directory column sorting, sizing, and view changes persist across sessions
 
 ### 🚀 Upcoming Alpha Features
-- [ ] Support multi-column sorting (smart grouping)
 - [ ] Add multi-tagging of objects
 - [ ] Enhanced theme customization, such as custom layouts, mix/match UI elements, styles, etc
 - [ ] Support network devices

--- a/src/build.rs
+++ b/src/build.rs
@@ -16,6 +16,25 @@ fn main() {
         res.set("ProductVersion", env!("CARGO_PKG_VERSION"));
         res.set("OriginalFilename", "EdenExplorer.exe");
 
+        res.set_manifest(
+            r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
+    <security>
+      <requestedPrivileges>
+        <requestedExecutionLevel level="asInvoker" uiAccess="false" />
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/pm</dpiAware>
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>
+    </windowsSettings>
+  </application>
+</assembly>"#,
+        );
+
         res.compile().expect("Failed to compile Windows resources");
     }
 }

--- a/src/core/indexer.rs
+++ b/src/core/indexer.rs
@@ -1,6 +1,7 @@
 use crate::core::fs::{DateStyle, MY_PC_PATH};
 use crate::gui::theme::{THEME_VERSION, ThemePalette, get_default_palette};
 use crate::gui::windows::containers::enums::ItemViewerHeaderColumn;
+use crate::gui::windows::containers::structs::{GalleryThumbnailSize, ItemViewerDisplayMode};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
@@ -63,6 +64,39 @@ struct AppSettingsSnapshot {
     item_viewer_drive_column_sizes: Vec<f32>,
     #[serde(default = "default_recycle_bin_column_size")]
     recycle_bin_column_sizes: Vec<f32>,
+    #[serde(default)]
+    directory_settings: Vec<DirectorySettingsSnapshot>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct DirectorySettingsSnapshot {
+    pub directory: PathBuf,
+    #[serde(default = "default_item_viewer_file_column_order")]
+    pub item_viewer_file_column_order: Vec<ItemViewerHeaderColumn>,
+    #[serde(default = "default_item_viewer_drive_column_order")]
+    pub item_viewer_drive_column_order: Vec<ItemViewerHeaderColumn>,
+    #[serde(default = "default_recycle_bin_column_order")]
+    pub recycle_bin_column_order: Vec<ItemViewerHeaderColumn>,
+    #[serde(default = "default_item_viewer_file_column_size")]
+    pub item_viewer_file_column_sizes: Vec<f32>,
+    #[serde(default = "default_item_viewer_drive_column_size")]
+    pub item_viewer_drive_column_sizes: Vec<f32>,
+    #[serde(default = "default_recycle_bin_column_size")]
+    pub recycle_bin_column_sizes: Vec<f32>,
+    #[serde(default)]
+    pub filter_query: String,
+    #[serde(default)]
+    pub display_mode: ItemViewerDisplayMode,
+    #[serde(default = "default_gallery_thumbnail_size")]
+    pub gallery_thumbnail_size: GalleryThumbnailSize,
+    #[serde(default = "default_sort_column")]
+    pub sort_column: crate::gui::utils::SortColumn,
+    #[serde(default)]
+    pub sort_ascending: bool,
+}
+
+fn default_gallery_thumbnail_size() -> GalleryThumbnailSize {
+    GalleryThumbnailSize::Medium
 }
 
 // Legacy snapshot struct for deserializing old settings with HalfScreen
@@ -106,6 +140,7 @@ impl From<LegacyAppSettingsSnapshot> for AppSettingsSnapshot {
             item_viewer_file_column_sizes: default_item_viewer_file_column_size(),
             item_viewer_drive_column_sizes: default_item_viewer_drive_column_size(),
             recycle_bin_column_sizes: default_recycle_bin_column_size(),
+            directory_settings: Vec::new(),
         }
     }
 }
@@ -355,6 +390,7 @@ pub fn load_app_settings() -> (
     Vec<f32>,
     Vec<f32>,
     Vec<f32>,
+    Vec<DirectorySettingsSnapshot>,
 ) {
     let default_path = PathBuf::from(MY_PC_PATH);
 
@@ -393,6 +429,7 @@ pub fn load_app_settings() -> (
         snapshot.item_viewer_file_column_sizes,
         snapshot.item_viewer_drive_column_sizes,
         snapshot.recycle_bin_column_sizes,
+        snapshot.directory_settings,
     )
 }
 
@@ -418,6 +455,7 @@ fn default_app_settings(
     Vec<f32>,
     Vec<f32>,
     Vec<f32>,
+    Vec<DirectorySettingsSnapshot>,
 ) {
     (
         true,
@@ -439,6 +477,7 @@ fn default_app_settings(
         default_item_viewer_file_column_size(),
         default_item_viewer_drive_column_size(),
         default_recycle_bin_column_size(),
+        Vec::new(),
     )
 }
 
@@ -462,6 +501,7 @@ pub fn save_app_settings(
     item_viewer_file_column_sizes: &[f32],
     item_viewer_drive_column_sizes: &[f32],
     recycle_bin_column_sizes: &[f32],
+    directory_settings: &[DirectorySettingsSnapshot],
 ) {
     let path = match settings_cache_path() {
         Some(path) => path,
@@ -488,6 +528,7 @@ pub fn save_app_settings(
         item_viewer_file_column_sizes: item_viewer_file_column_sizes.to_vec(),
         item_viewer_drive_column_sizes: item_viewer_drive_column_sizes.to_vec(),
         recycle_bin_column_sizes: recycle_bin_column_sizes.to_vec(),
+        directory_settings: directory_settings.to_vec(),
     };
     if let Ok(data) = postcard::to_allocvec(&snapshot) {
         let _ = std::fs::write(path, data);

--- a/src/core/indexer.rs
+++ b/src/core/indexer.rs
@@ -1,5 +1,6 @@
 use crate::core::fs::{DateStyle, MY_PC_PATH};
 use crate::gui::theme::{THEME_VERSION, ThemePalette, get_default_palette};
+use crate::gui::utils::SortKey;
 use crate::gui::windows::containers::enums::ItemViewerHeaderColumn;
 use crate::gui::windows::containers::structs::{GalleryThumbnailSize, ItemViewerDisplayMode};
 use serde::{Deserialize, Serialize};
@@ -93,6 +94,8 @@ pub struct DirectorySettingsSnapshot {
     pub sort_column: crate::gui::utils::SortColumn,
     #[serde(default)]
     pub sort_ascending: bool,
+    #[serde(default)]
+    pub sort_keys: Vec<SortKey>,
 }
 
 fn default_gallery_thumbnail_size() -> GalleryThumbnailSize {

--- a/src/core/utils/sorting.rs
+++ b/src/core/utils/sorting.rs
@@ -1,6 +1,6 @@
 use crate::core::fs::FileItem;
 use serde::{Deserialize, Serialize};
-use std::cmp::Ordering::{Greater, Less};
+use std::cmp::Ordering::{Equal, Greater, Less};
 
 #[derive(PartialEq, Clone, Copy, Debug, Serialize, Deserialize)]
 pub enum SortColumn {
@@ -13,41 +13,53 @@ pub enum SortColumn {
     OriginalDirectory,
 }
 
-pub fn sort_files(files: &mut Vec<FileItem>, column: SortColumn, ascending: bool) {
+#[derive(PartialEq, Clone, Copy, Debug, Serialize, Deserialize)]
+pub struct SortKey {
+    pub column: SortColumn,
+    pub ascending: bool,
+}
+
+pub fn sort_files_by_keys(files: &mut Vec<FileItem>, keys: &[SortKey]) {
     files.sort_by(|a, b| {
         if a.is_dir != b.is_dir {
             return if a.is_dir { Less } else { Greater };
         }
 
-        let ord = match column {
-            SortColumn::Name => a.name.to_lowercase().cmp(&b.name.to_lowercase()),
-            SortColumn::Size => a.file_size.unwrap_or(0).cmp(&b.file_size.unwrap_or(0)),
-            SortColumn::Modified => a.modified_time_raw.cmp(&b.modified_time_raw),
-            SortColumn::Created => a.created_time_raw.cmp(&b.created_time_raw),
-            SortColumn::Deleted => a.deleted_time_raw.cmp(&b.deleted_time_raw),
-            SortColumn::OriginalDirectory => a.original_directory.cmp(&b.original_directory),
-            SortColumn::Type => match (a.is_dir, b.is_dir) {
-                (true, false) => Less,
-                (false, true) => Greater,
-                (true, true) => a.name.to_lowercase().cmp(&b.name.to_lowercase()),
-                (false, false) => {
-                    let a_ext = a
-                        .path
-                        .extension()
-                        .and_then(|s| s.to_str())
-                        .unwrap_or("")
-                        .to_lowercase();
-                    let b_ext = b
-                        .path
-                        .extension()
-                        .and_then(|s| s.to_str())
-                        .unwrap_or("")
-                        .to_lowercase();
-                    a_ext.cmp(&b_ext)
-                }
-            },
-        };
+        for key in keys {
+            let ord = match key.column {
+                SortColumn::Name => a.name.to_lowercase().cmp(&b.name.to_lowercase()),
+                SortColumn::Size => a.file_size.unwrap_or(0).cmp(&b.file_size.unwrap_or(0)),
+                SortColumn::Modified => a.modified_time_raw.cmp(&b.modified_time_raw),
+                SortColumn::Created => a.created_time_raw.cmp(&b.created_time_raw),
+                SortColumn::Deleted => a.deleted_time_raw.cmp(&b.deleted_time_raw),
+                SortColumn::OriginalDirectory => a.original_directory.cmp(&b.original_directory),
+                SortColumn::Type => match (a.is_dir, b.is_dir) {
+                    (true, false) => Less,
+                    (false, true) => Greater,
+                    (true, true) => a.name.to_lowercase().cmp(&b.name.to_lowercase()),
+                    (false, false) => {
+                        let a_ext = a
+                            .path
+                            .extension()
+                            .and_then(|s| s.to_str())
+                            .unwrap_or("")
+                            .to_lowercase();
+                        let b_ext = b
+                            .path
+                            .extension()
+                            .and_then(|s| s.to_str())
+                            .unwrap_or("")
+                            .to_lowercase();
+                        a_ext.cmp(&b_ext)
+                    }
+                },
+            };
 
-        if ascending { ord } else { ord.reverse() }
+            if ord != Equal {
+                return if key.ascending { ord } else { ord.reverse() };
+            }
+        }
+
+        Equal
     });
 }

--- a/src/gui/windows/containers/enums.rs
+++ b/src/gui/windows/containers/enums.rs
@@ -21,7 +21,11 @@ pub enum ItemViewerHeaderColumn {
 }
 
 pub enum ItemViewerAction {
-    Sort(SortColumn),
+    Sort {
+        column: SortColumn,
+        additive: bool,
+        remove: bool,
+    },
     ToggleColumnVisibility(ItemViewerHeaderColumn),
     FitColumn(ItemViewerHeaderColumn),
     FitAllColumns,

--- a/src/gui/windows/containers/itemviewer.rs
+++ b/src/gui/windows/containers/itemviewer.rs
@@ -278,7 +278,9 @@ pub fn draw_item_viewer(
                 .id_salt((
                     "item_viewer_table",
                     active_tab_id,
-                    column_layout.layout_generation,
+                    &current_dir,
+                    is_drive_view,
+                    is_recycle_bin_view,
                 ));
 
             // If we have a pending selection from a refresh, scroll to it and select it

--- a/src/gui/windows/containers/itemviewer.rs
+++ b/src/gui/windows/containers/itemviewer.rs
@@ -63,6 +63,7 @@ pub fn draw_item_viewer(
     let files = &view.files;
     let sort_column = view.sort_column;
     let sort_ascending = view.sort_ascending;
+    let sort_keys = view.sort_keys.clone();
     let column_state = &mut view.column_state;
     let filter_state = &mut view.item_viewer_filter_state;
     let drag_state = &mut view.drag_state;
@@ -261,6 +262,15 @@ pub fn draw_item_viewer(
         ui.scope_builder(egui::UiBuilder::new().max_rect(table_rect), |ui| {
             ui.visuals_mut().widgets.noninteractive.bg_stroke =
                 egui::Stroke::new(1.0, palette.borders_default);
+            let table_id_salt = egui::Id::new((
+                "item_viewer_table",
+                active_tab_id,
+                &current_dir,
+                is_drive_view,
+                is_recycle_bin_view,
+                column_state.layout_generation,
+            ));
+            let table_state_id = ui.id().with(table_id_salt);
             let mut table = TableBuilder::new(ui)
                 .vscroll(true)
                 .max_scroll_height(available_height)
@@ -275,13 +285,7 @@ pub fn draw_item_viewer(
                 })
                 .animate_scrolling(true)
                 .resizable(true)
-                .id_salt((
-                    "item_viewer_table",
-                    active_tab_id,
-                    &current_dir,
-                    is_drive_view,
-                    is_recycle_bin_view,
-                ));
+                .id_salt(table_id_salt);
 
             // If we have a pending selection from a refresh, scroll to it and select it
             if let Some(pending_paths) = explorer_state.pending_selection_paths.clone() {
@@ -401,8 +405,7 @@ pub fn draw_item_viewer(
                         &column_layout.ordered_columns,
                         &filter_state.cached_indices,
                         files,
-                        sort_column,
-                        sort_ascending,
+                        &sort_keys,
                         &palette,
                         explorer_state,
                         &*column_state,
@@ -629,6 +632,54 @@ pub fn draw_item_viewer(
 
                     action = Some(ItemViewerAction::ColumnSizesChanged);
                 }
+            }
+
+            let divider_tolerance = ui.style().interaction.resize_grab_radius_side + 3.0;
+            let divider_double_clicked_column = ui.ctx().input(|input| {
+                let Some(pointer_pos) = input.pointer.interact_pos() else {
+                    return None;
+                };
+                if !input
+                    .pointer
+                    .button_double_clicked(egui::PointerButton::Primary)
+                    || !table_rect.contains(pointer_pos)
+                {
+                    return None;
+                }
+
+                let spacing_x = ui.spacing().item_spacing.x;
+                let mut divider_x = table_rect.left() - spacing_x * 0.5;
+                for (table_index, width) in actual_column_widths.iter().enumerate() {
+                    divider_x += *width + spacing_x;
+                    if (pointer_pos.x - divider_x).abs() <= divider_tolerance {
+                        return table_index.checked_sub(checkbox_column_count).and_then(
+                            |column_index| column_layout.ordered_columns.get(column_index).copied(),
+                        );
+                    }
+                }
+                None
+            });
+
+            if let Some(column) = divider_double_clicked_column {
+                action = Some(ItemViewerAction::FitColumn(column));
+            }
+
+            let divider_double_clicked_column = (0..actual_column_widths.len()).find_map(|index| {
+                let resize_id = table_state_id.with("resize_column").with(index);
+                ui.ctx()
+                    .read_response(resize_id)
+                    .filter(|response| response.double_clicked())
+                    .and_then(|_| {
+                        index
+                            .checked_sub(checkbox_column_count)
+                            .and_then(|column_index| {
+                                column_layout.ordered_columns.get(column_index).copied()
+                            })
+                    })
+            });
+
+            if let Some(column) = divider_double_clicked_column {
+                action = Some(ItemViewerAction::FitColumn(column));
             }
 
             if let Some(rect) = hovered_drop_target_rect {

--- a/src/gui/windows/containers/itemviewer_gallery.rs
+++ b/src/gui/windows/containers/itemviewer_gallery.rs
@@ -476,21 +476,7 @@ fn draw_gallery_toolbar(
                     )
                     .clicked()
                 {
-                    gallery_state.thumbnail_size = size;
-                    gallery_state.thumbnail_gap = match size {
-                        GalleryThumbnailSize::ExtraSmall => 0.0,
-                        GalleryThumbnailSize::Small => 4.0,
-                        GalleryThumbnailSize::Medium => 8.0,
-                        GalleryThumbnailSize::Large => 12.0,
-                        GalleryThumbnailSize::ExtraLarge => 16.0,
-                    };
-                    gallery_state.thumbnail_padding = match size {
-                        GalleryThumbnailSize::ExtraSmall => 0.0,
-                        GalleryThumbnailSize::Small => 2.0,
-                        GalleryThumbnailSize::Medium => 6.0,
-                        GalleryThumbnailSize::Large => 8.0,
-                        GalleryThumbnailSize::ExtraLarge => 10.0,
-                    };
+                    gallery_state.set_thumbnail_size(size);
                 }
             }
         },

--- a/src/gui/windows/containers/itemviewer_gallery.rs
+++ b/src/gui/windows/containers/itemviewer_gallery.rs
@@ -449,7 +449,12 @@ fn draw_gallery_toolbar(
                         (SortColumn::Created, i18n.tr("explorer_cols_created")),
                     ] {
                         if ui.selectable_label(sort_column == column, label).clicked() {
-                            action = Some(ItemViewerAction::Sort(column));
+                            let modifiers = ui.input(|input| input.modifiers);
+                            action = Some(ItemViewerAction::Sort {
+                                column,
+                                additive: modifiers.shift,
+                                remove: modifiers.ctrl,
+                            });
                             ui.close();
                         }
                     }

--- a/src/gui/windows/containers/itemviewer_helper.rs
+++ b/src/gui/windows/containers/itemviewer_helper.rs
@@ -1195,6 +1195,20 @@ fn draw_header_cell(
     header.col(|ui| {
         let cell_id = ui.id().with(("itemviewer_header_cell", column));
         let cell_resp = ui.interact(ui.max_rect(), cell_id, egui::Sense::click());
+        let cell_rect = cell_resp.rect;
+        let divider_rect = egui::Rect::from_min_max(
+            egui::pos2(cell_rect.right() - 8.0, cell_rect.top()),
+            egui::pos2(cell_rect.right() + 12.0, cell_rect.bottom()),
+        );
+        let divider_double_clicked = ui.input(|input| {
+            input
+                .pointer
+                .button_double_clicked(egui::PointerButton::Primary)
+                && input
+                    .pointer
+                    .interact_pos()
+                    .is_some_and(|pos| divider_rect.contains(pos))
+        });
         let (sort_label, arrow) = match column_action {
             Some(SortColumn::Name) if sort_column == SortColumn::Name => (
                 label.clone(),
@@ -1274,6 +1288,9 @@ fn draw_header_cell(
             && let Some(col) = column_action
         {
             *action = Some(ItemViewerAction::Sort(col));
+        }
+        if divider_double_clicked {
+            *action = Some(ItemViewerAction::FitColumn(column));
         }
 
         let order = column_state.order(is_drive_view, is_recycle_bin_view);
@@ -1785,7 +1802,6 @@ pub fn compute_item_viewer_column_layout(
     viewport_width: f32,
 ) -> ItemViewerColumnLayout {
     let fit_request = column_state.pending_fit_request.take();
-    let layout_generation = column_state.layout_generation;
     let ordered_columns = column_state.visible_order(is_drive_view, is_recycle_bin_view);
 
     let mut column_sizes_changed = false;
@@ -1947,7 +1963,6 @@ pub fn compute_item_viewer_column_layout(
     };
 
     ItemViewerColumnLayout {
-        layout_generation,
         ordered_columns,
         name_width,
         type_width,

--- a/src/gui/windows/containers/itemviewer_helper.rs
+++ b/src/gui/windows/containers/itemviewer_helper.rs
@@ -9,7 +9,7 @@ use crate::gui::i18n::I18n;
 use crate::gui::icons::IconCache;
 use crate::gui::theme::{ThemePalette, apply_checkbox_colors};
 use crate::gui::utils::{
-    SortColumn, clear_clipboard_files, drive_usage_bar, format_size, get_file_type_name,
+    SortColumn, SortKey, clear_clipboard_files, drive_usage_bar, format_size, get_file_type_name,
     truncate_item_text,
 };
 use crate::gui::windows::containers::enums::{
@@ -1104,8 +1104,7 @@ pub fn draw_item_viewer_header(
     ordered_columns: &[ItemViewerHeaderColumn],
     filtered_indices: &[usize],
     files: &[FileItem],
-    sort_column: SortColumn,
-    sort_ascending: bool,
+    sort_keys: &[SortKey],
     palette: &crate::gui::theme::ThemePalette,
     explorer_state: &mut ExplorerState,
     column_state: &ItemViewerColumnState,
@@ -1151,8 +1150,7 @@ pub fn draw_item_viewer_header(
             i18n,
             palette,
             &font_id,
-            sort_column,
-            sort_ascending,
+            sort_keys,
             column,
             label,
             &mut action,
@@ -1170,8 +1168,7 @@ fn draw_header_cell(
     i18n: &I18n,
     palette: &crate::gui::theme::ThemePalette,
     font_id: &FontId,
-    sort_column: SortColumn,
-    sort_ascending: bool,
+    sort_keys: &[SortKey],
     column: ItemViewerHeaderColumn,
     label: String,
     action: &mut Option<ItemViewerAction>,
@@ -1195,81 +1192,17 @@ fn draw_header_cell(
     header.col(|ui| {
         let cell_id = ui.id().with(("itemviewer_header_cell", column));
         let cell_resp = ui.interact(ui.max_rect(), cell_id, egui::Sense::click());
-        let cell_rect = cell_resp.rect;
-        let divider_rect = egui::Rect::from_min_max(
-            egui::pos2(cell_rect.right() - 8.0, cell_rect.top()),
-            egui::pos2(cell_rect.right() + 12.0, cell_rect.bottom()),
-        );
-        let divider_double_clicked = ui.input(|input| {
-            input
-                .pointer
-                .button_double_clicked(egui::PointerButton::Primary)
-                && input
-                    .pointer
-                    .interact_pos()
-                    .is_some_and(|pos| divider_rect.contains(pos))
-        });
-        let (sort_label, arrow) = match column_action {
-            Some(SortColumn::Name) if sort_column == SortColumn::Name => (
-                label.clone(),
-                if sort_ascending {
+        let arrow = column_action
+            .and_then(|column| sort_keys.iter().find(|key| key.column == column))
+            .map(|key| {
+                if key.ascending {
                     regular::CARET_UP
                 } else {
                     regular::CARET_DOWN
-                },
-            ),
-            Some(SortColumn::Type) if sort_column == SortColumn::Type => (
-                label.clone(),
-                if sort_ascending {
-                    regular::CARET_UP
-                } else {
-                    regular::CARET_DOWN
-                },
-            ),
-            Some(SortColumn::Size) if sort_column == SortColumn::Size => (
-                label.clone(),
-                if sort_ascending {
-                    regular::CARET_UP
-                } else {
-                    regular::CARET_DOWN
-                },
-            ),
-            Some(SortColumn::Modified) if sort_column == SortColumn::Modified => (
-                label.clone(),
-                if sort_ascending {
-                    regular::CARET_UP
-                } else {
-                    regular::CARET_DOWN
-                },
-            ),
-            Some(SortColumn::Created) if sort_column == SortColumn::Created => (
-                label.clone(),
-                if sort_ascending {
-                    regular::CARET_UP
-                } else {
-                    regular::CARET_DOWN
-                },
-            ),
-            Some(SortColumn::Deleted) if sort_column == SortColumn::Deleted => (
-                label.clone(),
-                if sort_ascending {
-                    regular::CARET_UP
-                } else {
-                    regular::CARET_DOWN
-                },
-            ),
-            Some(SortColumn::OriginalDirectory) if sort_column == SortColumn::OriginalDirectory => {
-                (
-                    label.clone(),
-                    if sort_ascending {
-                        regular::CARET_UP
-                    } else {
-                        regular::CARET_DOWN
-                    },
-                )
-            }
-            _ => (label.clone(), ""),
-        };
+                }
+            })
+            .unwrap_or("");
+        let sort_label = label;
 
         ui.add(
             egui::Label::new(
@@ -1287,12 +1220,13 @@ fn draw_header_cell(
         if cell_resp.clicked()
             && let Some(col) = column_action
         {
-            *action = Some(ItemViewerAction::Sort(col));
+            let modifiers = ui.input(|input| input.modifiers);
+            *action = Some(ItemViewerAction::Sort {
+                column: col,
+                additive: modifiers.shift,
+                remove: modifiers.ctrl,
+            });
         }
-        if divider_double_clicked {
-            *action = Some(ItemViewerAction::FitColumn(column));
-        }
-
         let order = column_state.order(is_drive_view, is_recycle_bin_view);
         let order_index = order.iter().position(|c| *c == column);
 
@@ -1850,6 +1784,8 @@ pub fn compute_item_viewer_column_layout(
                 column_sizes_changed = true;
             }
         }
+
+        column_state.layout_generation = column_state.layout_generation.wrapping_add(1);
     }
 
     // Default widths are only used when a column has never been explicitly

--- a/src/gui/windows/containers/structs.rs
+++ b/src/gui/windows/containers/structs.rs
@@ -5,7 +5,7 @@ use crate::core::indexer::{
     default_recycle_bin_column_size,
 };
 use crate::core::utils::thumbnails::ThumbnailService;
-use crate::gui::utils::hsl_to_color32;
+use crate::gui::utils::{SortKey, hsl_to_color32};
 use crate::gui::windows::containers::enums::{
     ItemViewerAction, ItemViewerHeaderColumn, ItemViewerNavAction,
 };
@@ -76,6 +76,7 @@ pub struct TabView {
     pub breadcrumb_path_error_animation_time: f64,
     pub sort_column: crate::gui::utils::SortColumn,
     pub sort_ascending: bool,
+    pub sort_keys: Vec<SortKey>,
     pub explorer_state: ExplorerState,
     pub item_viewer_filter_state: FilterState,
     pub column_state: ItemViewerColumnState,
@@ -109,6 +110,10 @@ impl TabView {
             breadcrumb_path_error_animation_time: 0.0,
             sort_column: default_sort_column,
             sort_ascending: default_sort_ascending,
+            sort_keys: vec![SortKey {
+                column: default_sort_column,
+                ascending: default_sort_ascending,
+            }],
             explorer_state: ExplorerState::default(),
             item_viewer_filter_state: FilterState::default(),
             column_state: ItemViewerColumnState::default(),
@@ -131,6 +136,7 @@ impl TabView {
     /// and sort as `self`, but with its own (empty) selection/filter/listing.
     pub fn duplicate_as_new(&self) -> Self {
         let mut view = Self::new(self.nav.clone(), self.sort_column, self.sort_ascending);
+        view.sort_keys = self.sort_keys.clone();
         view.column_state = self.column_state.clone();
         view.display_mode = self.display_mode;
         view.gallery_state = self.gallery_state;

--- a/src/gui/windows/containers/structs.rs
+++ b/src/gui/windows/containers/structs.rs
@@ -14,6 +14,7 @@ use crate::gui::windows::structs::Navigation;
 use crossbeam_channel::{Receiver, Sender};
 use egui::Color32;
 use rand::Rng;
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::collections::VecDeque;
@@ -137,19 +138,31 @@ impl TabView {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ItemViewerDisplayMode {
     Details,
     Gallery,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+impl Default for ItemViewerDisplayMode {
+    fn default() -> Self {
+        Self::Details
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum GalleryThumbnailSize {
     ExtraSmall,
     Small,
     Medium,
     Large,
     ExtraLarge,
+}
+
+impl Default for GalleryThumbnailSize {
+    fn default() -> Self {
+        Self::Medium
+    }
 }
 
 impl GalleryThumbnailSize {
@@ -188,6 +201,26 @@ impl Default for GalleryState {
             thumbnail_gap: 12.0,
             thumbnail_padding: 6.0,
         }
+    }
+}
+
+impl GalleryState {
+    pub fn set_thumbnail_size(&mut self, size: GalleryThumbnailSize) {
+        self.thumbnail_size = size;
+        self.thumbnail_gap = match size {
+            GalleryThumbnailSize::ExtraSmall => 0.0,
+            GalleryThumbnailSize::Small => 4.0,
+            GalleryThumbnailSize::Medium => 8.0,
+            GalleryThumbnailSize::Large => 12.0,
+            GalleryThumbnailSize::ExtraLarge => 16.0,
+        };
+        self.thumbnail_padding = match size {
+            GalleryThumbnailSize::ExtraSmall => 0.0,
+            GalleryThumbnailSize::Small => 2.0,
+            GalleryThumbnailSize::Medium => 6.0,
+            GalleryThumbnailSize::Large => 8.0,
+            GalleryThumbnailSize::ExtraLarge => 10.0,
+        };
     }
 }
 
@@ -436,16 +469,6 @@ impl ItemViewerColumnState {
             widths.usage_width,
         );
     }
-    pub fn column_sizes(&self, is_drive_view: bool, is_recycle_bin_view: bool) -> &[f32] {
-        if is_drive_view {
-            &self.drive_column_sizes
-        } else if is_recycle_bin_view {
-            &self.recycle_bin_column_sizes
-        } else {
-            &self.file_column_sizes
-        }
-    }
-
     pub fn from_orders(
         file_column_order: Vec<ItemViewerHeaderColumn>,
         drive_column_order: Vec<ItemViewerHeaderColumn>,
@@ -1103,7 +1126,6 @@ pub fn default_tag_color() -> Color32 {
 }
 
 pub struct ItemViewerColumnLayout {
-    pub layout_generation: u64,
     pub ordered_columns: Vec<ItemViewerHeaderColumn>,
     pub name_width: f32,
     pub type_width: f32,

--- a/src/gui/windows/mainwindow.rs
+++ b/src/gui/windows/mainwindow.rs
@@ -23,7 +23,8 @@ use crate::gui::windows::containers::tags::{
 };
 use crate::gui::windows::containers::topbar::draw_topbar;
 use crate::gui::windows::mainwindow_imp::{
-    handle_draw_customizetheme_window, handle_pending_actions,
+    apply_directory_settings_to_view, directory_settings_snapshot_for_view,
+    handle_draw_customizetheme_window, handle_pending_actions, persist_directory_settings_snapshot,
 };
 use crate::gui::windows::structs::{
     AboutWindow, AppSettings, Navigation, SettingsWindow, SidebarState, ThemeCustomizer,
@@ -114,6 +115,7 @@ impl Default for MainWindow {
             item_viewer_file_column_sizes,
             item_viewer_drive_column_sizes,
             recycle_bin_column_sizes,
+            directory_settings,
         ) = load_app_settings();
         let loaded_settings = AppSettings {
             folder_scanning_enabled,
@@ -134,6 +136,7 @@ impl Default for MainWindow {
             item_viewer_file_column_sizes,
             item_viewer_drive_column_sizes,
             recycle_bin_column_sizes,
+            directory_settings,
         };
 
         let system_locale = sys_locale::get_locale().unwrap_or_else(|| "en-US".to_string());
@@ -247,6 +250,14 @@ impl Default for MainWindow {
 
         app.i18n.set_locale(lang);
         app.settings_window.current_settings = loaded_settings;
+
+        let current_settings = app.settings_window.current_settings.clone();
+        for tab in &mut app.tabs {
+            apply_directory_settings_to_view(&mut tab.primary_view, &current_settings);
+            if let Some(split) = tab.split_view.as_mut() {
+                apply_directory_settings_to_view(split, &current_settings);
+            }
+        }
 
         match load_theme_settings() {
             Some((light, dark)) => {
@@ -449,6 +460,7 @@ impl eframe::App for MainWindow {
                             .settings_window
                             .current_settings
                             .recycle_bin_column_sizes,
+                        &self.settings_window.current_settings.directory_settings,
                     );
 
                     self.last_window_size = Some(current_size);
@@ -810,6 +822,19 @@ impl eframe::App for MainWindow {
                                                             );
                                                             tabbar_action = a;
                                                             pending_action = b;
+                                                            let snapshot =
+                                                                directory_settings_snapshot_for_view(
+                                                                    &self.tabs[self.active_tab]
+                                                                        .primary_view,
+                                                                );
+                                                            let _ =
+                                                                persist_directory_settings_snapshot(
+                                                                    &mut self
+                                                                        .settings_window
+                                                                        .current_settings
+                                                                        .directory_settings,
+                                                                    snapshot,
+                                                                );
                                                         },
                                                     );
                                                 });
@@ -892,6 +917,21 @@ impl eframe::App for MainWindow {
                                                             );
                                                             secondary_tabbar_action = a;
                                                             secondary_pending_action = b;
+                                                            let snapshot =
+                                                                directory_settings_snapshot_for_view(
+                                                                    self.tabs[self.active_tab]
+                                                                        .split_view
+                                                                        .as_ref()
+                                                                        .unwrap(),
+                                                                );
+                                                            let _ =
+                                                                persist_directory_settings_snapshot(
+                                                                    &mut self
+                                                                        .settings_window
+                                                                        .current_settings
+                                                                        .directory_settings,
+                                                                    snapshot,
+                                                                );
                                                         },
                                                     );
                                                 });
@@ -942,6 +982,17 @@ impl eframe::App for MainWindow {
                                             );
                                             tabbar_action = a;
                                             pending_action = b;
+                                            let snapshot =
+                                                directory_settings_snapshot_for_view(
+                                                    &self.tabs[self.active_tab].primary_view,
+                                                );
+                                            let _ = persist_directory_settings_snapshot(
+                                                &mut self
+                                                    .settings_window
+                                                    .current_settings
+                                                    .directory_settings,
+                                                snapshot,
+                                            );
                                         }
                                     });
                                 },

--- a/src/gui/windows/mainwindow_imp.rs
+++ b/src/gui/windows/mainwindow_imp.rs
@@ -11,8 +11,8 @@ use crate::gui::theme::{
     ThemeMode, ThemePalette, apply_font_to_context, get_default_palette, set_palette,
 };
 use crate::gui::utils::{
-    SortColumn, clear_clipboard_files, get_clipboard_files, is_clipboard_cut, set_clipboard_files,
-    shell_delete_to_recycle_bin, show_copy_move_dialog, sort_files,
+    SortColumn, SortKey, clear_clipboard_files, get_clipboard_files, is_clipboard_cut,
+    set_clipboard_files, shell_delete_to_recycle_bin, show_copy_move_dialog, sort_files_by_keys,
 };
 use crate::gui::windows::about::draw_about_window;
 use crate::gui::windows::containers::enums::{
@@ -78,6 +78,10 @@ pub(crate) fn default_directory_settings_snapshot(directory: PathBuf) -> Directo
         gallery_thumbnail_size: GalleryThumbnailSize::Medium,
         sort_column: SortColumn::Name,
         sort_ascending: true,
+        sort_keys: vec![SortKey {
+            column: SortColumn::Name,
+            ascending: true,
+        }],
     }
 }
 
@@ -95,6 +99,7 @@ pub(crate) fn directory_settings_snapshot_for_view(view: &TabView) -> DirectoryS
         gallery_thumbnail_size: view.gallery_state.thumbnail_size,
         sort_column: view.sort_column,
         sort_ascending: view.sort_ascending,
+        sort_keys: view.sort_keys.clone(),
     }
 }
 
@@ -121,13 +126,26 @@ pub(crate) fn apply_directory_settings_to_view(view: &mut TabView, settings: &Ap
         view.display_mode = snapshot.display_mode;
         view.gallery_state
             .set_thumbnail_size(snapshot.gallery_thumbnail_size);
-        view.sort_column = snapshot.sort_column;
-        view.sort_ascending = snapshot.sort_ascending;
+        view.sort_keys = if snapshot.sort_keys.is_empty() {
+            vec![SortKey {
+                column: snapshot.sort_column,
+                ascending: snapshot.sort_ascending,
+            }]
+        } else {
+            snapshot.sort_keys.clone()
+        };
+        let primary = view.sort_keys[0];
+        view.sort_column = primary.column;
+        view.sort_ascending = primary.ascending;
     } else {
         view.column_state = default_column_state(settings);
         view.item_viewer_filter_state = FilterState::default();
         view.display_mode = ItemViewerDisplayMode::Details;
         view.gallery_state = Default::default();
+        view.sort_keys = vec![SortKey {
+            column: settings.sort_column,
+            ascending: settings.sort_ascending,
+        }];
         view.sort_column = settings.sort_column;
         view.sort_ascending = settings.sort_ascending;
     }
@@ -318,24 +336,46 @@ impl MainWindow {
         favorites
     }
 
-    pub fn toggle_sort(&mut self, col: SortColumn) {
+    pub fn toggle_sort(&mut self, col: SortColumn, additive: bool, remove: bool) {
         let side = self.focused_split;
-        let (sort_column, sort_ascending) = {
+        let sort_keys = {
             let view = self.active_tab_mut().view_mut(side);
-            if view.sort_column == col {
-                view.sort_ascending = !view.sort_ascending;
+            if remove {
+                view.sort_keys.retain(|key| key.column != col);
+                if view.sort_keys.is_empty() {
+                    view.sort_keys.push(SortKey {
+                        column: SortColumn::Name,
+                        ascending: true,
+                    });
+                }
+            } else if additive {
+                if let Some(key) = view.sort_keys.iter_mut().find(|key| key.column == col) {
+                    key.ascending = !key.ascending;
+                } else {
+                    view.sort_keys.push(SortKey {
+                        column: col,
+                        ascending: true,
+                    });
+                }
             } else {
-                view.sort_column = col;
-                view.sort_ascending = true;
+                let ascending = view
+                    .sort_keys
+                    .first()
+                    .filter(|key| key.column == col)
+                    .map(|key| !key.ascending)
+                    .unwrap_or(true);
+                view.sort_keys = vec![SortKey {
+                    column: col,
+                    ascending,
+                }];
             }
-            (view.sort_column, view.sort_ascending)
+            let primary = view.sort_keys[0];
+            view.sort_column = primary.column;
+            view.sort_ascending = primary.ascending;
+            view.sort_keys.clone()
         };
 
-        sort_files(
-            &mut self.active_tab_mut().view_mut(side).files,
-            sort_column,
-            sort_ascending,
-        );
+        sort_files_by_keys(&mut self.active_tab_mut().view_mut(side).files, &sort_keys);
 
         let snapshot = directory_settings_snapshot_for_view(self.active_tab().view(side));
         let _ = persist_directory_settings_snapshot(
@@ -442,10 +482,6 @@ impl MainWindow {
             view.item_viewer_filter_state.dirty = true;
             view.item_viewer_filter_state.cached_indices.clear();
         }
-        let (sort_column, sort_ascending) = {
-            let view = self.active_tab().view(side);
-            (view.sort_column, view.sort_ascending)
-        };
         self.folder_sizes.clear();
         self.file_size_text_cache.clear();
         self.folder_size_text_cache.clear();
@@ -482,7 +518,7 @@ impl MainWindow {
                 }
             }
 
-            sort_files(&mut view.files, sort_column, sort_ascending);
+            sort_files_by_keys(&mut view.files, &view.sort_keys);
             return;
         }
 
@@ -523,11 +559,6 @@ impl MainWindow {
             BHID_EnumItems, FOLDERID_RecycleBinFolder, IEnumShellItems, ILFree, ILGetSize,
             IShellItem, SHCreateItemFromIDList, SHGetIDListFromObject, SHGetKnownFolderIDList,
             SIGDN_DESKTOPABSOLUTEPARSING, SIGDN_FILESYSPATH, SIGDN_NORMALDISPLAY,
-        };
-
-        let (sort_column, sort_ascending) = {
-            let view = self.active_tab().view(side);
-            (view.sort_column, view.sort_ascending)
         };
 
         let mut recycle_items = Vec::new();
@@ -659,7 +690,7 @@ impl MainWindow {
 
         let view = self.active_tab_mut().view_mut(side);
         view.files = recycle_items;
-        sort_files(&mut view.files, sort_column, sort_ascending);
+        sort_files_by_keys(&mut view.files, &view.sort_keys);
     }
 
     pub fn create_new_folder(&mut self) {
@@ -2013,12 +2044,8 @@ impl MainWindow {
         }
 
         if updated {
-            let (sort_column, sort_ascending) = {
-                let view = self.active_tab().view(side);
-                (view.sort_column, view.sort_ascending)
-            };
             let view = self.active_tab_mut().view_mut(side);
-            sort_files(&mut view.files, sort_column, sort_ascending);
+            sort_files_by_keys(&mut view.files, &view.sort_keys);
         }
         updated
     }
@@ -2078,13 +2105,9 @@ impl MainWindow {
                 }
             }
 
-            let (sort_column, sort_ascending) = {
-                let view = self.active_tab().view(side);
-                (view.sort_column, view.sort_ascending)
-            };
             let view = self.active_tab_mut().view_mut(side);
             view.files.extend(batch);
-            sort_files(&mut view.files, sort_column, sort_ascending);
+            sort_files_by_keys(&mut view.files, &view.sort_keys);
             any_change = true;
         }
 
@@ -2243,7 +2266,11 @@ pub fn handle_pending_actions(pending_action: Option<ItemViewerAction>, explorer
         }
 
         match action {
-            ItemViewerAction::Sort(col) => explorer.toggle_sort(col),
+            ItemViewerAction::Sort {
+                column,
+                additive,
+                remove,
+            } => explorer.toggle_sort(column, additive, remove),
             ItemViewerAction::ToggleColumnVisibility(column) => {
                 let new_order = {
                     let view = explorer.active_tab_mut().view_mut(side);

--- a/src/gui/windows/mainwindow_imp.rs
+++ b/src/gui/windows/mainwindow_imp.rs
@@ -2,7 +2,8 @@ use crate::core::drives::{get_drive_infos, is_raw_physical_drive_path};
 use crate::core::fs::{FileItem, get_shell_item_metadata};
 use crate::core::fs::{MY_RECYCLE_BIN_PATH, parallel_directory_scan, scan_dir_async};
 use crate::core::indexer::{
-    load_app_settings, save_app_settings, save_favorites, save_tags, save_theme_settings,
+    DirectorySettingsSnapshot, load_app_settings, save_app_settings, save_favorites, save_tags,
+    save_theme_settings,
 };
 use crate::gui::MainWindow;
 use crate::gui::i18n::I18n;
@@ -19,14 +20,15 @@ use crate::gui::windows::containers::enums::{
 };
 use crate::gui::windows::containers::itemviewer_navbar::open_default_terminal;
 use crate::gui::windows::containers::structs::{
-    FavoriteItem, ItemViewerColumnFitRequest, ItemViewerColumnState, ItemViewerFolderSizeState,
-    ItemViewerNavBarAction, RenameState, SidebarAction, SplitSide, TabState, TabsAction,
+    FavoriteItem, FilterState, GalleryThumbnailSize, ItemViewerColumnFitRequest,
+    ItemViewerColumnState, ItemViewerDisplayMode, ItemViewerFolderSizeState,
+    ItemViewerNavBarAction, RenameState, SidebarAction, SplitSide, TabState, TabView, TabsAction,
     TopbarAction,
 };
 use crate::gui::windows::customizetheme::draw_theme_customizer;
 use crate::gui::windows::enums::{SettingsAction, ThemeCustomizerAction};
 use crate::gui::windows::settings::draw_settings_window;
-use crate::gui::windows::structs::{Navigation, ThemeCustomizer};
+use crate::gui::windows::structs::{AppSettings, Navigation, ThemeCustomizer};
 use crate::gui::windows::windowsoverrides::mark_clipboard_dirty;
 use crate::gui::windows::windowsoverrides::toggle_window_fullscreen;
 use crossbeam_channel::Receiver;
@@ -48,6 +50,120 @@ use windows::Win32::UI::WindowsAndMessaging::*;
 use windows::core::{Error, HRESULT};
 
 use windows::{Win32::System::Com::*, Win32::UI::Shell::*, core::*};
+
+pub(crate) fn default_column_state(settings: &AppSettings) -> ItemViewerColumnState {
+    ItemViewerColumnState::from_orders(
+        settings.item_viewer_file_column_order.clone(),
+        settings.item_viewer_drive_column_order.clone(),
+        settings.recycle_bin_column_order.clone(),
+        settings.item_viewer_file_column_sizes.clone(),
+        settings.item_viewer_drive_column_sizes.clone(),
+        settings.recycle_bin_column_sizes.clone(),
+    )
+}
+
+pub(crate) fn default_directory_settings_snapshot(directory: PathBuf) -> DirectorySettingsSnapshot {
+    let default_settings = AppSettings::default();
+
+    DirectorySettingsSnapshot {
+        directory,
+        item_viewer_file_column_order: default_settings.item_viewer_file_column_order,
+        item_viewer_drive_column_order: default_settings.item_viewer_drive_column_order,
+        recycle_bin_column_order: default_settings.recycle_bin_column_order,
+        item_viewer_file_column_sizes: default_settings.item_viewer_file_column_sizes,
+        item_viewer_drive_column_sizes: default_settings.item_viewer_drive_column_sizes,
+        recycle_bin_column_sizes: default_settings.recycle_bin_column_sizes,
+        filter_query: String::new(),
+        display_mode: ItemViewerDisplayMode::Details,
+        gallery_thumbnail_size: GalleryThumbnailSize::Medium,
+        sort_column: SortColumn::Name,
+        sort_ascending: true,
+    }
+}
+
+pub(crate) fn directory_settings_snapshot_for_view(view: &TabView) -> DirectorySettingsSnapshot {
+    DirectorySettingsSnapshot {
+        directory: view.nav.current.clone(),
+        item_viewer_file_column_order: view.column_state.file_column_order.clone(),
+        item_viewer_drive_column_order: view.column_state.drive_column_order.clone(),
+        recycle_bin_column_order: view.column_state.recycle_bin_column_order.clone(),
+        item_viewer_file_column_sizes: view.column_state.file_column_sizes.clone(),
+        item_viewer_drive_column_sizes: view.column_state.drive_column_sizes.clone(),
+        recycle_bin_column_sizes: view.column_state.recycle_bin_column_sizes.clone(),
+        filter_query: view.item_viewer_filter_state.query.clone(),
+        display_mode: view.display_mode,
+        gallery_thumbnail_size: view.gallery_state.thumbnail_size,
+        sort_column: view.sort_column,
+        sort_ascending: view.sort_ascending,
+    }
+}
+
+pub(crate) fn apply_directory_settings_to_view(view: &mut TabView, settings: &AppSettings) {
+    let snapshot = settings
+        .directory_settings
+        .iter()
+        .find(|entry| entry.directory == view.nav.current);
+
+    if let Some(snapshot) = snapshot {
+        view.column_state = ItemViewerColumnState::from_orders(
+            snapshot.item_viewer_file_column_order.clone(),
+            snapshot.item_viewer_drive_column_order.clone(),
+            snapshot.recycle_bin_column_order.clone(),
+            snapshot.item_viewer_file_column_sizes.clone(),
+            snapshot.item_viewer_drive_column_sizes.clone(),
+            snapshot.recycle_bin_column_sizes.clone(),
+        );
+        view.item_viewer_filter_state = FilterState {
+            active: !snapshot.filter_query.is_empty(),
+            query: snapshot.filter_query.clone(),
+            ..Default::default()
+        };
+        view.display_mode = snapshot.display_mode;
+        view.gallery_state
+            .set_thumbnail_size(snapshot.gallery_thumbnail_size);
+        view.sort_column = snapshot.sort_column;
+        view.sort_ascending = snapshot.sort_ascending;
+    } else {
+        view.column_state = default_column_state(settings);
+        view.item_viewer_filter_state = FilterState::default();
+        view.display_mode = ItemViewerDisplayMode::Details;
+        view.gallery_state = Default::default();
+        view.sort_column = settings.sort_column;
+        view.sort_ascending = settings.sort_ascending;
+    }
+}
+
+pub(crate) fn persist_directory_settings_snapshot(
+    entries: &mut Vec<DirectorySettingsSnapshot>,
+    snapshot: DirectorySettingsSnapshot,
+) -> bool {
+    let default_snapshot = default_directory_settings_snapshot(snapshot.directory.clone());
+
+    if snapshot == default_snapshot {
+        if let Some(pos) = entries
+            .iter()
+            .position(|entry| entry.directory == snapshot.directory)
+        {
+            entries.remove(pos);
+            return true;
+        }
+        return false;
+    }
+
+    if let Some(pos) = entries
+        .iter()
+        .position(|entry| entry.directory == snapshot.directory)
+    {
+        if entries[pos] == snapshot {
+            return false;
+        }
+        entries[pos] = snapshot;
+        true
+    } else {
+        entries.push(snapshot);
+        true
+    }
+}
 
 impl Drop for MainWindow {
     fn drop(&mut self) {
@@ -133,33 +249,11 @@ impl MainWindow {
         };
         self.tabs
             .push(TabState::new(id, nav, sort_column, sort_ascending));
-        let column_state = ItemViewerColumnState::from_orders(
-            self.settings_window
-                .current_settings
-                .item_viewer_file_column_order
-                .clone(),
-            self.settings_window
-                .current_settings
-                .item_viewer_drive_column_order
-                .clone(),
-            self.settings_window
-                .current_settings
-                .recycle_bin_column_order
-                .clone(),
-            self.settings_window
-                .current_settings
-                .item_viewer_file_column_sizes
-                .clone(),
-            self.settings_window
-                .current_settings
-                .item_viewer_drive_column_sizes
-                .clone(),
-            self.settings_window
-                .current_settings
-                .recycle_bin_column_sizes
-                .clone(),
+        let current_settings = self.settings_window.current_settings.clone();
+        apply_directory_settings_to_view(
+            &mut self.tabs.last_mut().unwrap().primary_view,
+            &current_settings,
         );
-        self.tabs.last_mut().unwrap().primary_view.column_state = column_state;
         self.active_tab = self.tabs.len() - 1;
         self.mark_tab_infos_dirty();
     }
@@ -237,17 +331,18 @@ impl MainWindow {
             (view.sort_column, view.sort_ascending)
         };
 
-        // Update settings window with new sorting values (the default new tabs start with)
-        self.settings_window.current_settings.sort_column = sort_column;
-        self.settings_window.current_settings.sort_ascending = sort_ascending;
-
         sort_files(
             &mut self.active_tab_mut().view_mut(side).files,
             sort_column,
             sort_ascending,
         );
 
-        // Automatically save settings when sorting changes
+        let snapshot = directory_settings_snapshot_for_view(self.active_tab().view(side));
+        let _ = persist_directory_settings_snapshot(
+            &mut self.settings_window.current_settings.directory_settings,
+            snapshot,
+        );
+
         self.save_app_settings_to_disk();
     }
 
@@ -299,61 +394,24 @@ impl MainWindow {
                 .settings_window
                 .current_settings
                 .recycle_bin_column_sizes,
+            &self.settings_window.current_settings.directory_settings,
         );
     }
 
     fn apply_item_viewer_column_order(
         &mut self,
+        side: SplitSide,
         is_drive_view: bool,
         is_recycle_bin_view: bool,
         order: &[ItemViewerHeaderColumn],
     ) {
-        let target_order = if is_drive_view {
-            &mut self
-                .settings_window
-                .current_settings
-                .item_viewer_drive_column_order
-        } else if is_recycle_bin_view {
-            &mut self
-                .settings_window
-                .current_settings
-                .recycle_bin_column_order
-        } else {
-            &mut self
-                .settings_window
-                .current_settings
-                .item_viewer_file_column_order
-        };
-        eprintln!(
-            "SAVE COLUMN ORDER: drive={} recycle={} order={:?}",
-            is_drive_view, is_recycle_bin_view, order
-        );
-        *target_order = order.to_vec();
-
-        for tab in &mut self.tabs {
-            {
-                let view = &mut tab.primary_view;
-                let current_order = view
-                    .column_state
-                    .order_mut(is_drive_view, is_recycle_bin_view);
-                current_order.clear();
-                current_order.extend_from_slice(order);
-                view.column_state.layout_generation =
-                    view.column_state.layout_generation.wrapping_add(1);
-            }
-
-            if let Some(view) = tab.split_view.as_mut() {
-                let current_order = view
-                    .column_state
-                    .order_mut(is_drive_view, is_recycle_bin_view);
-                current_order.clear();
-                current_order.extend_from_slice(order);
-                view.column_state.layout_generation =
-                    view.column_state.layout_generation.wrapping_add(1);
-            }
-        }
-
-        self.save_app_settings_to_disk();
+        let view = self.active_tab_mut().view_mut(side);
+        let current_order = view
+            .column_state
+            .order_mut(is_drive_view, is_recycle_bin_view);
+        current_order.clear();
+        current_order.extend_from_slice(order);
+        view.column_state.layout_generation = view.column_state.layout_generation.wrapping_add(1);
     }
 
     pub fn load_path(&mut self) {
@@ -361,18 +419,16 @@ impl MainWindow {
     }
 
     pub(crate) fn load_view(&mut self, side: SplitSide) {
-        let (sort_column, sort_ascending, current_path, is_root) = {
+        let (current_path, is_root) = {
             let view = self.active_tab().view(side);
-            (
-                view.sort_column,
-                view.sort_ascending,
-                view.nav.current.clone(),
-                view.nav.is_root(),
-            )
+            (view.nav.current.clone(), view.nav.is_root())
         };
+
+        let current_settings = self.settings_window.current_settings.clone();
 
         {
             let view = self.active_tab_mut().view_mut(side);
+            apply_directory_settings_to_view(view, &current_settings);
             view.files.clear();
             view.rx = None;
             view.size_req_tx = None;
@@ -386,6 +442,10 @@ impl MainWindow {
             view.item_viewer_filter_state.dirty = true;
             view.item_viewer_filter_state.cached_indices.clear();
         }
+        let (sort_column, sort_ascending) = {
+            let view = self.active_tab().view(side);
+            (view.sort_column, view.sort_ascending)
+        };
         self.folder_sizes.clear();
         self.file_size_text_cache.clear();
         self.folder_size_text_cache.clear();
@@ -1208,6 +1268,13 @@ impl MainWindow {
         if let Some(action) = tabbar_action.as_ref().and_then(|t| t.nav.as_ref()) {
             match action {
                 ItemViewerNavAction::Back => {
+                    let snapshot = directory_settings_snapshot_for_view(
+                        self.active_tab().view(self.focused_split),
+                    );
+                    let _ = persist_directory_settings_snapshot(
+                        &mut self.settings_window.current_settings.directory_settings,
+                        snapshot,
+                    );
                     // Store current path in navigation history before going back
                     if let Some(parent) = self.current_nav().get_parent() {
                         let current = self.current_nav().current.clone();
@@ -1220,8 +1287,24 @@ impl MainWindow {
                     }
                     self.current_nav_mut().go_back();
                 }
-                ItemViewerNavAction::Forward => self.current_nav_mut().go_forward(),
+                ItemViewerNavAction::Forward => {
+                    let snapshot = directory_settings_snapshot_for_view(
+                        self.active_tab().view(self.focused_split),
+                    );
+                    let _ = persist_directory_settings_snapshot(
+                        &mut self.settings_window.current_settings.directory_settings,
+                        snapshot,
+                    );
+                    self.current_nav_mut().go_forward();
+                }
                 ItemViewerNavAction::Up => {
+                    let snapshot = directory_settings_snapshot_for_view(
+                        self.active_tab().view(self.focused_split),
+                    );
+                    let _ = persist_directory_settings_snapshot(
+                        &mut self.settings_window.current_settings.directory_settings,
+                        snapshot,
+                    );
                     // Store current path in navigation history before going up
                     if let Some(parent) = self.current_nav().get_parent() {
                         let current = self.current_nav().current.clone();
@@ -1254,6 +1337,13 @@ impl MainWindow {
             }
         } else {
             if let Some(path) = tabbar_action.as_ref().and_then(|t| t.nav_to.as_ref()) {
+                let snapshot = directory_settings_snapshot_for_view(
+                    self.active_tab().view(self.focused_split),
+                );
+                let _ = persist_directory_settings_snapshot(
+                    &mut self.settings_window.current_settings.directory_settings,
+                    snapshot,
+                );
                 // Store current path in navigation history before navigating
                 if let Some(parent) = self.current_nav().get_parent() {
                     let current = self.current_nav().current.clone();
@@ -1349,6 +1439,11 @@ impl MainWindow {
                 self.next_tab_id += 1;
                 self.tabs
                     .push(TabState::new(id, cloned_nav, sort_column, sort_ascending));
+                let current_settings = self.settings_window.current_settings.clone();
+                apply_directory_settings_to_view(
+                    &mut self.tabs.last_mut().unwrap().primary_view,
+                    &current_settings,
+                );
                 self.active_tab = self.tabs.len() - 1;
                 self.focused_split = SplitSide::Primary;
                 self.pending_tab_scroll_id = Some(id);
@@ -1358,6 +1453,20 @@ impl MainWindow {
             if let Some(id) = action.close {
                 if self.tabs.len() > 1 {
                     if let Some(idx) = self.tabs.iter().position(|t| t.id == id) {
+                        if let Some(tab) = self.tabs.get(idx) {
+                            let snapshot = directory_settings_snapshot_for_view(&tab.primary_view);
+                            let _ = persist_directory_settings_snapshot(
+                                &mut self.settings_window.current_settings.directory_settings,
+                                snapshot,
+                            );
+                            if let Some(split) = tab.split_view.as_ref() {
+                                let snapshot = directory_settings_snapshot_for_view(split);
+                                let _ = persist_directory_settings_snapshot(
+                                    &mut self.settings_window.current_settings.directory_settings,
+                                    snapshot,
+                                );
+                            }
+                        }
                         self.tabs.remove(idx);
                         if self.active_tab >= self.tabs.len() {
                             self.active_tab = self.tabs.len() - 1;
@@ -1370,6 +1479,11 @@ impl MainWindow {
                         self.load_path();
                     }
                 } else {
+                    let snapshot = directory_settings_snapshot_for_view(&self.tabs[0].primary_view);
+                    let _ = persist_directory_settings_snapshot(
+                        &mut self.settings_window.current_settings.directory_settings,
+                        snapshot,
+                    );
                     let (
                         _folder_scanning_enabled,
                         _show_hidden_files_folders,
@@ -1390,6 +1504,7 @@ impl MainWindow {
                         _item_viewer_file_column_sizes,
                         _item_viewer_drive_column_sizes,
                         _recycle_bin_column_sizes,
+                        _directory_settings,
                     ) = load_app_settings();
                     self.tabs[0].primary_view.nav = Navigation::new(start_path);
                     self.tabs[0].split_view = None;
@@ -1461,6 +1576,8 @@ impl MainWindow {
             .view(SplitSide::Primary)
             .duplicate_as_new();
         new_view.nav = Navigation::new(path);
+        let current_settings = self.settings_window.current_settings.clone();
+        apply_directory_settings_to_view(&mut new_view, &current_settings);
         let tab = self.active_tab_mut();
         tab.split_view = Some(new_view);
         self.focused_split = SplitSide::Secondary;
@@ -2149,9 +2266,16 @@ pub fn handle_pending_actions(pending_action: Option<ItemViewerAction>, explorer
 
                 if let Some(order) = new_order {
                     explorer.apply_item_viewer_column_order(
+                        side,
                         is_drive_view,
                         is_recycle_bin_view,
                         &order,
+                    );
+                    let snapshot =
+                        directory_settings_snapshot_for_view(explorer.active_tab().view(side));
+                    let _ = persist_directory_settings_snapshot(
+                        &mut explorer.settings_window.current_settings.directory_settings,
+                        snapshot,
                     );
                 }
             }
@@ -2197,9 +2321,16 @@ pub fn handle_pending_actions(pending_action: Option<ItemViewerAction>, explorer
                         .order(is_drive_view, is_recycle_bin_view)
                         .to_vec();
                     explorer.apply_item_viewer_column_order(
+                        side,
                         is_drive_view,
                         is_recycle_bin_view,
                         &order,
+                    );
+                    let snapshot =
+                        directory_settings_snapshot_for_view(explorer.active_tab().view(side));
+                    let _ = persist_directory_settings_snapshot(
+                        &mut explorer.settings_window.current_settings.directory_settings,
+                        snapshot,
                     );
                 }
             }
@@ -2217,9 +2348,16 @@ pub fn handle_pending_actions(pending_action: Option<ItemViewerAction>, explorer
                         .order(is_drive_view, is_recycle_bin_view)
                         .to_vec();
                     explorer.apply_item_viewer_column_order(
+                        side,
                         is_drive_view,
                         is_recycle_bin_view,
                         &order,
+                    );
+                    let snapshot =
+                        directory_settings_snapshot_for_view(explorer.active_tab().view(side));
+                    let _ = persist_directory_settings_snapshot(
+                        &mut explorer.settings_window.current_settings.directory_settings,
+                        snapshot,
                     );
                 }
             }
@@ -2241,9 +2379,16 @@ pub fn handle_pending_actions(pending_action: Option<ItemViewerAction>, explorer
                         .order(is_drive_view, is_recycle_bin_view)
                         .to_vec();
                     explorer.apply_item_viewer_column_order(
+                        side,
                         is_drive_view,
                         is_recycle_bin_view,
                         &order,
+                    );
+                    let snapshot =
+                        directory_settings_snapshot_for_view(explorer.active_tab().view(side));
+                    let _ = persist_directory_settings_snapshot(
+                        &mut explorer.settings_window.current_settings.directory_settings,
+                        snapshot,
                     );
                 }
             }
@@ -2265,9 +2410,16 @@ pub fn handle_pending_actions(pending_action: Option<ItemViewerAction>, explorer
                         .order(is_drive_view, is_recycle_bin_view)
                         .to_vec();
                     explorer.apply_item_viewer_column_order(
+                        side,
                         is_drive_view,
                         is_recycle_bin_view,
                         &order,
+                    );
+                    let snapshot =
+                        directory_settings_snapshot_for_view(explorer.active_tab().view(side));
+                    let _ = persist_directory_settings_snapshot(
+                        &mut explorer.settings_window.current_settings.directory_settings,
+                        snapshot,
                     );
                 }
             }
@@ -2395,6 +2547,13 @@ pub fn handle_pending_actions(pending_action: Option<ItemViewerAction>, explorer
                     view.item_viewer_filter_state.dirty = true;
                     view.item_viewer_filter_state.cached_indices.clear();
                 }
+                let snapshot = directory_settings_snapshot_for_view(
+                    explorer.active_tab().view(explorer.focused_split),
+                );
+                let _ = persist_directory_settings_snapshot(
+                    &mut explorer.settings_window.current_settings.directory_settings,
+                    snapshot,
+                );
 
                 // Store current path in navigation history before navigating
                 if let Some(parent) = explorer.current_nav().get_parent() {
@@ -2556,32 +2715,12 @@ pub fn handle_pending_actions(pending_action: Option<ItemViewerAction>, explorer
                 explorer.load_path();
             }
             ItemViewerAction::ColumnSizesChanged => {
-                let sizes = {
-                    let view = explorer.active_tab().view(side);
-
-                    view.column_state
-                        .column_sizes(is_drive_view, is_recycle_bin_view)
-                        .to_vec()
-                };
-
-                let target_sizes = if is_drive_view {
-                    &mut explorer
-                        .settings_window
-                        .current_settings
-                        .item_viewer_drive_column_sizes
-                } else if is_recycle_bin_view {
-                    &mut explorer
-                        .settings_window
-                        .current_settings
-                        .recycle_bin_column_sizes
-                } else {
-                    &mut explorer
-                        .settings_window
-                        .current_settings
-                        .item_viewer_file_column_sizes
-                };
-
-                *target_sizes = sizes;
+                let snapshot =
+                    directory_settings_snapshot_for_view(explorer.active_tab().view(side));
+                let _ = persist_directory_settings_snapshot(
+                    &mut explorer.settings_window.current_settings.directory_settings,
+                    snapshot,
+                );
 
                 explorer.save_app_settings_to_disk();
             }

--- a/src/gui/windows/settings.rs
+++ b/src/gui/windows/settings.rs
@@ -55,6 +55,7 @@ impl Default for AppSettings {
             item_viewer_file_column_sizes: vec![],
             item_viewer_drive_column_sizes: vec![],
             recycle_bin_column_sizes: vec![],
+            directory_settings: vec![],
         }
     }
 }

--- a/src/gui/windows/structs.rs
+++ b/src/gui/windows/structs.rs
@@ -1,5 +1,5 @@
 use crate::core::drives::DriveInfo;
-use crate::core::indexer::WindowSizeMode;
+use crate::core::indexer::{DirectorySettingsSnapshot, WindowSizeMode};
 use crate::gui::theme::{ThemeMode, ThemePalette};
 use crate::gui::utils::SortColumn;
 use crate::gui::windows::containers::enums::ItemViewerHeaderColumn;
@@ -58,6 +58,7 @@ pub struct AppSettings {
     pub item_viewer_file_column_sizes: Vec<f32>,
     pub item_viewer_drive_column_sizes: Vec<f32>,
     pub recycle_bin_column_sizes: Vec<f32>,
+    pub directory_settings: Vec<DirectorySettingsSnapshot>,
 }
 
 #[derive(Default)]

--- a/src/gui/windows/windowsoverrides.rs
+++ b/src/gui/windows/windowsoverrides.rs
@@ -108,6 +108,7 @@ fn save_manual_window_size(hwnd: HWND) {
             item_viewer_file_column_sizes,
             item_viewer_drive_column_sizes,
             recycle_bin_column_sizes,
+            directory_settings,
         ) = load_app_settings();
         let window_size_mode = WindowSizeMode::Custom { width, height };
 
@@ -131,6 +132,7 @@ fn save_manual_window_size(hwnd: HWND) {
             &item_viewer_file_column_sizes,
             &item_viewer_drive_column_sizes,
             &recycle_bin_column_sizes,
+            &directory_settings,
         );
     }
 }

--- a/src/gui/windows/windowsoverrides.rs
+++ b/src/gui/windows/windowsoverrides.rs
@@ -313,6 +313,11 @@ unsafe extern "system" fn custom_wndproc(
             LRESULT(0)
         }
 
+        // Keep the custom borderless frame's client area aligned with the
+        // window. Without this, Windows 10 may retain a non-client top inset
+        // after WS_THICKFRAME is added, offsetting both painting and input.
+        WM_NCCALCSIZE if wparam.0 != 0 => LRESULT(0),
+
         WM_NCHITTEST => {
             let x = get_x_lparam(lparam);
             let y = get_y_lparam(lparam);


### PR DESCRIPTION
## 🆕 What's New

- All directories now have persisted settings. In other words, if you resize, sort, change visibility of columns, they are persisted across sessions for that specific folder. Same goes with the Gallery view changes.
- Double-clicking on the column divider triggers the "Resize this column to fit"
- Added lexicographic multi-column sorting using Shift+Click

## 🐛 What's Fixed

- Windows 11 border/draw bug that may have to do with DPI

## 🔗 Related Issues

https://github.com/mtucciarone/EdenExplorer/issues/80
https://github.com/mtucciarone/EdenExplorer/issues/66
https://github.com/mtucciarone/EdenExplorer/issues/44
