### PR TITLE
fix: clipboard handling and item pasting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "EdenExplorer"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "bincode",
  "chrono",

--- a/src/core/utils/clipboard.rs
+++ b/src/core/utils/clipboard.rs
@@ -2,35 +2,101 @@ use std::ffi::OsStr;
 use std::mem::size_of;
 use std::os::windows::ffi::OsStrExt;
 use std::path::PathBuf;
-use windows::Win32::Foundation::{HANDLE, POINT};
+use std::thread;
+use std::time::Duration;
+use windows::Win32::Foundation::{GlobalFree, HANDLE, HGLOBAL, HWND, POINT};
 use windows::Win32::System::DataExchange::{
-    CloseClipboard, EmptyClipboard, GetClipboardData, OpenClipboard, RegisterClipboardFormatW,
-    SetClipboardData,
+    CloseClipboard, EmptyClipboard, GetClipboardData, IsClipboardFormatAvailable, OpenClipboard,
+    RegisterClipboardFormatW, SetClipboardData,
 };
 use windows::Win32::System::Memory::{GMEM_MOVEABLE, GlobalAlloc, GlobalLock, GlobalUnlock};
 use windows::Win32::System::Ole::{CF_HDROP, CF_UNICODETEXT};
 use windows::Win32::UI::Shell::DragQueryFileW;
 use windows::core::PCWSTR;
 
-pub fn clear_clipboard_files() {
+const CLIPBOARD_OPEN_ATTEMPTS: usize = 5;
+const CLIPBOARD_OPEN_RETRY_DELAY: Duration = Duration::from_millis(10);
+
+pub enum ClipboardFileRead {
+    Files(Vec<PathBuf>),
+    Empty,
+    Unavailable,
+}
+
+/// Opens the clipboard for reading.
+///
+/// A NULL owner is fine here because we aren't calling EmptyClipboard or
+/// SetClipboardData. The clipboard is only being inspected.
+fn open_clipboard_for_read() -> bool {
+    for attempt in 0..CLIPBOARD_OPEN_ATTEMPTS {
+        if unsafe { OpenClipboard(None).is_ok() } {
+            return true;
+        }
+
+        if attempt + 1 < CLIPBOARD_OPEN_ATTEMPTS {
+            thread::sleep(CLIPBOARD_OPEN_RETRY_DELAY);
+        }
+    }
+
+    false
+}
+
+/// Opens the clipboard for writing and associates it with our application window.
+///
+/// This must use a real HWND. Opening with NULL and then calling EmptyClipboard()
+/// makes the clipboard owner NULL, which causes SetClipboardData() to fail.
+fn open_clipboard_for_write(hwnd: Option<HWND>) -> bool {
+    let Some(hwnd) = hwnd else {
+        return false;
+    };
+
+    for attempt in 0..CLIPBOARD_OPEN_ATTEMPTS {
+        if unsafe { OpenClipboard(Some(hwnd)).is_ok() } {
+            return true;
+        }
+
+        if attempt + 1 < CLIPBOARD_OPEN_ATTEMPTS {
+            thread::sleep(CLIPBOARD_OPEN_RETRY_DELAY);
+        }
+    }
+
+    false
+}
+
+/// Clears the entire clipboard.
+///
+/// This requires a real HWND so that EmptyClipboard assigns clipboard ownership
+/// to our application.
+pub fn clear_clipboard_files(hwnd: Option<HWND>) {
+    let Some(hwnd) = hwnd else {
+        return;
+    };
+
     unsafe {
-        if OpenClipboard(None).is_ok() {
-            let _ = SetClipboardData(CF_HDROP.0 as u32, None);
+        if open_clipboard_for_write(Some(hwnd)) {
+            let _ = EmptyClipboard();
             let _ = CloseClipboard();
         }
     }
 }
 
-pub fn set_clipboard_files(paths: &[PathBuf], cut: bool) -> bool {
+pub fn set_clipboard_files(hwnd: Option<HWND>, paths: &[PathBuf], cut: bool) -> bool {
+    let Some(hwnd) = hwnd else {
+        return false;
+    };
+
     if paths.is_empty() {
         return false;
     }
 
     let mut wide: Vec<u16> = Vec::new();
+
     for path in paths {
         wide.extend(path.as_os_str().encode_wide());
         wide.push(0);
     }
+
+    // DROPFILES requires a double-null-terminated file list.
     wide.push(0);
 
     #[repr(C)]
@@ -48,12 +114,16 @@ pub fn set_clipboard_files(paths: &[PathBuf], cut: bool) -> bool {
         Err(_) => return false,
     };
 
+    // Fill the DROPFILES structure.
     unsafe {
-        let ptr = GlobalLock(hglobal) as *mut u8;
+        let ptr = GlobalLock(hglobal);
+
         if ptr.is_null() {
-            let _ = GlobalUnlock(hglobal);
+            let _ = GlobalFree(Some(hglobal));
             return false;
         }
+
+        let ptr = ptr as *mut u8;
 
         let drop_files = DropFiles {
             p_files: size_of::<DropFiles>() as u32,
@@ -84,61 +154,130 @@ pub fn set_clipboard_files(paths: &[PathBuf], cut: bool) -> bool {
 
     let format = unsafe { RegisterClipboardFormatW(PCWSTR(format_name.as_ptr())) };
 
-    if unsafe { OpenClipboard(None).is_err() } {
+    if format == 0 {
+        unsafe {
+            let _ = GlobalFree(Some(hglobal));
+        }
         return false;
     }
-    let _ = unsafe { EmptyClipboard() };
-    let _ = unsafe { SetClipboardData(CF_HDROP.0 as u32, Some(HANDLE(hglobal.0))) };
 
-    let effect: u32 = if cut { 2 } else { 5 };
+    if !open_clipboard_for_write(Some(hwnd)) {
+        unsafe {
+            let _ = GlobalFree(Some(hglobal));
+        }
+        return false;
+    }
+
+    if unsafe { EmptyClipboard() }.is_err() {
+        unsafe {
+            let _ = GlobalFree(Some(hglobal));
+            let _ = CloseClipboard();
+        }
+        return false;
+    }
+
+    // SetClipboardData takes ownership of hglobal on success.
+    if unsafe { SetClipboardData(CF_HDROP.0 as u32, Some(HANDLE(hglobal.0))) }.is_err() {
+        unsafe {
+            let _ = GlobalFree(Some(hglobal));
+            let _ = CloseClipboard();
+        }
+        return false;
+    }
+
+    // DROPEFFECT_MOVE = 2
+    // DROPEFFECT_COPY = 1
+    let effect: u32 = if cut { 2 } else { 1 };
+
     let hglobal_effect = match unsafe { GlobalAlloc(GMEM_MOVEABLE, size_of::<u32>()) } {
         Ok(h) => h,
         Err(_) => {
-            let _ = unsafe { CloseClipboard() };
+            // CF_HDROP was successfully installed. The primary operation succeeded.
+            unsafe {
+                let _ = CloseClipboard();
+            }
             return true;
         }
     };
-    if !hglobal_effect.0.is_null() {
-        unsafe {
-            let ptr = GlobalLock(hglobal_effect) as *mut u32;
-            if !ptr.is_null() {
-                *ptr = effect;
-                let _ = GlobalUnlock(hglobal_effect);
-                let _ = SetClipboardData(format, Some(HANDLE(hglobal_effect.0)));
-            }
+
+    let effect_written = unsafe {
+        let ptr = GlobalLock(hglobal_effect);
+
+        if ptr.is_null() {
+            false
+        } else {
+            *(ptr as *mut u32) = effect;
+            let _ = GlobalUnlock(hglobal_effect);
+            true
         }
+    };
+
+    if !effect_written {
+        unsafe {
+            let _ = GlobalFree(Some(hglobal_effect));
+            let _ = CloseClipboard();
+        }
+
+        // The file clipboard is still valid, so report success.
+        return true;
     }
 
-    let _ = unsafe { CloseClipboard() };
+    // SetClipboardData takes ownership of hglobal_effect on success.
+    if unsafe { SetClipboardData(format, Some(HANDLE(hglobal_effect.0))) }.is_err() {
+        unsafe {
+            let _ = GlobalFree(Some(hglobal_effect));
+            let _ = CloseClipboard();
+        }
+
+        // CF_HDROP is already valid. Only the copy/cut indicator failed.
+        return true;
+    }
+
+    unsafe {
+        let _ = CloseClipboard();
+    }
+
     true
 }
 
-pub fn get_clipboard_files() -> Option<Vec<PathBuf>> {
-    if unsafe { OpenClipboard(None).is_err() } {
-        return None;
+pub fn read_clipboard_files() -> ClipboardFileRead {
+    if !open_clipboard_for_read() {
+        return ClipboardFileRead::Unavailable;
     }
 
-    let hdrop = unsafe { GetClipboardData(CF_HDROP.0 as u32) };
-    let hdrop = match hdrop {
-        Ok(h) => h,
-        Err(_) => {
-            let _ = unsafe { CloseClipboard() };
-            return None;
+    if unsafe { IsClipboardFormatAvailable(CF_HDROP.0 as u32) }.is_err() {
+        unsafe {
+            let _ = CloseClipboard();
+        }
+        return ClipboardFileRead::Empty;
+    }
+
+    let hdrop = match unsafe { GetClipboardData(CF_HDROP.0 as u32) } {
+        Ok(h) if !h.0.is_null() => h,
+        _ => {
+            unsafe {
+                let _ = CloseClipboard();
+            }
+            return ClipboardFileRead::Unavailable;
         }
     };
 
     let hdrop = windows::Win32::UI::Shell::HDROP(hdrop.0);
+
+    // UINT_MAX requests the number of files in the HDROP.
     let count = unsafe { DragQueryFileW(hdrop, 0xFFFFFFFF, None) };
 
-    let mut paths = Vec::new();
+    let mut paths = Vec::with_capacity(count as usize);
 
     for i in 0..count {
         let len = unsafe { DragQueryFileW(hdrop, i, None) };
+
         if len == 0 {
             continue;
         }
 
         let mut buf = vec![0u16; (len + 1) as usize];
+
         let copied = unsafe { DragQueryFileW(hdrop, i, Some(&mut buf)) };
 
         if copied > 0 {
@@ -147,13 +286,19 @@ pub fn get_clipboard_files() -> Option<Vec<PathBuf>> {
         }
     }
 
-    let _ = unsafe { CloseClipboard() };
+    unsafe {
+        let _ = CloseClipboard();
+    }
 
-    Some(paths)
+    if paths.is_empty() {
+        ClipboardFileRead::Empty
+    } else {
+        ClipboardFileRead::Files(paths)
+    }
 }
 
 pub fn is_clipboard_cut() -> bool {
-    if unsafe { OpenClipboard(None).is_err() } {
+    if !open_clipboard_for_read() {
         return false;
     }
 
@@ -164,64 +309,96 @@ pub fn is_clipboard_cut() -> bool {
 
     let format = unsafe { RegisterClipboardFormatW(PCWSTR(format_name.as_ptr())) };
 
+    if format == 0 {
+        unsafe {
+            let _ = CloseClipboard();
+        }
+        return false;
+    }
+
     let mut is_cut = false;
 
     if let Ok(hglobal) = unsafe { GetClipboardData(format) } {
         if !hglobal.0.is_null() {
-            let ptr =
-                unsafe { GlobalLock(windows::Win32::Foundation::HGLOBAL(hglobal.0 as *mut _)) }
-                    as *const u32;
+            let hglobal = HGLOBAL(hglobal.0 as *mut _);
+
+            let ptr = unsafe { GlobalLock(hglobal) };
 
             if !ptr.is_null() {
-                let val = unsafe { *ptr };
+                let value = unsafe { *(ptr as *const u32) };
 
-                // 2 = DROPEFFECT_MOVE (cut)
-                // 5 = DROPEFFECT_COPY | DROPEFFECT_LINK (rare combos)
-                is_cut = val == 2;
+                // DROPEFFECT_MOVE = 2
+                is_cut = value == 2;
 
-                let _ = unsafe {
-                    GlobalUnlock(windows::Win32::Foundation::HGLOBAL(hglobal.0 as *mut _))
-                };
+                let _ = unsafe { GlobalUnlock(hglobal) };
             }
         }
     }
 
-    let _ = unsafe { CloseClipboard() };
+    unsafe {
+        let _ = CloseClipboard();
+    }
 
     is_cut
 }
 
-pub fn copy_text_to_clipboard(text: &str) -> bool {
-    if unsafe { OpenClipboard(None).is_err() } {
+pub fn copy_text_to_clipboard(hwnd: Option<HWND>, text: &str) -> bool {
+    let Some(hwnd) = hwnd else {
+        return false;
+    };
+
+    if !open_clipboard_for_write(Some(hwnd)) {
         return false;
     }
 
-    let _ = unsafe { EmptyClipboard() };
+    if unsafe { EmptyClipboard() }.is_err() {
+        unsafe {
+            let _ = CloseClipboard();
+        }
+        return false;
+    }
 
-    // Convert string to wide string (UTF-16)
+    // Convert string to null-terminated UTF-16.
     let wide_text: Vec<u16> = text.encode_utf16().chain(std::iter::once(0)).collect();
-    let text_size = wide_text.len() * std::mem::size_of::<u16>();
+
+    let text_size = wide_text.len() * size_of::<u16>();
 
     let hglobal = match unsafe { GlobalAlloc(GMEM_MOVEABLE, text_size) } {
         Ok(h) => h,
         Err(_) => {
-            let _ = unsafe { CloseClipboard() };
+            unsafe {
+                let _ = CloseClipboard();
+            }
             return false;
         }
     };
 
-    let ptr = unsafe { GlobalLock(hglobal) };
-    if !ptr.is_null() {
-        unsafe {
-            std::ptr::copy_nonoverlapping(wide_text.as_ptr(), ptr as *mut u16, wide_text.len());
-            let _ = GlobalUnlock(hglobal);
-            let _ = SetClipboardData(CF_UNICODETEXT.0 as u32, Some(HANDLE(hglobal.0)));
+    unsafe {
+        let ptr = GlobalLock(hglobal);
+
+        if ptr.is_null() {
+            let _ = GlobalFree(Some(hglobal));
+            let _ = CloseClipboard();
+            return false;
         }
-    } else {
-        let _ = unsafe { CloseClipboard() };
+
+        std::ptr::copy_nonoverlapping(wide_text.as_ptr(), ptr as *mut u16, wide_text.len());
+
+        let _ = GlobalUnlock(hglobal);
+    }
+
+    // SetClipboardData takes ownership of hglobal on success.
+    if unsafe { SetClipboardData(CF_UNICODETEXT.0 as u32, Some(HANDLE(hglobal.0))) }.is_err() {
+        unsafe {
+            let _ = GlobalFree(Some(hglobal));
+            let _ = CloseClipboard();
+        }
         return false;
     }
 
-    let _ = unsafe { CloseClipboard() };
+    unsafe {
+        let _ = CloseClipboard();
+    }
+
     true
 }

--- a/src/gui/windows/containers/itemviewer.rs
+++ b/src/gui/windows/containers/itemviewer.rs
@@ -158,6 +158,7 @@ pub fn draw_item_viewer(
             is_recycle_bin_view,
             theme_customizer_window,
             settings_window,
+            hwnd,
         ) {
             action = Some(global_action);
         }

--- a/src/gui/windows/containers/itemviewer_helper.rs
+++ b/src/gui/windows/containers/itemviewer_helper.rs
@@ -865,6 +865,7 @@ pub fn handle_global_actions(
     is_recycle_bin_view: bool,
     theme_customizer_window: &mut ThemeCustomizer,
     settings_windows: &mut SettingsWindow,
+    hwnd: Option<HWND>,
 ) -> Option<ItemViewerAction> {
     let filtered_indices = &filter_state.cached_indices;
     let mut action: Option<ItemViewerAction> = None;
@@ -884,7 +885,7 @@ pub fn handle_global_actions(
     if is_cut_mode {
         let cancel_called = ui.input(|i| i.key_pressed(egui::Key::Escape));
         if cancel_called {
-            clear_clipboard_files();
+            clear_clipboard_files(hwnd);
         }
     }
 

--- a/src/gui/windows/containers/itemviewer_navbar.rs
+++ b/src/gui/windows/containers/itemviewer_navbar.rs
@@ -3,7 +3,7 @@ use crate::core::portable;
 use crate::gui::i18n::I18n;
 use crate::gui::icons::IconCache;
 use crate::gui::theme::ThemePalette;
-use crate::gui::utils::{clear_clipboard_files, clickable_icon, expand_environment_variables};
+use crate::gui::utils::{clickable_icon, expand_environment_variables};
 use crate::gui::windows::containers::enums::ItemViewerNavAction;
 use crate::gui::windows::containers::structs::{
     Breadcrumb, ItemViewerDisplayMode, ItemViewerNavBarAction, RenderedBreadcrumb, TabView,
@@ -412,7 +412,6 @@ fn draw_navigation_bar_buttons(
         .clicked()
     {
         action.refresh_current_directory = true;
-        clear_clipboard_files();
     }
 
     // Action buttons

--- a/src/gui/windows/mainwindow.rs
+++ b/src/gui/windows/mainwindow.rs
@@ -472,10 +472,23 @@ impl eframe::App for MainWindow {
         }
 
         if consume_clipboard_dirty() {
-            self.clipboard_paths = crate::gui::utils::get_clipboard_files().unwrap_or_default();
-            self.clipboard_is_cut = crate::gui::utils::is_clipboard_cut();
-            self.clipboard_has_files = !self.clipboard_paths.is_empty();
-            self.clipboard_set = self.clipboard_paths.iter().cloned().collect();
+            match crate::gui::utils::read_clipboard_files() {
+                crate::gui::utils::ClipboardFileRead::Files(paths) => {
+                    self.clipboard_is_cut = crate::gui::utils::is_clipboard_cut();
+                    self.clipboard_has_files = !paths.is_empty();
+                    self.clipboard_set = paths.iter().cloned().collect();
+                    self.clipboard_paths = paths;
+                }
+                crate::gui::utils::ClipboardFileRead::Empty => {
+                    self.clipboard_paths.clear();
+                    self.clipboard_set.clear();
+                    self.clipboard_is_cut = false;
+                    self.clipboard_has_files = false;
+                }
+                // Preserve the last known clipboard state when another process is temporarily
+                // using the clipboard. The next clipboard update will refresh it.
+                crate::gui::utils::ClipboardFileRead::Unavailable => {}
+            }
         }
 
         // Increase scroll speed for the explorer view.

--- a/src/gui/windows/mainwindow_imp.rs
+++ b/src/gui/windows/mainwindow_imp.rs
@@ -11,8 +11,9 @@ use crate::gui::theme::{
     ThemeMode, ThemePalette, apply_font_to_context, get_default_palette, set_palette,
 };
 use crate::gui::utils::{
-    SortColumn, SortKey, clear_clipboard_files, get_clipboard_files, is_clipboard_cut,
-    set_clipboard_files, shell_delete_to_recycle_bin, show_copy_move_dialog, sort_files_by_keys,
+    ClipboardFileRead, SortColumn, SortKey, clear_clipboard_files, is_clipboard_cut,
+    read_clipboard_files, set_clipboard_files, shell_delete_to_recycle_bin, show_copy_move_dialog,
+    sort_files_by_keys,
 };
 use crate::gui::windows::about::draw_about_window;
 use crate::gui::windows::containers::enums::{
@@ -856,18 +857,21 @@ impl MainWindow {
     pub fn handle_context_action(&mut self, action: ItemViewerContextAction) {
         match action {
             ItemViewerContextAction::Cut(paths) => {
-                let _ = set_clipboard_files(&paths, true);
-                mark_clipboard_dirty();
-                if let Some(first) = paths.first() {
-                    let side = self.focused_split;
-                    let explorer_state = &mut self.active_tab_mut().view_mut(side).explorer_state;
-                    explorer_state.selected_paths.clear();
-                    explorer_state.selected_paths.insert(first.clone());
+                if set_clipboard_files(self.hwnd, &paths, true) {
+                    mark_clipboard_dirty();
+                    if let Some(first) = paths.first() {
+                        let side = self.focused_split;
+                        let explorer_state =
+                            &mut self.active_tab_mut().view_mut(side).explorer_state;
+                        explorer_state.selected_paths.clear();
+                        explorer_state.selected_paths.insert(first.clone());
+                    }
                 }
             }
             ItemViewerContextAction::Copy(paths) => {
-                let _ = set_clipboard_files(&paths, false);
-                mark_clipboard_dirty();
+                if set_clipboard_files(self.hwnd, &paths, false) {
+                    mark_clipboard_dirty();
+                }
             }
             ItemViewerContextAction::CopyPath(paths) => {
                 use crate::gui::utils::copy_text_to_clipboard;
@@ -877,7 +881,7 @@ impl MainWindow {
                     paths.iter().map(|p| p.display().to_string()).collect();
 
                 let text = path_strings.join("\r\n");
-                let _ = copy_text_to_clipboard(&text);
+                let _ = copy_text_to_clipboard(self.hwnd, &text);
             }
             ItemViewerContextAction::Paste => {
                 if let Err(e) = self.paste_clipboard_native() {
@@ -1014,13 +1018,12 @@ impl MainWindow {
     pub fn paste_clipboard_native(&mut self) -> windows::core::Result<()> {
         use windows::Win32::System::Com::{CLSCTX_ALL, CoCreateInstance};
         use windows::Win32::UI::Shell::{
-            FOF_ALLOWUNDO, FOF_NOCONFIRMMKDIR, FOF_RENAMEONCOLLISION, FileOperation,
-            IFileOperation, IShellItem, SHCreateItemFromParsingName,
+            FOF_ALLOWUNDO, FileOperation, IFileOperation, IShellItem, SHCreateItemFromParsingName,
         };
         use windows::core::HSTRING;
 
-        let paths = match get_clipboard_files() {
-            Some(p) if !p.is_empty() => p,
+        let paths = match read_clipboard_files() {
+            ClipboardFileRead::Files(paths) if !paths.is_empty() => paths,
             _ => return Ok(()),
         };
 
@@ -1035,8 +1038,10 @@ impl MainWindow {
         unsafe {
             let file_op: IFileOperation = CoCreateInstance(&FileOperation, None, CLSCTX_ALL)?;
 
-            file_op
-                .SetOperationFlags(FOF_ALLOWUNDO | FOF_RENAMEONCOLLISION | FOF_NOCONFIRMMKDIR)?;
+            // Leave collision handling to the Windows shell. In particular, a folder with the
+            // same name in the target should produce Explorer's merge confirmation instead of
+            // silently creating a " - Copy" sibling.
+            file_op.SetOperationFlags(FOF_ALLOWUNDO)?;
 
             let target_item: IShellItem = SHCreateItemFromParsingName(
                 &HSTRING::from(self.current_nav().current.to_string_lossy().to_string()),
@@ -2327,7 +2332,6 @@ pub fn handle_pending_actions(pending_action: Option<ItemViewerAction>, explorer
             ItemViewerAction::CreateFolder => explorer.create_new_folder(),
             ItemViewerAction::CreateFile => explorer.create_new_file(),
             ItemViewerAction::RefreshCurrentDirectory => {
-                clear_clipboard_files();
                 explorer.load_path();
             }
             ItemViewerAction::OpenTerminal => {


### PR DESCRIPTION
## 🔄 What's Changed

- Prompt users when pasting clipboard content into a directory with more options. Previously pasting FolderA (with updated children items) into a parent directory with an existing FolderA should simply create a duplicate, named `FolderA - Copy` but instead I'd like for the user to be prompted what they would like to do.

## 🐛 What's Fixed

- I've noticed a few bugs around clipboard handling in the application so decided to refactor ownership to HWND which seems to have fixed most of what I've been experiencing.